### PR TITLE
Add table and model for memes from users

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -33,7 +33,6 @@ engine = create_async_engine(DATABASE_URL)
 
 metadata = MetaData(naming_convention=DB_NAMING_CONVENTION)
 
-
 language = Table(
     "language",
     metadata,
@@ -42,7 +41,6 @@ language = Table(
 
     # TODO: flag: show in language selector UI or not
 )
-
 
 meme_source = Table(
     "meme_source",
@@ -59,7 +57,6 @@ meme_source = Table(
     Column("created_at", DateTime, server_default=func.now(), nullable=False),
     Column("updated_at", DateTime, onupdate=func.now()),
 )
-
 
 meme_raw_telegram = Table(
     "meme_raw_telegram",
@@ -87,13 +84,27 @@ meme_raw_telegram = Table(
     UniqueConstraint("meme_source_id", "post_id", name=MEME_SOURCE_POST_UNIQUE_CONSTRAINT),
 )
 
+meme_raw_upload = Table(
+    "meme_raw_upload",
+    metadata,
+    Column("id", Integer, Identity(), primary_key=True),
+    Column("message_id", Integer, nullable=False),
+    Column("chat", JSONB, nullable=False),
 
-# meme_raw_upload = Table(
-#     "meme_raw_upload",
-#     metadata,
-# TODO: columns TBD, probably also JSONBs to store all raw data
-# )
+    Column("content", String),
+    Column("date", DateTime, nullable=False),
 
+    Column("out_links", JSONB),
+    Column("mentions", JSONB),
+    Column("hashtags", JSONB),
+    Column("forwarded", JSONB),
+
+    Column("image", JSONB),
+    Column("video", JSONB),
+
+    Column("created_at", DateTime, server_default=func.now(), nullable=False),
+    Column("updated_at", DateTime, onupdate=func.now())
+)
 
 meme = Table(
     "meme",
@@ -117,7 +128,6 @@ meme = Table(
     UniqueConstraint("meme_source_id", "raw_meme_id", name=MEME_SOURCE_RAW_MEME_UNIQUE_CONSTRAINT),
 )
 
-
 user_tg = Table(
     "user_tg",
     metadata,
@@ -135,7 +145,6 @@ user_tg = Table(
     Column("updated_at", DateTime, onupdate=func.now()),
 )
 
-
 user = Table(
     "user",
     metadata,
@@ -146,7 +155,6 @@ user = Table(
     Column("last_active_at", DateTime, onupdate=func.now()),
     Column("blocked_bot_at", DateTime),
 )
-
 
 user_language = Table(
     "user_language",

--- a/src/database.py
+++ b/src/database.py
@@ -102,9 +102,7 @@ meme_raw_upload = Table(
     Column("mentions", JSONB),
     Column("hashtags", JSONB),
     Column("forwarded", JSONB),
-
-    Column("image", JSONB),
-    Column("video", JSONB),
+    Column("media", JSONB),
 
     Column("created_at", DateTime, server_default=func.now(), nullable=False),
     Column("updated_at", DateTime, onupdate=func.now())

--- a/src/database.py
+++ b/src/database.py
@@ -33,6 +33,7 @@ engine = create_async_engine(DATABASE_URL)
 
 metadata = MetaData(naming_convention=DB_NAMING_CONVENTION)
 
+
 language = Table(
     "language",
     metadata,
@@ -41,6 +42,7 @@ language = Table(
 
     # TODO: flag: show in language selector UI or not
 )
+
 
 meme_source = Table(
     "meme_source",
@@ -57,6 +59,7 @@ meme_source = Table(
     Column("created_at", DateTime, server_default=func.now(), nullable=False),
     Column("updated_at", DateTime, onupdate=func.now()),
 )
+
 
 meme_raw_telegram = Table(
     "meme_raw_telegram",
@@ -84,6 +87,7 @@ meme_raw_telegram = Table(
     UniqueConstraint("meme_source_id", "post_id", name=MEME_SOURCE_POST_UNIQUE_CONSTRAINT),
 )
 
+
 meme_raw_upload = Table(
     "meme_raw_upload",
     metadata,
@@ -105,6 +109,7 @@ meme_raw_upload = Table(
     Column("created_at", DateTime, server_default=func.now(), nullable=False),
     Column("updated_at", DateTime, onupdate=func.now())
 )
+
 
 meme = Table(
     "meme",
@@ -128,6 +133,7 @@ meme = Table(
     UniqueConstraint("meme_source_id", "raw_meme_id", name=MEME_SOURCE_RAW_MEME_UNIQUE_CONSTRAINT),
 )
 
+
 user_tg = Table(
     "user_tg",
     metadata,
@@ -145,6 +151,7 @@ user_tg = Table(
     Column("updated_at", DateTime, onupdate=func.now()),
 )
 
+
 user = Table(
     "user",
     metadata,
@@ -155,6 +162,7 @@ user = Table(
     Column("last_active_at", DateTime, onupdate=func.now()),
     Column("blocked_bot_at", DateTime),
 )
+
 
 user_language = Table(
     "user_language",

--- a/src/storage/schemas.py
+++ b/src/storage/schemas.py
@@ -17,3 +17,20 @@ class OcrResult(CustomModel):
     model: str
     result: dict
     calculated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class MemeUserUpload(CustomModel):
+    message_id: int
+    chat: dict
+
+    content: str | None = None
+    date: datetime
+
+    out_links: list[str] | None = None
+    mentions: list[str] | None = None # mentioned usernames
+    hashtags: list[str] | None = None
+    forwarded: dict | None = None
+
+    image: list[dict] | None = None
+    video: list[dict] | None = None
+

--- a/src/storage/schemas.py
+++ b/src/storage/schemas.py
@@ -30,7 +30,5 @@ class MemeUserUpload(CustomModel):
     mentions: list[str] | None = None # mentioned usernames
     hashtags: list[str] | None = None
     forwarded: dict | None = None
-
-    image: list[dict] | None = None
-    video: list[dict] | None = None
+    media: list[dict] | None = None
 


### PR DESCRIPTION
Пояснение к таблице meme_raw_upload:

``` python
class MemeUserUpload(CustomModel):
    message_id: int
    chat: dict

    content: str | None = None
    date: datetime

    out_links: list[str] | None = None
    mentions: list[str] | None = None # mentioned usernames
    hashtags: list[str] | None = None
    forwarded: dict | None = None
    
    image: list[dict] | None = None # по факту не лист из тех данных, что пришли, а dict но тут нужно еще посмотреть больше с несколькими картинками и видео
    video: list[dict] | None = None
    
meme_raw_upload = Table(
    "meme_raw_upload",
    metadata,
    Column("id", Integer, Identity(), primary_key=True),
    Column("message_id", Integer, nullable=False),
    # from message_id
    # type int not null
    # Example 17, 20 ...
    Column("chat", JSONB, nullable=False),
    # from chat
    # type jsonb not null
    # Example Chat(first_name='', id=, type=<ChatType.PRIVATE>, username=''),
    # first_name как будто не очень нужно, а остальное я бы оставил

    Column("content", String),
    # from caption
    # type varchar null
    # Example текст, текст ...
    Column("date", DateTime, nullable=False),
    # from date
    # type datetime not null
    # Example datetime.datetime(2023, 12, 29, 19, 25, 5, tzinfo=<UTC>)

    Column("out_links", JSONB),
    # from caption_entities where type MessageEntityType.TEXT_LINK
    # type jsonb null
    # Example [https://t.me/ffmemesbot?start=sc_267689, https://huggingface.co/spaces/badayvedat/LLaVA]
    Column("mentions", JSONB),
    # Не было примеров, но может нужно 
    # скорее всего будет в caption_entities с каким-то типом
    # type jsonb null
    Column("hashtags", JSONB),
    # from caption_entities where type MessageEntityType.HASHTAG get length and offset ->parsing caption
    # type jsonb null
    # Example [#meme]
    Column("forwarded", JSONB),
    # from api_kwargs.forward_origin when resend to bot
    # type jsonb null
    # Examples: {'type': 'channel', 'chat': {
    # 					'id': ,
    # 					'title': 'Fast Food Memes / ffmemes',
    # 					'username': 'fastfoodmemes',
    # 					'type': 'channel'
    # 					},
    # 			  'message_id': 8118,
    # 			  'date': 1703875067
    # 		     }
    # 		     {'type': 'hidden_user', 'sender_user_name': '', 'date': 1703853440}}
    #            {'type': 'user', 'sender_user': {'id': , 'is_bot': False, 'first_name': ''}, 'date': 1703877450}

    Column("media", JSONB),
    # from photo я бы взял с наибольшим height+width один dict PhotoSize, нет примера с двумя картинками
    # type jsonb null
    # Examples:
    # photo=(
	#	PhotoSize(file_id='QADNAQ', file_size=1446, file_unique_id='G00eYUh9', height=90, width=58),
    #	PhotoSize(file_id='QADNAQ', file_size=19393, file_unique_id='G00eYUh9', height=320, width=206),
    #	PhotoSize(file_id='QADNAQ', file_size=72237, file_unique_id='G00eYUh9', height=800, width=516),
    #	PhotoSize(file_id='QADNAQ', file_size=88190, file_unique_id='G00eYUh9-', height=1080, width=696)
	#	)
    # from video много данных, основные как будто все строчки кроме api_kwargs и thumbnail, в примере с двумя видео данные об одном
    # type jsonb null
    # Examples:
    # video=Video(
    # 	api_kwargs={
    # 		'thumb': {
    # 			'file_id': 'BwEAB20AAzQE',
    # 			'file_unique_id': 'A',
    # 			'file_size': 11829,
    # 			'width': 175,
    # 			'height': 320
    # 		 }
    # 	},
    # 	duration=21,
    # 	file_id='gTXqpPgc0BA',
    # 	file_name='IMG_2990.MP4',
    # 	file_size=2688663,
    # 	file_unique_id='F',
    # 	height=848,
    # 	mime_type='video/mp4',
    # 	thumbnail=PhotoSize(file_id='BwEAB20AAzQE', file_size=11829, file_unique_id='BwEAB20AAzQE', height=320, width=175),
    # 	width=464)
    Column("created_at", DateTime, server_default=func.now(), nullable=False),
    Column("updated_at", DateTime, onupdate=func.now())
```