### PR TITLE
Show meme stats for forwarded bot messages

### DIFF
--- a/src/tgbot/handlers/upload/forwarded_meme.py
+++ b/src/tgbot/handlers/upload/forwarded_meme.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any, Iterable
+from urllib.parse import parse_qs, urlparse
+
+BOT_DEEP_LINK_REGEXP = re.compile(r"s_\d+_\d+")
+MEME_ID_REGEXP = re.compile(r"s_\d+_(\d+)")
+URL_REGEXP = re.compile(r"https?://\S+")
+
+
+def was_forwarded_from_bot(message: Any, bot_id: int) -> bool:
+    if message is None:
+        return False
+
+    forward_from = getattr(message, "forward_from", None)
+    if forward_from and getattr(forward_from, "id", None) == bot_id:
+        return True
+
+    forward_origin = getattr(message, "forward_origin", None)
+    sender_user = getattr(forward_origin, "sender_user", None) if forward_origin else None
+    if sender_user and getattr(sender_user, "id", None) == bot_id:
+        return True
+
+    return False
+
+
+def _iter_message_urls(message: Any) -> Iterable[str]:
+    if message is None:
+        return
+
+    candidates: list[tuple[str, list[Any]]] = []
+
+    text = getattr(message, "text", None)
+    if text:
+        entities = getattr(message, "entities", None) or []
+        candidates.append((text, list(entities)))
+
+    caption = getattr(message, "caption", None)
+    if caption:
+        caption_entities = getattr(message, "caption_entities", None) or []
+        candidates.append((caption, list(caption_entities)))
+
+    for text_value, entities in candidates:
+        seen_offsets: set[tuple[int, int]] = set()
+        for entity in entities:
+            entity_type = getattr(entity, "type", None)
+            if entity_type == "text_link":
+                url = getattr(entity, "url", None)
+                if url:
+                    yield url
+                continue
+
+            if entity_type == "url":
+                offset = getattr(entity, "offset", 0)
+                length = getattr(entity, "length", 0)
+                key = (offset, length)
+                if key in seen_offsets:
+                    continue
+                seen_offsets.add(key)
+                yield text_value[offset : offset + length]
+
+        for match in URL_REGEXP.findall(text_value):
+            yield match.rstrip(".,)")
+
+
+def extract_meme_id_from_message(message: Any) -> int | None:
+    for url in _iter_message_urls(message):
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        start_param = query.get("start") or query.get("startapp")
+        if not start_param:
+            continue
+
+        start_value = start_param[0]
+        if not BOT_DEEP_LINK_REGEXP.fullmatch(start_value):
+            continue
+
+        meme_id_match = MEME_ID_REGEXP.fullmatch(start_value)
+        if meme_id_match:
+            return int(meme_id_match.group(1))
+
+    return None
+
+
+def format_age(published_at: datetime, *, now: datetime | None = None) -> str:
+    current_time = now or datetime.utcnow()
+    delta = current_time - published_at
+    if delta.total_seconds() < 0:
+        delta = -delta
+
+    days = delta.days
+    hours, remainder = divmod(delta.seconds, 3600)
+    minutes = remainder // 60
+
+    parts: list[str] = []
+    if days:
+        parts.append(f"{days}d")
+    if hours and len(parts) < 2:
+        parts.append(f"{hours}h")
+    if minutes and len(parts) < 2:
+        parts.append(f"{minutes}m")
+
+    if not parts:
+        return "< 1m"
+
+    return " ".join(parts)
+
+
+__all__ = [
+    "BOT_DEEP_LINK_REGEXP",
+    "MEME_ID_REGEXP",
+    "extract_meme_id_from_message",
+    "format_age",
+    "was_forwarded_from_bot",
+]

--- a/src/tgbot/handlers/upload/upload_meme.py
+++ b/src/tgbot/handlers/upload/upload_meme.py
@@ -6,6 +6,8 @@ Methods for Meme uploading via bot:
 
 import asyncio
 import re
+from datetime import datetime
+from html import escape
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ParseMode
@@ -15,6 +17,11 @@ from src import localizer
 from src.recommendations.meme_queue import check_queue
 from src.tgbot.constants import UserType
 from src.tgbot.handlers.upload.constants import SUPPORTED_LANGUAGES
+from src.tgbot.handlers.upload.forwarded_meme import (
+    extract_meme_id_from_message,
+    format_age,
+    was_forwarded_from_bot,
+)
 from src.tgbot.handlers.upload.moderation import uploaded_meme_auto_review
 from src.tgbot.handlers.upload.service import (
     count_24h_uploaded_not_approved_memes,
@@ -24,6 +31,12 @@ from src.tgbot.handlers.upload.service import (
 )
 from src.tgbot.logs import log
 from src.tgbot.senders.next_message import next_message
+from src.tgbot.service import (
+    get_meme_by_id,
+    get_meme_source_by_id,
+    get_meme_source_stats_by_id,
+    get_meme_stats,
+)
 from src.tgbot.user_info import get_user_info
 from src.tgbot.utils import (
     check_if_user_follows_related_channel,
@@ -38,6 +51,73 @@ LANGUAGE_SELECTED_CALLBACK_DATA_REGEXP = r"upload:(\d+):lang:(\w+)"
 
 LANGUAGE_SELECTED_OTHER_CALLBACK_DATA_PATTERN = "upload:{upload_id}:lang:other"
 LANGUAGE_SELECTED_OTHER_CALLBACK_DATA_REGEXP = r"upload:(\d+):lang:other"
+
+
+async def _reply_with_forwarded_meme_stats(
+    update: Update,
+    meme_id: int,
+) -> bool:
+    meme = await get_meme_by_id(meme_id)
+    if not meme:
+        await update.message.reply_text(
+            f"Не нашёл информацию по мему #{meme_id}.",
+        )
+        return True
+
+    meme_source = await get_meme_source_by_id(meme["meme_source_id"])
+    if not meme_source:
+        await update.message.reply_text(
+            f"Источник мема #{meme_id} не найден.",
+        )
+        return True
+    meme_stats = await get_meme_stats(meme_id)
+    meme_source_stats = await get_meme_source_stats_by_id(meme_source["id"])
+
+    meme_nlikes = meme_stats["nlikes"] if meme_stats else 0
+    meme_ndislikes = meme_stats["ndislikes"] if meme_stats else 0
+    meme_views = meme_stats["nmemes_sent"] if meme_stats else 0
+
+    source_nlikes = meme_source_stats["nlikes"] if meme_source_stats else 0
+    source_ndislikes = meme_source_stats["ndislikes"] if meme_source_stats else 0
+    source_views = meme_source_stats["nmemes_sent"] if meme_source_stats else 0
+
+    published_at = meme.get("published_at")
+    published_text = ""
+    if isinstance(published_at, datetime):
+        age_text = format_age(published_at)
+        published_text = (
+            f"🗓 Добавлен: <b>{published_at:%Y-%m-%d %H:%M}</b> ({age_text} ago)\n"
+        )
+
+    source_url = meme_source.get("url") if meme_source else None
+    source_url_html = (
+        f'<a href="{escape(source_url, quote=True)}">{escape(source_url, quote=False)}</a>'
+        if source_url
+        else "—"
+    )
+
+    info_lines = [
+        f"<b>📊 Мем #{meme_id}</b>",
+        published_text.strip(),
+        f"👁️ Показов: <b>{meme_views}</b>",
+        f"👍 Лайков: <b>{meme_nlikes}</b>",
+        f"👎 Дизлайков: <b>{meme_ndislikes}</b>",
+        "",
+        "<b>📡 Источник</b>",
+        f"🔗 {source_url_html}",
+        f"👍 Лайков: <b>{source_nlikes}</b>",
+        f"👎 Дизлайков: <b>{source_ndislikes}</b>",
+        f"📨 Отправлено мемов: <b>{source_views}</b>",
+    ]
+
+    info_text = "\n".join(line for line in info_lines if line)
+
+    await update.message.reply_text(
+        info_text,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
+    )
+    return True
 
 
 def get_meme_language_selector_keyboard(upload_id: int) -> list[list[dict]]:
@@ -76,6 +156,13 @@ def get_meme_language_selector_keyboard(upload_id: int) -> list[list[dict]]:
 
 async def handle_message_with_meme(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """When a user sends a message with a meme"""
+    if was_forwarded_from_bot(update.message, context.bot.id):
+        meme_id = extract_meme_id_from_message(update.message)
+        if meme_id is not None:
+            handled = await _reply_with_forwarded_meme_stats(update, meme_id)
+            if handled:
+                return
+
     user = await get_user_info(update.effective_user.id)
     if not UserType(user["type"]).is_moderator:
         if user["nmemes_sent"] < 10:

--- a/tests/tgbot/test_forwarded_meme_utils.py
+++ b/tests/tgbot/test_forwarded_meme_utils.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from src.tgbot.handlers.upload.forwarded_meme import (
+    extract_meme_id_from_message,
+    format_age,
+    was_forwarded_from_bot,
+)
+
+
+def _make_message(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def test_extract_meme_id_from_plain_url() -> None:
+    message = _make_message(
+        text="https://t.me/ffmemesbot?start=s_111_222",
+        entities=None,
+        caption=None,
+        caption_entities=None,
+    )
+
+    assert extract_meme_id_from_message(message) == 222
+
+
+def test_extract_meme_id_from_caption_entity() -> None:
+    entity = SimpleNamespace(type="text_link", url="https://t.me/ffmemesbot?start=s_333_444")
+    message = _make_message(
+        text=None,
+        entities=None,
+        caption="Fast Food Memes",
+        caption_entities=[entity],
+    )
+
+    assert extract_meme_id_from_message(message) == 444
+
+
+def test_extract_meme_id_trims_trailing_characters() -> None:
+    message = _make_message(
+        text="Check this https://t.me/ffmemesbot?start=s_777_888).",
+        entities=None,
+        caption=None,
+        caption_entities=None,
+    )
+
+    assert extract_meme_id_from_message(message) == 888
+
+
+def test_format_age_uses_explicit_now() -> None:
+    fixed_now = datetime(2023, 1, 1, 12, 0, 0)
+    published_at = fixed_now - timedelta(days=1, hours=2, minutes=30)
+
+    assert format_age(published_at, now=fixed_now) == "1d 2h"
+
+
+def test_was_forwarded_from_bot_by_forward_from() -> None:
+    message = _make_message(forward_from=_make_message(id=1), forward_origin=None)
+
+    assert was_forwarded_from_bot(message, 1)
+
+
+def test_was_forwarded_from_bot_by_forward_origin() -> None:
+    message = _make_message(
+        forward_from=None,
+        forward_origin=_make_message(sender_user=_make_message(id=2)),
+    )
+
+    assert was_forwarded_from_bot(message, 2)


### PR DESCRIPTION
## Summary
- add utilities to detect forwarded memes and parse meme ids from bot deep links
- return meme and source statistics when a forwarded bot message is received instead of starting upload
- cover the new helper logic with unit tests

## Testing
- pytest tests/tgbot/test_forwarded_meme_utils.py


------
https://chatgpt.com/codex/tasks/task_e_68e8dba8234c83268c4cf9ac519a2394