### PR TITLE
Faster reaction times

### DIFF
--- a/src/tgbot/handlers/reaction.py
+++ b/src/tgbot/handlers/reaction.py
@@ -25,7 +25,7 @@ async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     )
 
     await asyncio.gather(
-        await update_user_info_counters(user_id),
+        update_user_info_counters(user_id),
         update_user_meme_reaction(
             user_id=user_id,
             meme_id=int(meme_id),

--- a/src/tgbot/handlers/reaction.py
+++ b/src/tgbot/handlers/reaction.py
@@ -2,6 +2,7 @@
     Handle reactions on sent memes
 """
 
+import asyncio
 import logging
 
 from telegram import Update
@@ -23,17 +24,17 @@ async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         f"🛜 reaction: user_id={user_id}, meme_id={meme_id}, reaction_id={reaction_id}"
     )
 
-    await update_user_info_counters(user_id)
 
-    reaction_is_new = await update_user_meme_reaction(
-        user_id=user_id,
-        meme_id=int(meme_id),
-        reaction_id=int(reaction_id),
+    await asyncio.gather(
+        await update_user_info_counters(user_id),
+        update_user_meme_reaction(
+            user_id=user_id,
+            meme_id=int(meme_id),
+            reaction_id=int(reaction_id),
+        ),
+        next_message(
+                user_id,
+                prev_update=update,
+                prev_reaction_id=int(reaction_id),
+       )
     )
-
-    if reaction_is_new:
-        return await next_message(
-            user_id,
-            prev_update=update,
-            prev_reaction_id=int(reaction_id),
-        )

--- a/src/tgbot/handlers/reaction.py
+++ b/src/tgbot/handlers/reaction.py
@@ -24,7 +24,6 @@ async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         f"🛜 reaction: user_id={user_id}, meme_id={meme_id}, reaction_id={reaction_id}"
     )
 
-
     await asyncio.gather(
         await update_user_info_counters(user_id),
         update_user_meme_reaction(
@@ -33,8 +32,8 @@ async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             reaction_id=int(reaction_id),
         ),
         next_message(
-                user_id,
-                prev_update=update,
-                prev_reaction_id=int(reaction_id),
-       )
+            user_id,
+            prev_update=update,
+            prev_reaction_id=int(reaction_id),
+        ),
     )


### PR DESCRIPTION
Do database insert, send new meme & redis update all at the same time.
Since in the recommendation function we check the existence of meme-reaction pair, not it having an actual reaction, we don't need to do it before deciding on the next meme.
We also don't need to check whether we've reacted to that meme in the past, because if we did - the buttons would automatically disappear via the webhook response.