### PR TITLE
fix(cold-start): replace source-diversity with globally best memes

### DIFF
--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -317,48 +317,40 @@ async def cold_start_explore(
     limit: int = 15,
     exclude_meme_ids: list[int] = [],
 ):
-    """Phase 1 cold start: diverse high-quality memes from different sources.
+    """Phase 1 cold start: globally top-quality memes by like rate.
 
-    Selects the best meme from each top source (DISTINCT ON meme_source_id)
-    to guarantee source diversity. Data-driven source selection — top sources
-    by average like rate for the user's language. No hardcoded source list.
+    Serves the highest lr_smoothed memes overall — no source-diversity
+    constraint. For new users with no preference data, maximising per-meme
+    quality gives the best chance of a good first impression regardless of
+    genre. The adapt phase (memes 6-15) then calibrates on real reactions.
 
     Used for memes 1-5 (first impression).
     """
 
     query = f"""
-        SELECT id, type, telegram_file_id, caption, recommended_by
-        FROM (
-            SELECT DISTINCT ON (M.meme_source_id)
-                M.id
-                , M.type, M.telegram_file_id, M.caption
-                , 'cold_start_explore' AS recommended_by
-                , MSS.nlikes::float / NULLIF(MSS.nlikes + MSS.ndislikes, 0) AS source_lr
-                , MS.lr_smoothed
+        SELECT
+            M.id
+            , M.type, M.telegram_file_id, M.caption
+            , 'cold_start_explore' AS recommended_by
 
-            FROM meme M
-            INNER JOIN meme_stats MS
-                ON MS.meme_id = M.id
-            INNER JOIN meme_source_stats MSS
-                ON MSS.meme_source_id = M.meme_source_id
-            INNER JOIN user_language L
-                ON L.language_code = M.language_code
-                AND L.user_id = :user_id
-            LEFT JOIN user_meme_reaction R
-                ON R.meme_id = M.id
-                AND R.user_id = :user_id
+        FROM meme M
+        INNER JOIN meme_stats MS
+            ON MS.meme_id = M.id
+        INNER JOIN user_language L
+            ON L.language_code = M.language_code
+            AND L.user_id = :user_id
+        LEFT JOIN user_meme_reaction R
+            ON R.meme_id = M.id
+            AND R.user_id = :user_id
 
-            WHERE 1=1
-                AND M.status = 'ok'
-                AND R.meme_id IS NULL
-                AND MS.nmemes_sent >= 20
-                AND MS.lr_smoothed > 0.3
-                AND MSS.nlikes + MSS.ndislikes > 50
-                {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+        WHERE 1=1
+            AND M.status = 'ok'
+            AND R.meme_id IS NULL
+            AND MS.nmemes_sent >= 20
+            AND MS.lr_smoothed > 0.45
+            {exclude_meme_ids_sql_filter(exclude_meme_ids)}
 
-            ORDER BY M.meme_source_id, MS.lr_smoothed DESC
-        ) sub
-        ORDER BY source_lr DESC, lr_smoothed DESC
+        ORDER BY MS.lr_smoothed DESC
         LIMIT :limit
     """
     return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))


### PR DESCRIPTION
## Problem

`cold_start_explore` (memes 1-5 for new users) had **34.5% session continuation**, vs 96%+ for the regular engine. On 3 of the last 6 days it was 0%. This churns new users at their very first interaction.

**Root cause**: The explore phase used `DISTINCT ON meme_source_id` to enforce genre diversity — guaranteeing one meme from each top source. But with no user preference data, this exposed users to unwanted genres (e.g. political memes) before any taste signal existed. A user who dislikes political memes and gets 3 of them first will exit immediately.

## Fix (Option C)

Replace source-diversity-first selection with globally top-quality memes by `lr_smoothed`:

- **Removed**: `DISTINCT ON meme_source_id` (forced diversity), `meme_source_stats` join (source-level filter)
- **Raised**: quality threshold `lr_smoothed > 0.3` → `> 0.45` (battle-tested memes only)
- **Simplified**: pure `ORDER BY lr_smoothed DESC` — best memes globally, no genre constraints
- **Adapt phase unchanged**: memes 6-15 still calibrate on actual user reactions in real-time

## Why Option C

- Simplest, lowest risk change to the explore query
- `lr_smoothed` computation already accounts for user-bias correction and requires min `nmemes_sent >= 20`
- Fallback chain (lr_smoothed engine → best_uploaded_memes) handles any empty-result edge cases
- The 3-phase flow structure is unchanged (this only modifies Phase 1 behavior)

## Known Tradeoff

All 5 explore memes may come from the same high-lr source. This is intentional: for a user with zero taste data, "best memes globally" has a higher prior of a positive first impression than "one meme from each genre." The adapt phase corrects course immediately after.

## Success Criteria

- `cold_start_explore` continuation >70% (up from 34.5%)
- `cold_start_explore` first meme LR >30%
- No North Star regression (session length ≥18)

## Notes

- Does NOT modify the 3-phase cold start flow or `cold_start_adapt`
- Active experiment `cold_start_3phase` (runs until 2026-04-02) is unaffected
- `/review` passed: no critical issues found

Fixes [FFM-10](/FFM/issues/FFM-10)