### PR TITLE
Decrease coefficient of deduplication to 0.8

### DIFF
--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -410,7 +410,7 @@ async def find_meme_duplicate(meme_id: int, imagetext: str) -> int | None:
             AND similarity(
                 :imagetext,
                 M.ocr_result ->> 'text'
-              ) >= 0.86
+              ) >= 0.8
             AND M.status != 'duplicate'
         ORDER BY M.id ASC
         LIMIT 1

--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -410,7 +410,7 @@ async def find_meme_duplicate(meme_id: int, imagetext: str) -> int | None:
             AND similarity(
                 :imagetext,
                 M.ocr_result ->> 'text'
-              ) >= 0.9
+              ) >= 0.86
             AND M.status != 'duplicate'
         ORDER BY M.id ASC
         LIMIT 1


### PR DESCRIPTION
НЕТ логирования найденных дубликатов в чат логов.

0.86 взял потому что эти запросы имеют такую [схожесть](https://metabase.okhlopkov.com/question/162-similarity-of-two-long-text-0-86)