### PR TITLE
Clarify handling of missing previous Telegram messages

### DIFF
--- a/src/tgbot/senders/next_message.py
+++ b/src/tgbot/senders/next_message.py
@@ -113,7 +113,13 @@ async def _replace_previous_message(
             previous_message, meme, reply_markup
         )
     except BadRequest as error:
-        if "Message to edit not found" in str(error):
+        if _is_missing_message_error(error):
+            logging.info(
+                "Previous message for meme %s is missing (error: %s). "
+                "Sending new message instead.",
+                meme.id,
+                error,
+            )
             edited_message = None
         else:
             raise
@@ -139,3 +145,8 @@ async def _disable_broken_meme(meme: MemeData, error: BadRequest) -> None:
     await log(
         f"meme {meme.id} is disabled now because of: {error.__class__.__name__}: {error}"
     )
+
+
+def _is_missing_message_error(error: BadRequest) -> bool:
+    message = str(error).lower()
+    return "message to edit not found" in message or "message_id_invalid" in message


### PR DESCRIPTION
## Summary
- send a fresh meme when editing the previous message fails because the original message is gone
- treat Telegram `message_id_invalid` errors as a missing previous message and log before resending

## Testing
- not run (tests require unavailable third-party dependencies in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e29ce0d5d08326b83c5b367076cb53