### PR TITLE
Improve Redis connection handling

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,7 @@ class Config(BaseSettings):
     DATABASE_POOL_PRE_PING: bool = True
 
     REDIS_URL: RedisDsn
+    REDIS_HEALTH_CHECK_INTERVAL: int = 30
 
     SITE_DOMAIN: str = "myapp.com"
 

--- a/src/redis.py
+++ b/src/redis.py
@@ -10,6 +10,8 @@ from src.models import CustomModel
 pool = aioredis.ConnectionPool.from_url(
     str(settings.REDIS_URL),
     max_connections=settings.REDIS_MAX_CONNECTIONS,
+    health_check_interval=settings.REDIS_HEALTH_CHECK_INTERVAL,
+    socket_keepalive=True,
     decode_responses=True,
 )
 redis_client = aioredis.Redis(connection_pool=pool)
@@ -64,10 +66,10 @@ async def add_memes_to_queue_by_key(
     key: str, memes: list[dict], expire: int = 3600
 ) -> None:
     jsoned_memes = [orjson.dumps(meme) for meme in memes]
-    p = await redis_client.pipeline(transaction=True)
-    await p.sadd(key, *jsoned_memes)
-    await p.expire(key, expire)
-    await p.execute(raise_on_error=True)
+    async with redis_client.pipeline(transaction=True) as pipe:
+        await pipe.sadd(key, *jsoned_memes)
+        await pipe.expire(key, expire)
+        await pipe.execute(raise_on_error=True)
 
 
 def get_user_info_key(user_id: int) -> str:


### PR DESCRIPTION
## Summary
- add configuration for Redis health checks and enable socket keepalive on the async connection pool
- wrap the meme queue pipeline usage in an async context manager so connections are released properly

## Testing
- pytest *(fails: missing optional test dependencies such as pytest_asyncio, sqlalchemy, and orjson in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc050362b88326b3e20da30203a807