### PR TITLE
Update Telegram CTA link text to use bot handle

### DIFF
--- a/src/flows/crossposting/meme.py
+++ b/src/flows/crossposting/meme.py
@@ -117,7 +117,7 @@ def _get_ru_caption_for_crossposting_meme(meme: MemeData, channel: Channel) -> s
     # caption = escape(meme.caption, quote=False) if meme.caption else ""
     # text = caption + "\n\n" + referral_html
 
-    text = cta + ": " + f"""<a href="{ref_link}">🍔🍔🍔</a>"""
+    text = cta + ": " + f"""<a href="{ref_link}">@ffmemesbot</a>"""
 
     return text
 


### PR DESCRIPTION
## Summary
- replace the burger emoji hyperlink label in Telegram crossposting captions with the @ffmemesbot handle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7de9f7c808326a15f6a57392c6b30