### PR TITLE
fix sending non-image memes to Mystic OCR

### DIFF
--- a/src/flows/storage/memes.py
+++ b/src/flows/storage/memes.py
@@ -127,6 +127,8 @@ async def tg_meme_pipeline() -> None:
     memes = await upload_memes_to_telegram(unloaded_memes)
 
     for meme in memes:
+        if meme["type"] != MemeType.IMAGE:
+            continue
         await ocr_meme_content(
             meme["id"], meme["__original_content"], meme["language_code"]
         )
@@ -151,6 +153,8 @@ async def vk_meme_pipeline() -> None:
     memes = await upload_memes_to_telegram(unloaded_memes)
 
     for meme in memes:
+        if meme["type"] != MemeType.IMAGE:
+            continue
         await ocr_meme_content(
             meme["id"], meme["__original_content"], meme["language_code"]
         )

--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -228,7 +228,8 @@ async def get_memes_to_ocr(limit=100):
 
 
 async def get_unloaded_tg_memes(limit) -> list[dict[str, Any]]:
-    """Returns only MemeType.IMAGE memes"""
+    """Returns memes from Telegram, that have not been yet uploaded to Telegram."""
+
     select_query = f"""
         SELECT
             meme.id,
@@ -254,11 +255,12 @@ async def get_unloaded_tg_memes(limit) -> list[dict[str, Any]]:
 
 
 async def get_unloaded_vk_memes() -> list[dict[str, Any]]:
-    "Returns only MemeType.IMAGE memes"
+    """Returns memes from VK, that have not been yet uploaded to Telegram."""
+
     select_query = f"""
         SELECT
             meme.id,
-            '{MemeType.IMAGE}' AS type,
+            meme.type,
             meme_raw_vk.media->>0 content_url
         FROM meme
         INNER JOIN meme_source


### PR DESCRIPTION
Currently, we are sometimes sending files that are not images to Mystic OCR, resulting in errors and more bandwitdth being used.
This PR fixes it.