### PR TITLE
Fix ruff lint errors

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ async def lifespan(_application: FastAPI) -> AsyncGenerator:
     )
     await tgbot_app.application.initialize()
 
-    # flush all redis keys on startup for debug 
+    # flush all redis keys on startup for debug
     # await redis.redis_client.flushall()
 
     # if is_webhook:  # all gunicorn workers will call this and hit rate limit

--- a/src/redis.py
+++ b/src/redis.py
@@ -2,8 +2,8 @@ from datetime import timedelta
 from typing import Optional
 
 import orjson
-import redis.asyncio as aioredis
 
+import redis.asyncio as aioredis
 from src.config import settings
 from src.models import CustomModel
 

--- a/src/tgbot/app.py
+++ b/src/tgbot/app.py
@@ -1,7 +1,6 @@
-from telegram import (
-    Update,
-)
+from telegram import Update
 from telegram.ext import (
+    AIORateLimiter,
     Application,
     CallbackQueryHandler,
     ChatBoostHandler,
@@ -11,7 +10,6 @@ from telegram.ext import (
     InlineQueryHandler,
     MessageHandler,
     PreCheckoutQueryHandler,
-    AIORateLimiter,
     filters,
 )
 
@@ -24,12 +22,9 @@ from src.tgbot.constants import (
     MEME_SOURCE_SET_LANG_REGEXP,
     MEME_SOURCE_SET_STATUS_REGEXP,
     POPUP_BUTTON_CALLBACK_DATA_REGEXP,
-    TELEGRAM_CHANNEL_EN_CHAT_ID,
     TELEGRAM_CHANNEL_RU_CHAT_ID,
-    TELEGRAM_CHAT_EN_CHAT_ID,
     TELEGRAM_CHAT_RU_CHAT_ID,
     TELEGRAM_FEEDBACK_CHAT_ID,
-    TELEGRAM_MODERATOR_CHAT_ID,
 )
 from src.tgbot.handlers import (
     alerts,
@@ -55,6 +50,7 @@ from src.tgbot.handlers.admin.user_info import (
 )
 from src.tgbot.handlers.chat.chat import handle_chat_message
 from src.tgbot.handlers.chat.chat_member import handle_chat_member_update
+
 # from src.tgbot.handlers.chat.explain_meme import explain_meme_en, explain_meme_ru
 from src.tgbot.handlers.chat.feedback import (
     handle_feedback_message,
@@ -267,7 +263,10 @@ def add_handlers(application: Application) -> None:
     # TODO: turn in when I'll have more free ChatGPT credits (probably never)
     # application.add_handler(
     #     MessageHandler(
-    #         filters=filters.Chat([TELEGRAM_CHAT_RU_CHAT_ID, TELEGRAM_MODERATOR_CHAT_ID])
+    #         filters=filters.Chat([
+    #             TELEGRAM_CHAT_RU_CHAT_ID,
+    #             TELEGRAM_MODERATOR_CHAT_ID,
+    #         ])
     #         & filters.PHOTO
     #         & filters.UpdateType.MESSAGE,
     #         callback=explain_meme_ru,

--- a/src/tgbot/handlers/chat/chat_member.py
+++ b/src/tgbot/handlers/chat/chat_member.py
@@ -4,13 +4,7 @@ import logging
 from typing import Optional, Tuple
 
 from telegram import Chat, ChatMember, ChatMemberUpdated, Update
-from telegram.ext import (
-    ContextTypes,
-)
-
-from src.tgbot.handlers import (
-    block,
-)
+from telegram.ext import ContextTypes
 
 
 def extract_status_change(

--- a/src/tgbot/handlers/upload/upload_meme.py
+++ b/src/tgbot/handlers/upload/upload_meme.py
@@ -94,8 +94,8 @@ async def handle_message_with_meme(
             return await update.message.reply_text(
                 """
 You already uploaded lots of memes today. Try again tomorrow.
-Think about quality, not quantity: your goal is to get as many likes as possible. 
-Analyse your /uploads 
+Think about quality, not quantity: your goal is to get as many likes as possible.
+Analyse your /uploads
                 """
             )
 


### PR DESCRIPTION
## Summary
- reorder and clean up imports in the Telegram bot modules to satisfy Ruff
- remove unused constants and break long comment lines flagged by the linter
- strip trailing whitespace in handlers that upload memes and adjust Redis import spacing

## Testing
- ruff check src

------
https://chatgpt.com/codex/tasks/task_e_68dfe36df5c48326ad269efc308df661