### PR TITLE
Handle Telegram 'Message is not modified' errors

### DIFF
--- a/src/tgbot/handlers/upload/moderation.py
+++ b/src/tgbot/handlers/upload/moderation.py
@@ -250,7 +250,7 @@ async def handle_uploaded_meme_review_button(
                     reply_markup=None,
                 )
             except BadRequest as exc:
-                if exc.message != "Message is not modified":
+                if "Message is not modified" not in str(exc):
                     raise
 
         await create_user_meme_reaction(  # author auto like for the uploaded meme
@@ -316,7 +316,7 @@ See realtime stats of your uploaded memes: /uploads
                     reply_markup=None,
                 )
             except BadRequest as exc:
-                if exc.message != "Message is not modified":
+                if "Message is not modified" not in str(exc):
                     raise
         try:
             await context.bot.send_message(


### PR DESCRIPTION
## Summary
- avoid failing meme review callbacks when Telegram refuses to edit an unchanged message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7ce5fe0dc83268b2b1aec98b25863