### PR TITLE
feat: auto-snooze dead/low-quality TG sources (FFM-12)

### DIFF
--- a/src/flows/parsers/tg.py
+++ b/src/flows/parsers/tg.py
@@ -10,8 +10,10 @@ from src.storage.etl import insert_parsed_posts_from_telegram
 from src.storage.parsers.tg import TelegramChannelScraper
 from src.storage.service import (
     get_telegram_sources_to_parse,
+    maybe_auto_snooze_source,
     update_meme_source,
 )
+from src.tgbot.logs import log
 
 
 @flow(name="Parse Telegram Source", timeout_seconds=300)
@@ -31,6 +33,17 @@ async def parse_telegram_source(
         await insert_parsed_posts_from_telegram(meme_source_id, posts)
 
     await update_meme_source(meme_source_id=meme_source_id, parsed_at=datetime.utcnow())
+
+    snooze_reason = await maybe_auto_snooze_source(meme_source_id, len(posts))
+    if snooze_reason:
+        logger.warning(
+            f"Auto-snoozed source {meme_source_id} ({meme_source_url}): {snooze_reason}"
+        )
+        await log(
+            f"🔕 Auto-snoozed TG source <b>@{tg_username}</b> (id={meme_source_id})\n"
+            f"Reason: <code>{snooze_reason}</code>"
+        )
+
     await asyncio.sleep(5)
 
 

--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import nulls_first, select, text
@@ -8,6 +9,7 @@ from src.database import (
     fetch_one,
     meme,
     meme_source,
+    meme_source_stats,
 )
 from src.storage.constants import (
     MemeSourceStatus,
@@ -68,6 +70,70 @@ async def update_meme_source(meme_source_id: int, **kwargs) -> dict[str, Any] | 
         .returning(meme_source)
     )
     return await fetch_one(update_query)
+
+
+async def maybe_auto_snooze_source(
+    meme_source_id: int,
+    new_posts_count: int,
+) -> str | None:
+    """
+    Check auto-snooze criteria after a parse attempt.
+    Snoozes the source if either criterion is met:
+      1. 3 consecutive parse attempts returned 0 posts.
+      2. like_rate < 10% with at least 100 total reactions.
+    Returns the snooze reason string if snoozed, None otherwise.
+    """
+    source = await fetch_one(
+        select(meme_source).where(meme_source.c.id == meme_source_id)
+    )
+    if not source or source["status"] != MemeSourceStatus.PARSING_ENABLED.value:
+        return None
+
+    current_data = source["data"] or {}
+    now_iso = datetime.utcnow().isoformat()
+
+    # Track consecutive empty parses
+    if new_posts_count == 0:
+        consecutive = current_data.get("consecutive_empty_parses", 0) + 1
+    else:
+        consecutive = 0
+
+    updated_data = {**current_data, "consecutive_empty_parses": consecutive}
+
+    # Criterion 1: 3+ consecutive empty parses
+    if consecutive >= 3:
+        await update_meme_source(
+            meme_source_id,
+            status=MemeSourceStatus.SNOOZED.value,
+            data={**updated_data, "snoozed_reason": "no_posts_3x", "snoozed_at": now_iso},
+        )
+        return "no_posts_3x"
+
+    # Criterion 2: like_rate < 10% (min 100 reactions for a meaningful sample)
+    stats = await fetch_one(
+        select(meme_source_stats).where(
+            meme_source_stats.c.meme_source_id == meme_source_id
+        )
+    )
+    if stats is not None:
+        total = stats["nlikes"] + stats["ndislikes"]
+        if total >= 100 and stats["nlikes"] / total < 0.10:
+            await update_meme_source(
+                meme_source_id,
+                status=MemeSourceStatus.SNOOZED.value,
+                data={
+                    **updated_data,
+                    "snoozed_reason": "low_like_rate",
+                    "snoozed_at": now_iso,
+                },
+            )
+            return "low_like_rate"
+
+    # No snooze: persist updated counter if it changed
+    if updated_data != current_data:
+        await update_meme_source(meme_source_id, data=updated_data)
+
+    return None
 
 
 async def update_meme(meme_id: int, **kwargs) -> dict[str, Any] | None:

--- a/tests/test_auto_snooze.py
+++ b/tests/test_auto_snooze.py
@@ -1,0 +1,157 @@
+"""Integration tests for maybe_auto_snooze_source."""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from src.database import engine, fetch_one, meme_source
+from src.storage.constants import MemeSourceStatus
+from src.storage.service import maybe_auto_snooze_source
+from tests.factories import (
+    TEST_ID_START,
+    cleanup_test_data,
+    create_meme_source,
+    create_meme_source_stats,
+)
+
+
+@pytest_asyncio.fixture()
+async def conn():
+    async with engine.connect() as conn:
+        yield conn
+        await cleanup_test_data(conn)
+
+
+SOURCE_ID = TEST_ID_START + 500
+
+
+@pytest.mark.asyncio
+async def test_no_snooze_on_first_empty_parse(conn: AsyncConnection):
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    await conn.commit()
+
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    assert result is None
+
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.PARSING_ENABLED.value
+    assert source["data"]["consecutive_empty_parses"] == 1
+
+
+@pytest.mark.asyncio
+async def test_no_snooze_on_second_empty_parse(conn: AsyncConnection):
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    await conn.commit()
+
+    await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    assert result is None
+
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.PARSING_ENABLED.value
+    assert source["data"]["consecutive_empty_parses"] == 2
+
+
+@pytest.mark.asyncio
+async def test_snooze_on_third_consecutive_empty_parse(conn: AsyncConnection):
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    await conn.commit()
+
+    await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+
+    assert result == "no_posts_3x"
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.SNOOZED.value
+    assert source["data"]["snoozed_reason"] == "no_posts_3x"
+    assert "snoozed_at" in source["data"]
+
+
+@pytest.mark.asyncio
+async def test_counter_resets_after_successful_parse(conn: AsyncConnection):
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    await conn.commit()
+
+    await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    # successful parse resets counter
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=5)
+    assert result is None
+
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.PARSING_ENABLED.value
+    assert source["data"]["consecutive_empty_parses"] == 0
+
+    # subsequent empty parses start from 1 again
+    await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    assert result == "no_posts_3x"
+
+
+@pytest.mark.asyncio
+async def test_snooze_on_low_like_rate(conn: AsyncConnection):
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    # 5% like rate with 200 total reactions → should snooze
+    await create_meme_source_stats(
+        conn,
+        meme_source_id=SOURCE_ID,
+        nlikes=10,
+        ndislikes=190,
+        nmemes_sent=200,
+    )
+    await conn.commit()
+
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=5)
+
+    assert result == "low_like_rate"
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.SNOOZED.value
+    assert source["data"]["snoozed_reason"] == "low_like_rate"
+
+
+@pytest.mark.asyncio
+async def test_no_snooze_on_acceptable_like_rate(conn: AsyncConnection):
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    # 50% like rate → healthy, no snooze
+    await create_meme_source_stats(
+        conn,
+        meme_source_id=SOURCE_ID,
+        nlikes=100,
+        ndislikes=100,
+        nmemes_sent=200,
+    )
+    await conn.commit()
+
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=5)
+    assert result is None
+
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.PARSING_ENABLED.value
+
+
+@pytest.mark.asyncio
+async def test_no_snooze_when_below_min_reactions(conn: AsyncConnection):
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    # 5% like rate but only 40 reactions → not enough data, no snooze
+    await create_meme_source_stats(
+        conn,
+        meme_source_id=SOURCE_ID,
+        nlikes=2,
+        ndislikes=38,
+        nmemes_sent=40,
+    )
+    await conn.commit()
+
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=5)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_already_snoozed_source_skipped(conn: AsyncConnection):
+    await create_meme_source(conn, id=SOURCE_ID, status="snoozed")
+    await conn.commit()
+
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=0)
+    assert result is None


### PR DESCRIPTION
## Summary

Implements auto-snooze for dead or broken Telegram meme sources (FFM-12).

- Adds `maybe_auto_snooze_source()` in `src/storage/service.py` — called after every TG source parse
- Snooze is triggered by **either** criterion:
  - **3 consecutive empty parses** (`snoozed_reason: no_posts_3x`) — channel is dead/blocked
  - **like_rate < 10%** with ≥100 total reactions (`snoozed_reason: low_like_rate`) — content too low quality
- On snooze: sets `meme_source.status = 'snoozed'`, writes `{snoozed_reason, snoozed_at}` to `meme_source.data` JSONB, and sends an admin Telegram notification via `log()`
- Counter resets to 0 on any successful parse (non-zero posts), so intermittent failures don't accumulate across healthy runs
- Snoozed sources are already excluded from parse batches via `get_telegram_sources_to_parse` (filters on `status = 'parsing_enabled'`)

## Test plan

- [ ] `tests/test_auto_snooze.py` covers: first/second empty parse (no snooze), third triggers snooze, counter reset after success, low like_rate snooze, acceptable like_rate no snooze, below-min-reactions no snooze, already-snoozed source skipped
- [ ] Run: `docker compose exec app pytest tests/test_auto_snooze.py`
- [ ] QA: verify snoozed sources disappear from next parse batch and admin receives Telegram alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)