### PR TITLE
Handle no-op moderator invite markup edits

### DIFF
--- a/src/tgbot/handlers/moderator/invite.py
+++ b/src/tgbot/handlers/moderator/invite.py
@@ -106,7 +106,12 @@ async def handle_moderator_invite_callback(
         try:
             await query.edit_message_reply_markup(reply_markup=None)
         except BadRequest as exc:
-            if exc.message != "Message is not modified":
+            if exc.message and "Message is not modified" in exc.message:
+                logging.debug(
+                    "Moderator invite message for user_id=%s already had reply markup removed",
+                    user_id,
+                )
+            else:
                 raise
 
     await context.bot.send_message(


### PR DESCRIPTION
## Summary
- treat Telegram "Message is not modified" errors as benign when clearing moderator invite buttons
- add a debug log so the silent branch remains transparent in production logs

## Testing
- pytest tests/tgbot/handlers/moderator -k invite -q *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b30790588326b2a688b45997cf0b