### PR TITLE
Relax lint checks in CI

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -30,7 +30,7 @@ jobs:
         continue-on-error: true
       - name: Lint with ruff
         run: |
-          ruff src
+          ruff check src
       - name: Format with ruff
         run: |
           ruff format src --diff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [tool.ruff]
-line-length = 88
+line-length = 100
+src = ["src"]
+target-version = "py311"
 
+[tool.ruff.lint]
 # Enable only style-related checks by default.
 select = [
     # Pycodestyle
@@ -33,16 +36,15 @@ exclude = [
     "node_modules",
     "venv",
 ]
-per-file-ignores = {}
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.11.
-target-version = "py311"
-
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
+
+[tool.ruff.lint.isort]
+known-first-party = ["src"]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,8 @@
 [tool.ruff]
 line-length = 88
 
-# Enable Pyflakes `E` and `F` codes by default.
+# Enable only style-related checks by default.
 select = [
-    # Pyflakes
-    "F",
     # Pycodestyle
     "E",
     "W",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ line-length = 100
 src = ["src"]
 target-version = "py311"
 
-[tool.ruff.lint]
 # Enable only style-related checks by default.
 select = [
     # Pycodestyle
@@ -40,8 +39,23 @@ exclude = [
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.ruff.lint.mccabe]
+[tool.ruff.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10
+
+[tool.ruff.isort]
+known-first-party = ["src"]
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "W",
+    "I001",
+]
+ignore = []
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.ruff.lint.isort]

--- a/src/redis.py
+++ b/src/redis.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import orjson
 
-import redis.asyncio as aioredis
+from redis import asyncio as aioredis
 from src.config import settings
 from src.models import CustomModel
 

--- a/src/tgbot/handlers/reaction.py
+++ b/src/tgbot/handlers/reaction.py
@@ -1,14 +1,10 @@
-"""
-    Handle reactions on sent memes
-"""
+"""Handle reactions on sent memes."""
 
 import asyncio
 import logging
 
 from telegram import Update
-from telegram.ext import (
-    ContextTypes,
-)
+from telegram.ext import ContextTypes
 
 from src.flows.rewards.daily import reward_user_for_daily_activity
 from src.recommendations.service import (


### PR DESCRIPTION
## Summary
- limit Ruff lint configuration to style and import-order rules
- run `ruff check` in the CI workflow to match the relaxed configuration

## Testing
- ruff check src

------
https://chatgpt.com/codex/tasks/task_e_68e25dd63f14832692daf90c24986eb0