### PR TITLE
Fix HTML escaping in meme captions

### DIFF
--- a/src/tgbot/senders/meme_caption.py
+++ b/src/tgbot/senders/meme_caption.py
@@ -7,7 +7,7 @@ from src.tgbot.user_info import get_user_info
 async def get_meme_caption_for_user_id(meme: MemeData, user_id: int) -> str:
     user_info = await get_user_info(user_id)
 
-    caption = escape_html(meme.caption) if meme.caption or ""
+    caption = escape_html(meme.caption) if meme.caption else ""
 
     caption += "\n\n" + get_referral_html(user_id, meme.id)
 

--- a/src/tgbot/senders/meme_caption.py
+++ b/src/tgbot/senders/meme_caption.py
@@ -1,13 +1,13 @@
 from src.storage.schemas import MemeData
 from src.tgbot.constants import UserType
-from src.tgbot.senders.utils import get_referral_html
+from src.tgbot.senders.utils import escape_html, get_referral_html
 from src.tgbot.user_info import get_user_info
 
 
 async def get_meme_caption_for_user_id(meme: MemeData, user_id: int) -> str:
     user_info = await get_user_info(user_id)
 
-    caption = meme.caption or ""
+    caption = escape_html(meme.caption) if meme.caption or ""
 
     caption += "\n\n" + get_referral_html(user_id, meme.id)
 

--- a/src/tgbot/senders/meme_caption.py
+++ b/src/tgbot/senders/meme_caption.py
@@ -1,13 +1,15 @@
+from html import escape
+
 from src.storage.schemas import MemeData
 from src.tgbot.constants import UserType
-from src.tgbot.senders.utils import escape_html, get_referral_html
+from src.tgbot.senders.utils import get_referral_html
 from src.tgbot.user_info import get_user_info
 
 
 async def get_meme_caption_for_user_id(meme: MemeData, user_id: int) -> str:
     user_info = await get_user_info(user_id)
 
-    caption = escape_html(meme.caption) if meme.caption else ""
+    caption = escape(meme.caption, quote=False) if meme.caption else ""
 
     caption += "\n\n" + get_referral_html(user_id, meme.id)
 

--- a/src/tgbot/senders/utils.py
+++ b/src/tgbot/senders/utils.py
@@ -78,10 +78,6 @@ def get_referral_html(user_id: int, meme_id: int) -> str:
     return f"""{emoji} <i><a href="{ref_link}">Fast Food Memes</a></i>"""
 
 
-def escape_html(text: str) -> str:
-    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
-
 async def send_or_edit(
     prev_update: Update,
     text: str,

--- a/src/tgbot/senders/utils.py
+++ b/src/tgbot/senders/utils.py
@@ -78,6 +78,10 @@ def get_referral_html(user_id: int, meme_id: int) -> str:
     return f"""{emoji} <i><a href="{ref_link}">Fast Food Memes</a></i>"""
 
 
+def escape_html(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
 async def send_or_edit(
     prev_update: Update,
     text: str,


### PR DESCRIPTION
will remove the HTML parse error if some meme caption has `<`, `>`, or `&` symbols.