### PR TITLE
Handle missing Instagram users during parsing

### DIFF
--- a/src/storage/parsers/ig.py
+++ b/src/storage/parsers/ig.py
@@ -11,16 +11,26 @@ async def _get_user_info(
     username: str,
 ) -> dict | None:
     async with httpx.AsyncClient(timeout=20.0) as client:
-        response = await client.get(
-            "https://api.hikerapi.com/v2/user/by/username",
-            params={"username": username},
-            headers={
-                "accept": "application/json",
-                "x-access-key": settings.HIKERAPI_TOKEN,
-            },
-        )
+        try:
+            response = await client.get(
+                "https://api.hikerapi.com/v2/user/by/username",
+                params={"username": username},
+                headers={
+                    "accept": "application/json",
+                    "x-access-key": settings.HIKERAPI_TOKEN,
+                },
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                logging.warning(
+                    "Instagram user '%s' not found. Skipping.",
+                    username,
+                )
+                return None
 
-        response.raise_for_status()
+            raise
+
         return response.json()
 
 
@@ -43,6 +53,9 @@ async def _get_user_medias(
 
 async def get_user_info(instagram_username: str):
     user_info_response = await _get_user_info(instagram_username)
+    if not user_info_response:
+        return None
+
     if user_info_response["status"] != "ok" or not user_info_response.get("user"):
         logging.warning(
             f"Failed to get @{instagram_username} info. Result: {user_info_response}"


### PR DESCRIPTION
## Summary
- treat 404 responses from the Instagram user lookup API as a missing user instead of an error
- return early when the user lookup fails so the flow can continue parsing other usernames

## Testing
- pytest *(fails: missing optional dependencies such as pytest_asyncio, sqlalchemy, orjson)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdef6347c832684d5b1ff84e6fe6f