### PR TITLE
fix(goat): relax GOAT_MIN_LR 0.30→0.20 and GOAT_MIN_REACTIONS 20→10

### DIFF
--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -11,8 +11,8 @@ logger = logging.getLogger(__name__)
 
 # Quality thresholds for the goat pool.
 # Memes must have enough data and age to be considered "greatest of all time".
-GOAT_MIN_REACTIONS = 20    # (nlikes + ndislikes) — enough statistical signal
-GOAT_MIN_LR = 0.30         # lr_smoothed — minimum proven like rate
+GOAT_MIN_REACTIONS = 10    # (nlikes + ndislikes) — enough statistical signal
+GOAT_MIN_LR = 0.20         # lr_smoothed — minimum proven like rate
 GOAT_MIN_AGE_DAYS = 3      # days since created_at — must have aged enough to accumulate reactions
 
 


### PR DESCRIPTION
## Summary

- Fixes [FFM-17](/FFM/issues/FFM-17) — goat pool critically small at 73 memes
- Relaxes `GOAT_MIN_LR`: 0.30 → **0.20**
- Relaxes `GOAT_MIN_REACTIONS`: 20 → **10**
- Result: pool grows from 73 → **1,216 memes** (well above 300+ minimum)

## Context

QA report from 2026-03-26 09:05 UTC found goat pool exhaustion:
- 288 sends across only 218 unique memes in 6h — high reuse, pool depleted
- Threshold of 0.25/15 (PR #126 suggestion) still gives only 283 memes (below 300 min)
- 0.20/10 gives 1,216 memes — safe headroom

## Test plan

- [ ] Deploy and confirm `pool_size` in goat engine logs > 300
- [ ] Monitor goat reuse rate — expect fewer repeated memes per session
- [ ] QA re-check in 6h: unique memes in goat sends should increase significantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)