### PR TITLE
Handle missing Telegram animation payloads on upload

### DIFF
--- a/src/storage/upload.py
+++ b/src/storage/upload.py
@@ -90,9 +90,17 @@ async def _upload_meme_content_to_tg(
         except telegram.error.TimedOut:
             return None
 
+        animation = msg.animation or msg.video or msg.document
+        if not animation:
+            logging.warning(
+                "Telegram did not return animation/video/document for meme %s upload.",
+                meme_id,
+            )
+            return None
+
         meme = await update_meme(
             meme_id=meme_id,
-            telegram_file_id=msg.animation.file_id,
+            telegram_file_id=animation.file_id,
         )
 
     return meme


### PR DESCRIPTION
### Motivation
- Fix a recurring `AttributeError: 'NoneType' object has no attribute 'file_id'` raised when uploading animations to the storage Telegram chat.  
- Telegram can sometimes return the uploaded media under `animation`, `video`, or `document`, or none at all, causing the code to assume a missing attribute.  
- Prevent Prefect flows from failing when the Telegram API response doesn't include the expected `animation` object.  

### Description
- Added a guard in `src/storage/upload.py` inside the `ANIMATION` branch to check `msg.animation or msg.video or msg.document` before accessing `.file_id`.  
- Log a warning and return `None` when Telegram returns no media object for the upload to avoid raising an exception.  
- Use the discovered media object (`animation`) to populate `telegram_file_id` when present.  

### Testing
- No automated tests were run as part of this change.  
- Local static checks and import validation were not executed in this rollout.  
- CI/automated test runs were not triggered by this patch.  
- Manual runtime verification is recommended in a staging environment to ensure Prefect flows no longer raise the `AttributeError`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bd7a388908326ac27a954fccbc168)