### PR TITLE
Add recently liked algo

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -37,6 +37,6 @@ jobs:
       # - name: Lint with mypy
       #   run: |
       #     mypy src tests
-      # - name: Run tests
-      #   run: |
-      #     pytest
+      - name: Run tests
+        run: |
+          pytest

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -214,7 +214,8 @@ async def generate_with_blender(
                 "uploaded_memes": 0.2,
                 "fast_dopamine": 0.2,
                 "best_memes_from_each_source": 0.2,
-                "lr_smoothed": 0.4,
+                "lr_smoothed": 0.2,
+                "recently_liked": 0.2,
             }
 
             engines = [
@@ -222,6 +223,7 @@ async def generate_with_blender(
                 "fast_dopamine",
                 "best_memes_from_each_source",
                 "lr_smoothed",
+                "recently_liked",
             ]
             candidates_dict = await retriever.get_candidates_dict(
                 engines, user_id, limit, exclude_mem_ids=meme_ids_in_queue


### PR DESCRIPTION
Current local issue:

``` sh
docker-compose up -d --build 
docker-compose exec app pytest
```

```
============================================================================================= FAILURES =============================================================================================
_______________________________________________________________________________ test_generate_with_blender_below_100 _______________________________________________________________________________

    @pytest.mark.asyncio
    async def test_generate_with_blender_below_100():
        async def uploaded_memes(
            self,
            user_id: int,
            limit: int = 10,
            exclude_meme_ids: list[int] = [],
        ) -> list[dict[str, Any]]:
            return [
                {"id": 1},
                {"id": 2},
            ]
    
        async def get_fast_dopamine(
            self,
            user_id: int,
            limit: int = 10,
            exclude_meme_ids: list[int] = [],
        ) -> list[dict[str, Any]]:
            return [
                {"id": 3},
                {"id": 4},
            ]
    
        async def get_best_memes_from_each_source(
            self,
            user_id: int,
            limit: int = 10,
            exclude_meme_ids: list[int] = [],
        ) -> list[dict[str, Any]]:
            return [
                {"id": 5},
                {"id": 6},
            ]
    
        async def get_lr_smoothed(
            self,
            user_id: int,
            limit: int = 10,
            exclude_meme_ids: list[int] = [],
        ) -> list[dict[str, Any]]:
            return [
                {"id": 7},
                {"id": 8},
                {"id": 9},
                {"id": 10},
            ]
    
        class TestRetriever(CandidatesRetriever):
            engine_map = {
                "uploaded_memes": uploaded_memes,
                "fast_dopamine": get_fast_dopamine,
                "best_memes_from_each_source": get_best_memes_from_each_source,
                "lr_smoothed": get_lr_smoothed,
            }
    
>       candidates = await generate_with_blender(1, 10, 40, TestRetriever())

tests/recommendations/test_meme_queue.py:120: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/recommendations/meme_queue.py:268: in generate_with_blender
    candidates = await get_candidates(user_id, limit)
src/recommendations/meme_queue.py:228: in get_candidates
    candidates_dict = await retriever.get_candidates_dict(
src/recommendations/candidates.py:731: in get_candidates_dict
    candidates_dict[engine] = await self.get_candidates(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <test_meme_queue.test_generate_with_blender_below_100.<locals>.TestRetriever object at 0xffffaa948220>, engine = 'recently_liked', user_id = 1, limit = 10, exclude_mem_ids = [2, 3, 1, 4]

    async def get_candidates(
        self,
        engine: str,
        user_id: int,
        limit: int = 10,
        exclude_mem_ids: list[int] = [],
    ) -> list[dict[str, Any]]:
        if engine not in self.engine_map:
>           raise ValueError(f"engine {engine} is not supported")
E           ValueError: engine recently_liked is not supported

src/recommendations/candidates.py:718: ValueError
========================================================================================= warnings summary =========================================================================================
../usr/local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py:263
  /usr/local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py:263: PydanticDeprecatedSince20: `json_encoders` is deprecated. See https://docs.pydantic.dev/2.7/concepts/serialization/#custom-serializers for alternatives. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== short test summary info ======================================================================================
FAILED tests/recommendations/test_meme_queue.py::test_generate_with_blender_below_100 - ValueError: engine recently_liked is not supported
============================================================================= 1 failed, 13 passed, 1 warning in 20.21s =============================================================================
Exception ignored in: <function AbstractConnection.__del__ at 0xffffac715ea0>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/redis/asyncio/connection.py", line 218, in __del__
  File "/usr/local/lib/python3.10/site-packages/redis/asyncio/connection.py", line 225, in _close
  File "/usr/local/lib/python3.10/asyncio/streams.py", line 337, in close
  File "/usr/local/lib/python3.10/asyncio/selector_events.py", line 706, in close
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 753, in call_soon
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 515, in _check_closed
RuntimeError: Event loop is closed
```