### PR TITLE
Add meme channel links to crash notification

### DIFF
--- a/src/tgbot/handlers/error.py
+++ b/src/tgbot/handlers/error.py
@@ -6,9 +6,13 @@ from telegram import Update
 from telegram.error import Forbidden
 from telegram.ext import ContextTypes
 
-from src.tgbot.constants import UserType
+from src.tgbot.constants import (
+    TELEGRAM_CHANNEL_EN_LINK,
+    TELEGRAM_CHANNEL_RU_LINK,
+    UserType,
+)
 from src.tgbot.logs import log
-from src.tgbot.service import update_user
+from src.tgbot.service import get_user_languages, update_user
 from src.tgbot.user_info import update_user_info_cache
 
 
@@ -37,16 +41,41 @@ async def send_stacktrace_to_tg_chat(update: Update, context: ContextTypes.DEFAU
 
     message = f"An exception was raised while handling an update\n<pre>{tb_string}</pre>"
 
-    await context.bot.send_message(
-        text="""
+    base_message = """
 😔 Something broke inside the bot. It is still early beta.
 We already received all the details.
 Wait for 2 minutes and press /start.
 
 👩🏻‍💻👨‍💻🧑🏻‍💻
-        """,
-        chat_id=user_id,
-    )
+    """
+
+    try:
+        languages = set(await get_user_languages(user_id))
+        language_code = update.effective_user.language_code if update.effective_user else None
+        if language_code:
+            languages.add(language_code)
+
+        has_russian = any(language and language.startswith("ru") for language in languages)
+        channel_link = TELEGRAM_CHANNEL_RU_LINK if has_russian else TELEGRAM_CHANNEL_EN_LINK
+
+        if has_russian:
+            channel_message = f"🎯 Пока мы всё чиним, мемы можно ловить тут: {channel_link}"
+        else:
+            channel_message = f"🎯 While we are fixing things, memes live here: {channel_link}"
+
+        await context.bot.send_message(
+            text=f"{base_message}\n\n{channel_message}",
+            chat_id=user_id,
+        )
+    except Exception:  # noqa: BLE001
+        logging.exception("Failed to send crash message with channel link")
+        try:
+            await context.bot.send_message(
+                text=base_message,
+                chat_id=user_id,
+            )
+        except Exception:  # noqa: BLE001
+            logging.exception("Failed to send crash message fallback")
 
     error_text_to_send = f"⚠️⚠️⚠️ for #{user_id}:\n{message}"
     return await log(error_text_to_send, context.bot)


### PR DESCRIPTION
## Summary
- send crash notification with a meme channel link that respects the user's language preference
- fall back to the original crash text if fetching languages or sending fails

## Testing
- python -m compileall src/tgbot/handlers/error.py

------
https://chatgpt.com/codex/tasks/task_e_68e7d0f6983c832685cbb91198c87f68