### PR TITLE
Increase database connection pool size and TTL

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,8 +8,8 @@ from src.constants import Environment
 
 class Config(BaseSettings):
     DATABASE_URL: PostgresDsn
-    DATABASE_POOL_SIZE: int = 16
-    DATABASE_POOL_TTL: int = 60 * 20  # 20 minutes
+    DATABASE_POOL_SIZE: int = 64
+    DATABASE_POOL_TTL: int = 60 * 30  # 30 minutes
     DATABASE_POOL_PRE_PING: bool = True
 
     REDIS_URL: RedisDsn


### PR DESCRIPTION
Increase the database connection pool size and TTL.

* Update `DATABASE_POOL_SIZE` to 64 in `src/config.py`
* Update `DATABASE_POOL_TTL` to 30 minutes in `src/config.py`

