### PR TITLE
Deduplication ocr text

### DIFF
--- a/src/flows/storage/memes.py
+++ b/src/flows/storage/memes.py
@@ -160,7 +160,9 @@ async def final_meme_pipeline() -> None:
         await analyse_meme_caption(meme)
 
         # TODO: check if we have meme with a same content in db
-        duplicate_meme_id = await find_meme_duplicate()
+        duplicate_meme_id = await find_meme_duplicate(
+            meme["id"], meme["ocr_result"]["text"]
+        )
         if duplicate_meme_id:
             await update_meme(
                 meme["id"], status=MemeStatus.DUPLICATE, duplicate_of=duplicate_meme_id

--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -270,6 +270,8 @@ async def update_meme_status_of_ready_memes() -> list[dict[str, Any]]:
 
 
 async def find_meme_duplicate(meme_id: int, imagetext: str) -> int | None:
+    if len(imagetext) < 3: # skip all memes with less than 3 letters 
+        return None
     select_query = """
         SELECT
             M.id

--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -270,7 +270,7 @@ async def update_meme_status_of_ready_memes() -> list[dict[str, Any]]:
 
 
 async def find_meme_duplicate(meme_id: int, imagetext: str) -> int | None:
-    if len(imagetext) < 3: # skip all memes with less than 3 letters 
+    if len(imagetext) < 3:  # skip all memes with less than 3 letters
         return None
     select_query = """
         SELECT

--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import nulls_first, or_, select, text, bindparam
+from sqlalchemy import bindparam, nulls_first, or_, select, text
 from sqlalchemy.dialects.postgresql import insert
 
 from src.database import (
@@ -283,11 +283,13 @@ async def find_meme_duplicate(meme_id: int, imagetext: str) -> int | None:
         ORDER BY M.id ASC
         LIMIT 1
     """
-    select_query = text(select_query).bindparams(bindparam('meme_id', value=meme_id), bindparam('imagetext', value=imagetext))
+    select_query = text(select_query).bindparams(
+        bindparam("meme_id", value=meme_id), bindparam("imagetext", value=imagetext)
+    )
 
     res = await fetch_one(select_query)
     if res:
-        res = min(meme_id, res['id'])
-        if meme_id != res['id']: # meme_id is not original meme_id
+        res = min(meme_id, res["id"])
+        if meme_id != res["id"]:  # meme_id is not original meme_id
             return res["id"]
     return None


### PR DESCRIPTION
1. add to Postgres built-in extension `CREATE EXTENSION pg_trgm;`
2. Can't test python code without db tokens. Tested SQL code in [metabase](https://metabase.okhlopkov.com/question/100-deduplication)
3. Table of results with [duplications](https://github.com/SUPERustam/ocr_example/blob/master/images/dupblication.csv). 5/12 accuracy
4. Use coefficient 0.9 not 1 because 0.9 indicate that 2 strings are very similar

Playground: https://metabase.okhlopkov.com/question/116-my1