### PR TITLE
fix(goat): add quality threshold to goat pool — fix LR regression

### DIFF
--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -1,10 +1,19 @@
 import asyncio
+import logging
 from typing import Any
 
 from sqlalchemy import text
 
-from src.database import fetch_all
+from src.database import fetch_all, fetch_one
 from src.recommendations.utils import exclude_meme_ids_sql_filter
+
+logger = logging.getLogger(__name__)
+
+# Quality thresholds for the goat pool.
+# Memes must have enough data and age to be considered "greatest of all time".
+GOAT_MIN_REACTIONS = 20    # (nlikes + ndislikes) — enough statistical signal
+GOAT_MIN_LR = 0.30         # lr_smoothed — minimum proven like rate
+GOAT_MIN_AGE_DAYS = 3      # days since created_at — must have aged enough to accumulate reactions
 
 
 def _build_params(
@@ -213,6 +222,24 @@ async def goat(
     limit: int = 10,
     exclude_meme_ids: list[int] = [],
 ):
+    # Log global pool size for QA monitoring (no user-specific join needed)
+    pool_row = await fetch_one(
+        text(
+            f"""
+            SELECT COUNT(*) AS pool_size
+            FROM meme M
+            INNER JOIN meme_stats MS ON MS.meme_id = M.id
+            WHERE M.status = 'ok'
+                AND (MS.nlikes + MS.ndislikes) >= {GOAT_MIN_REACTIONS}
+                AND MS.lr_smoothed >= {GOAT_MIN_LR}
+                AND M.created_at <= NOW() - INTERVAL '{GOAT_MIN_AGE_DAYS} days'
+        """
+        ),
+        {},
+    )
+    pool_size = pool_row["pool_size"] if pool_row else 0
+    logger.info("goat pool_size=%d", pool_size)
+
     query = f"""
         WITH SCORES AS (
             SELECT
@@ -236,6 +263,9 @@ async def goat(
                 ON UMSS.user_id = :user_id
                 AND UMSS.meme_source_id = M.meme_source_id
             WHERE M.status = 'ok'
+                AND (MS.nlikes + MS.ndislikes) >= {GOAT_MIN_REACTIONS}
+                AND MS.lr_smoothed >= {GOAT_MIN_LR}
+                AND M.created_at <= NOW() - INTERVAL '{GOAT_MIN_AGE_DAYS} days'
         )
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -73,11 +73,14 @@ async def create_meme(
     caption: str | None = None,
     raw_meme_id: int | None = None,
     published_at: datetime | None = None,
+    created_at: datetime | None = None,
 ) -> dict:
     if raw_meme_id is None:
         raw_meme_id = id
     if published_at is None:
         published_at = FIXED_DT
+    if created_at is None:
+        created_at = FIXED_DT
     row = {
         "id": id,
         "meme_source_id": meme_source_id,
@@ -88,6 +91,7 @@ async def create_meme(
         "telegram_file_id": telegram_file_id,
         "caption": caption,
         "published_at": published_at,
+        "created_at": created_at,
     }
     await conn.execute(insert(meme).values(row).on_conflict_do_nothing())
     return row


### PR DESCRIPTION
## Summary

Fixes [FFM-14](/FFM/issues/FFM-14): Goat engine LR has dropped to 24.4% vs 42.5% baseline.

**Root cause:** `like_spread_and_recent` experiment increased meme volume 5.9x, diluting the goat pool with newly-popular memes that haven't earned GOAT status. The pool now contains unproven memes — just recent ones.

**Fix:** Add quality threshold filters to the SCORES CTE so only proven memes qualify:
- `lr_smoothed >= 0.30` — minimum 30% smoothed like rate
- `(nlikes + ndislikes) >= 20` — enough data to be statistically meaningful  
- `created_at <= NOW() - INTERVAL '3 days'` — aged enough to accumulate reactions

Threshold values extracted as module-level constants (`GOAT_MIN_REACTIONS`, `GOAT_MIN_LR`, `GOAT_MIN_AGE_DAYS`) for easy tuning.

Also adds `INFO`-level pool-size logging on every `goat()` call: `goat pool_size=N`.

## Test plan

- [ ] Check `goat pool_size=N` in app logs after deploy — should be ≥ 500 memes
- [ ] Monitor goat engine LR over next 24–48h — expect recovery toward ≥ 35%
- [ ] Session length (North Star) should remain ≥ 18 — goat has 98% continuation rate
- [ ] If pool < 300 memes, relax `GOAT_MIN_LR` from 0.30 → 0.25 or `GOAT_MIN_REACTIONS` from 20 → 15

## Changes

- `src/recommendations/candidates.py`: quality filters in SCORES CTE + pool-size logging + module constants
- `tests/factories.py`: `create_meme()` now accepts `created_at` (default `FIXED_DT`) so goat contract tests exercise real filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)