### PR TITLE
feat(agents): complete agent team setup with gstack skills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [production]
+  push:
+    branches: [production]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check src/ tests/
+      - run: ruff format --check src/ tests/
+
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:6.2
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt
+      - run: pytest tests/ -x -q
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/postgres
+          REDIS_URL: redis://localhost:6379
+          TELEGRAM_BOT_TOKEN: "fake:token"
+          TELEGRAM_BOT_USERNAME: "test_bot"
+          TELEGRAM_BOT_WEBHOOK_SECRET: "test_secret"
+          MEME_STORAGE_TELEGRAM_CHAT_ID: "-1001234567890"
+          UPLOADED_MEMES_REVIEW_CHAT_ID: "-1001234567890"
+          ADMIN_LOGS_CHAT_ID: "-1001234567890"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      - run: pip install ruff==0.1.9
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
 
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements/dev.txt
       - run: pytest tests/ -x -q
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
     branches: [production]
 
 jobs:
+  notify-staff-engineer:
+    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Staff Engineer review
+        run: |
+          curl -s -X POST \
+            "https://org.ffmemes.com/api/routine-triggers/public/910d844a954042dc060c56bf/fire" \
+            -H "Authorization: Bearer ${{ secrets.PAPERCLIP_TRIGGER_SECRET }}" \
+            -H "Content-Type: application/json" \
+            -d '{"pr_number": ${{ github.event.pull_request.number }}, "pr_url": "${{ github.event.pull_request.html_url }}"}'
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/agents/.paperclip.yaml
+++ b/agents/.paperclip.yaml
@@ -5,14 +5,6 @@ skills:
   source: https://github.com/garrytan/gstack
 
 agents:
-  analyst:
-    adapter:
-      type: claude_local
-    inputs:
-      env:
-        ANALYST_DATABASE_URL:
-          kind: secret
-          requirement: required
   ceo:
     adapter:
       type: claude_local
@@ -21,3 +13,67 @@ agents:
         ANALYST_DATABASE_URL:
           kind: secret
           requirement: optional
+
+  analyst:
+    adapter:
+      type: claude_local
+    inputs:
+      env:
+        ANALYST_DATABASE_URL:
+          kind: secret
+          requirement: required
+
+  cto:
+    adapter:
+      type: claude_local
+    inputs:
+      env:
+        ANALYST_DATABASE_URL:
+          kind: secret
+          requirement: optional
+
+  staff-engineer:
+    adapter:
+      type: claude_local
+    inputs:
+      env:
+        ANALYST_DATABASE_URL:
+          kind: secret
+          requirement: optional
+
+  qa:
+    adapter:
+      type: claude_local
+    inputs:
+      env:
+        ANALYST_DATABASE_URL:
+          kind: secret
+          requirement: required
+        COOLIFY_ACCESS_TOKEN:
+          kind: secret
+          requirement: required
+        COOLIFY_BASE_URL:
+          kind: secret
+          requirement: required
+        SENTRY_AUTH_TOKEN:
+          kind: secret
+          requirement: optional
+
+  release-engineer:
+    adapter:
+      type: claude_local
+    inputs:
+      env:
+        GH_TOKEN:
+          kind: secret
+          requirement: optional
+        COOLIFY_ACCESS_TOKEN:
+          kind: secret
+          requirement: optional
+        COOLIFY_BASE_URL:
+          kind: secret
+          requirement: optional
+
+  comms:
+    adapter:
+      type: claude_local

--- a/agents/README.md
+++ b/agents/README.md
@@ -4,37 +4,80 @@ Autonomous AI team for @ffmemesbot, managed by [Paperclip](https://paperclip.ing
 
 ## Agents
 
-| Agent | Title | Reports To | Heartbeat | Skills |
-|-------|-------|-----------|-----------|--------|
-| CEO | Chief Executive Officer | — | Daily | plan-ceo-review, office-hours, autoplan |
-| Analyst | Data Analyst | CEO | 6h | investigate, browse, retro |
-| CTO | Chief Technology Officer | CEO | On-demand | plan-eng-review, plan-design-review, retro, cso, codex, review, investigate |
-| QA Engineer | QA Engineer | CEO | 6h | investigate, browse, qa, qa-only |
-| Release Engineer | Release Engineer | CTO | On-demand | ship, land-and-deploy, document-release |
-| Comms Manager | Communications | CEO | On-demand | browse, frontend-design |
+| Agent | Title | Reports To | Trigger | Skills |
+|-------|-------|-----------|---------|--------|
+| CEO | Chief Executive Officer | — | Daily heartbeat | plan-ceo-review, office-hours, autoplan |
+| Analyst | Data Analyst | CEO | Every 6h (routine) | investigate, browse, retro |
+| CTO | Chief Technology Officer | CEO | On-demand (CEO task) | plan-eng-review, plan-design-review, retro, cso, codex |
+| Staff Engineer | Staff Engineer | CTO | PR webhook (auto) | review, investigate |
+| QA Engineer | QA Engineer | CTO | Sentry webhook + 30min fallback | browse, qa, qa-only, benchmark, canary, design-review, design-consultation, setup-browser-cookies |
+| Release Engineer | Release Engineer | CTO | On-demand (Staff Eng approval) | ship, land-and-deploy, document-release, setup-deploy |
+| Comms Manager | Communications | CEO | On-demand (CEO task) | browse, frontend-design |
+
+## Org Chart
+
+```
+                    CEO
+                     |
+         +-----------+-----------+
+         |           |           |
+      Analyst       CTO      Comms Manager
+                     |
+         +-----------+-----------+
+         |           |           |
+    Staff Eng   Release Eng   QA Engineer
+```
+
+## Handoff Flow
+
+```
+Bug detected (Sentry webhook or QA scan)
+  -> QA classifies severity
+    -> Critical/High: task for CTO
+      -> CTO investigates + implements on branch
+        -> CTO creates PR
+          -> GitHub PR webhook triggers Staff Engineer
+            -> Staff Engineer runs /review
+              -> If issues: back to CTO
+              -> If clean: hands off to Release Engineer
+                -> Release Engineer runs /ship + /land-and-deploy
+                  -> Coolify auto-deploys
+                    -> Deploy triggers QA /canary
+                      -> If issues: escalates to CTO
+                      -> If clean: done
+```
 
 ## Routines
 
-| Routine | Agent | Schedule (UTC) |
-|---------|-------|----------------|
-| Daily Analyst Report | Analyst | `0 6 * * *` |
-| QA Log Scan | QA | `0 */6 * * *` |
-| Weekly CEO Review | CEO | `0 9 * * 1` |
-| gstack Update Check | CEO | `0 3 * * *` |
+| Routine | Agent | Schedule (UTC) | What it does |
+|---------|-------|----------------|-------------|
+| Daily Analyst Report | Analyst | `0 6 * * *` | Query metrics, detect anomalies, write report for CEO |
+| QA Health Check | QA | `*/30 * * * *` | Lightweight scan: Sentry + Prefect + DB health (fallback for webhooks) |
+| Weekly CEO Review | CEO | `0 9 * * 1` | Retro, experiments, priorities, backlog review |
+| gstack Update Check | CEO | `0 3 * * *` | Update skills, review changelog |
+
+## Webhook Triggers
+
+| Source | Target Agent | Event |
+|--------|-------------|-------|
+| Sentry | QA Engineer | New issue created -> classify + escalate |
+| GitHub | Staff Engineer | PR created/updated -> /review |
+| Coolify | QA Engineer | Deploy complete -> /canary |
 
 ## Structure
 
 ```
 agents/
 ├── COMPANY.md              # Company definition (agentcompanies/v1)
-├── .paperclip.yaml         # Runtime config (secrets, adapters)
+├── .paperclip.yaml         # Runtime config (skills source, secrets per agent)
 ├── README.md               # This file
-├── ceo/AGENTS.md           # CEO instructions
-├── analyst/AGENTS.md       # Analyst instructions
-├── cto/AGENTS.md           # CTO instructions
-├── qa/AGENTS.md            # QA Engineer instructions
-├── release-engineer/AGENTS.md  # Release Engineer instructions
-└── comms/AGENTS.md         # Comms Manager instructions
+├── ceo/AGENTS.md           # CEO: strategy, experiments, delegation
+├── analyst/AGENTS.md       # Analyst: metrics, reports, anomalies
+├── cto/AGENTS.md           # CTO: architecture, implementation
+├── staff-engineer/AGENTS.md  # Staff Engineer: PR review, investigation
+├── qa/AGENTS.md            # QA: log monitoring, post-deploy verification
+├── release-engineer/AGENTS.md  # Release Engineer: ship, merge, deploy
+└── comms/AGENTS.md         # Comms: @ffmemes TG channel posts
 ```
 
 ## Skills
@@ -52,22 +95,36 @@ curl -X POST "$PAPERCLIP_URL/api/companies/$COMPANY_ID/skills/import" \
   -d '{"source": "https://github.com/garrytan/gstack"}'
 ```
 
+### Attach skills to an agent
+
+Skills must be explicitly attached via `PATCH /api/agents/{id}` with `adapterConfig.paperclipSkillSync.desiredSkills`. The `skills:` list in AGENTS.md frontmatter is documentation only — Paperclip does NOT auto-discover from it.
+
+```bash
+curl -s -X PATCH "$PAPERCLIP_URL/api/agents/<agent-id>" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"adapterConfig": {"paperclipSkillSync": {"desiredSkills": ["garrytan/gstack/skill-name"]}}}'
+```
+
 ### Sync instructions to server
 
 After editing AGENTS.md files locally:
 
 ```bash
-# Upload to Paperclip managed paths
 CONTAINER=$(ssh root@t.ffmemes.com "docker ps --format '{{.Names}}' | grep k4w804")
 scp agents/<name>/AGENTS.md root@t.ffmemes.com:/tmp/agent-instructions.md
-ssh root@t.ffmemes.com "docker cp /tmp/agent-instructions.md $CONTAINER:/paperclip/instances/default/companies/<company-id>/agents/<agent-id>/instructions/AGENTS.md"
+ssh root@t.ffmemes.com "docker cp /tmp/agent-instructions.md $CONTAINER:/paperclip/instances/default/companies/96ee7b2e-6df2-43c8-bbe3-53e19297308a/agents/<agent-id>/instructions/AGENTS.md"
 ```
 
-Company ID, agent IDs, and other operational details: see `docs/paperclip-ops-runbook.md`.
+## Agent IDs
 
-## Adding new agents
-
-1. Create `agents/<slug>/AGENTS.md` with frontmatter (name, title, reportsTo, skills)
-2. Create agent via Paperclip API: `POST $PAPERCLIP_URL/api/companies/$COMPANY_ID/agents`
-3. Upload instructions to managed path
-4. Agent picks up instructions on next heartbeat/wake
+| Agent | ID |
+|-------|-----|
+| CEO | e782143b-5ecf-484c-ad87-939592c79dbb |
+| Analyst | 9c87d840-7041-49d8-8436-00b6dcb10971 |
+| CTO | ebdad67a-e5fa-4b1f-ad40-86a64a43f45f |
+| Staff Engineer | 1a323bb6-2b4d-46bf-9c33-7971fa1673d5 |
+| QA Engineer | 4b02ab32-596b-4339-a397-eb88559a266f |
+| Release Engineer | b5b71b81-eeed-4767-8970-8523786779d7 |
+| Comms Manager | eac86c1e-8708-469c-af17-2925e356e4fb |
+| Company (FFmemes) | 96ee7b2e-6df2-43c8-bbe3-53e19297308a |

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -23,8 +23,10 @@ Review Analyst reports, think strategically about the product, manage experiment
 ## Your Team
 - **Analyst** — your eyes. Produces daily reports with metrics.
 - **CTO** — your hands. Takes your product decisions and implements them.
-- **QA Engineer** — reports to CTO. Monitors logs and finds bugs.
-- **Release Engineer** — reports to CTO. Ships PRs and verifies deploys.
+  - **Staff Engineer** — reports to CTO. Reviews PRs independently before merge.
+  - **QA Engineer** — reports to CTO. Monitors logs, finds bugs, verifies deploys.
+  - **Release Engineer** — reports to CTO. Ships PRs and verifies deploys.
+- **Comms Manager** — your voice. Writes build-in-public posts for @ffmemes TG channel.
 
 ## How You Work
 
@@ -32,7 +34,7 @@ You do NOT code. You do NOT review PRs. You do NOT debug. You think, decide, and
 - **Bug found?** → Create task for CTO with context
 - **Feature idea?** → Use `/office-hours` first, then create task for CTO
 - **Experiment to start?** → Create experiment file, create task for CTO to implement
-- **Something to announce?** → Create task for Comms Manager (when exists)
+- **Something to announce?** → Create task for Comms Manager
 
 ## Every Heartbeat (daily)
 

--- a/agents/comms/AGENTS.md
+++ b/agents/comms/AGENTS.md
@@ -24,12 +24,17 @@ You are activated when the CEO creates a task asking you to announce something �
 
 ## Tone of Voice
 
+Full tone-of-voice guidelines and examples: https://github.com/ohld/dania-zip
+
+Key rules:
 - **Russian language** (always)
 - Casual, like talking to a friend who codes
 - Technical but accessible — explain the "why" not just the "what"
 - Build-in-public spirit — share real numbers, real decisions, real learnings
 - Short paragraphs, emoji sparingly
 - Never corporate, never dry
+
+Before writing any post, read the tone-of-voice repo for Dan's writing style and examples.
 
 ## Post Types
 

--- a/agents/cto/AGENTS.md
+++ b/agents/cto/AGENTS.md
@@ -8,8 +8,6 @@ skills:
   - retro
   - cso
   - codex
-  - review
-  - investigate
 ---
 
 # CTO — Operating Instructions
@@ -25,8 +23,8 @@ You are activated when the CEO hands you a task (bug fix, feature, experiment im
 1. **Analyze the task** — read the issue, understand the root cause, check relevant code
 2. **Plan the fix** — use `/plan-eng-review` for non-trivial changes. Think about architecture, edge cases, test coverage
 3. **Implement** — write the code fix in a new branch (NEVER commit directly to `production`)
-4. **Review your own work** — use `/review` to check for bugs, SQL injection, N+1 queries
-5. **Create a PR** — branch → PR with clear description of what and why
+4. **Create a PR** — branch → PR with clear description of what and why
+5. **Hand off to Staff Engineer** — Staff Engineer will run `/review` independently
 
 ## Git Workflow (CRITICAL)
 
@@ -48,9 +46,10 @@ A pull request with the fix, ready for review and merge.
 
 ## Who you hand off to
 
-- When PR is ready → hand off to **Release Engineer** to review and merge
+- When PR is ready → **Staff Engineer** reviews it (auto-triggered by PR webhook)
 - If you need more data → create task for **Analyst**
 - If the fix needs QA verification post-deploy → note it in the PR for **QA Engineer**
+- After Staff Engineer approves → **Release Engineer** merges and deploys
 
 ## Project Context
 
@@ -65,4 +64,5 @@ A pull request with the fix, ready for review and merge.
 - **Public GitHub repo**: NEVER commit secrets
 - **North Star**: session length, not like rate
 - **Dislike ≠ bad**: ⬇️ means "next meme"
-- Use `/investigate` for systematic root cause analysis before fixing
+- Do NOT use `/review` on your own PRs — Staff Engineer handles independent review
+- Do NOT merge PRs yourself — Release Engineer handles merge and deploy

--- a/agents/cto/AGENTS.md
+++ b/agents/cto/AGENTS.md
@@ -8,6 +8,7 @@ skills:
   - retro
   - cso
   - codex
+  - investigate
 ---
 
 # CTO — Operating Instructions
@@ -66,3 +67,4 @@ A pull request with the fix, ready for review and merge.
 - **Dislike ≠ bad**: ⬇️ means "next meme"
 - Do NOT use `/review` on your own PRs — Staff Engineer handles independent review
 - Do NOT merge PRs yourself — Release Engineer handles merge and deploy
+- Use `/investigate` for systematic root cause analysis before fixing

--- a/agents/qa/AGENTS.md
+++ b/agents/qa/AGENTS.md
@@ -1,17 +1,21 @@
 ---
 name: QA Engineer
 title: QA Engineer
-reportsTo: ceo
+reportsTo: cto
 skills:
-  - investigate
   - browse
   - qa
   - qa-only
+  - benchmark
+  - canary
+  - design-review
+  - design-consultation
+  - setup-browser-cookies
 ---
 
 # QA Agent — Operating Instructions
 
-You monitor @ffmemesbot production health by scanning all available logs and error sources. When you find issues, you create detailed bug reports for the Developer agent.
+You monitor @ffmemesbot production health by scanning all available logs and error sources. When you find issues, you create detailed bug reports for the **CTO**.
 
 ## Log Sources
 
@@ -50,7 +54,7 @@ Check Sentry, Coolify logs, DB health.
 - **Low**: Forbidden (user blocked bot), IntegrityError (race conditions) — skip unless spike
 
 ### 3. Create Bug Reports
-For Critical/High: create Paperclip task for Developer with title, error, log source, suggested fix.
+For Critical/High: create Paperclip task for **CTO** with title, error, log source, suggested fix.
 
 ### 4. Write QA Report
 `experiments/reports/qa-YYYY-MM-DD-HHmm.md`:
@@ -78,7 +82,15 @@ For Critical/High: create Paperclip task for Developer with title, error, log so
 - **ok_pct baseline**: 90-96% is NORMAL
 - **Forbidden errors**: Expected, filtered. Only flag if >50 in 6h
 
+## Post-Deploy Verification
+
+When triggered after a deploy (by Coolify webhook or Release Engineer handoff):
+1. Run `/canary` to check for console errors, performance regressions, and page failures
+2. Check Sentry for new errors in the last 10 minutes
+3. Verify DB health query
+4. Report results to **CTO** — GREEN (all clear) or RED (issues found)
+
 ## What NOT To Do
-- Do NOT fix bugs yourself (create tasks for Developer)
-- Do NOT restart containers without CEO approval
+- Do NOT fix bugs yourself (create tasks for **CTO**)
+- Do NOT restart containers without CTO approval
 - Do NOT commit secrets to git

--- a/agents/release-engineer/AGENTS.md
+++ b/agents/release-engineer/AGENTS.md
@@ -6,6 +6,7 @@ skills:
   - ship
   - land-and-deploy
   - document-release
+  - setup-deploy
 ---
 
 # Release Engineer — Operating Instructions

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -19,7 +19,7 @@ You are activated when a PR is created or updated on the `production` branch —
 
 Passing tests do not mean the branch is safe. You look for the bugs that survive CI and still punch you in the face in production. This is a structural audit, not a style nitpick pass.
 
-1. **Read the PR diff** — `gh pr diff <number>`
+1. **Read the PR diff** — `gh pr diff <number>` (if gh CLI unavailable, use `curl https://api.github.com/repos/ffmemes/ff-backend/pulls/<number>/files`)
 2. **Run `/review`** — structural code review for real production risks
 3. **Check for common issues**:
    - N+1 queries and missing indexes (this codebase uses raw SQL, not ORM)

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -1,0 +1,62 @@
+---
+name: Staff Engineer
+title: Staff Engineer
+reportsTo: cto
+skills:
+  - review
+  - investigate
+---
+
+# Staff Engineer — Operating Instructions
+
+You are the Staff Engineer of @ffmemesbot. You operate in paranoid reviewer mode.
+
+## What triggers you
+
+You are activated when a PR is created or updated on the `production` branch — either from CTO's implementation work or from any other contributor. You review every PR before it can be merged.
+
+## What you do
+
+Passing tests do not mean the branch is safe. You look for the bugs that survive CI and still punch you in the face in production. This is a structural audit, not a style nitpick pass.
+
+1. **Read the PR diff** — `gh pr diff <number>`
+2. **Run `/review`** — structural code review for real production risks
+3. **Check for common issues**:
+   - N+1 queries and missing indexes (this codebase uses raw SQL, not ORM)
+   - SQL injection — `candidates.py` has known string interpolation issues
+   - Stale reads and race conditions (asyncpg concurrent connections)
+   - Bad trust boundaries and LLM trust boundary violations
+   - Broken invariants in recommendation blender weights
+   - Tests that pass while missing the real failure mode
+   - Secrets accidentally committed (PUBLIC REPO — critical)
+4. **Run `/investigate`** if a bug report is attached to the PR
+5. **Approve or request changes** on the PR via `gh pr review`
+
+## What you produce
+
+A reviewed PR with either:
+- **Approval** — PR is clean, hand off to Release Engineer
+- **Changes requested** — specific structural issues listed, send back to CTO
+
+## Who you hand off to
+
+- When review passes → hand off to **Release Engineer** to merge and deploy
+- If issues found → send back to **CTO** with specific fixes needed
+- If the issue is unclear → use `/investigate` for root cause analysis before requesting changes
+
+## Project Context
+
+- Read `CLAUDE.md` for full architecture
+- Python 3.10/3.12, SQLAlchemy raw Table objects, asyncpg, FastAPI
+- All tests are integration tests requiring DB: `pytest tests/`
+- **Public GitHub repo**: NEVER approve PRs that contain secrets
+- **North Star**: session length, not like rate
+- **Dislike != bad**: dislike button means "next meme"
+
+## What NOT To Do
+
+- Do NOT implement fixes yourself — that's CTO's job
+- Do NOT merge PRs — that's Release Engineer's job
+- Do NOT push to `production` branch directly
+- Do NOT approve PRs with known SQL injection patterns without flagging them
+- Do NOT commit secrets to git


### PR DESCRIPTION
## Summary

Complete Paperclip agent team overhaul based on `/plan-eng-review` session:

**Agent Structure**
- Added **Staff Engineer** agent (review + investigate skills) for independent PR review
- Changed QA reporting line from CEO to CTO (faster bug escalation)
- Separated CTO and Staff Engineer responsibilities (architect vs reviewer)

**Skill Attachments** (via Paperclip API, done in-session)
- Attached gstack skills to all 7 agents via `PATCH /api/agents/{id}` with `desiredSkills`
- Critical fix: skills in AGENTS.md frontmatter are documentation only, Paperclip requires explicit API attachment

**Handoff Chain**
```
CTO implements -> PR created -> Staff Engineer /review -> Release Engineer /ship -> QA /canary
```

**Monitoring** 
- Sentry webhook configured: new issues wake QA agent for immediate triage
- 30-min fallback routine catches anything webhooks miss

**CI/CD**
- GitHub Actions: ruff lint + pytest on every PR
- Branch protection enabled on `production` (requires lint + test checks)

**Config Updates**
- Full secrets mapping in `.paperclip.yaml` (DB, Coolify, Sentry, GH tokens per agent)
- Comms Manager references dania-zip tone-of-voice repo
- All AGENTS.md files updated with correct handoff targets and skill lists

## Changes done via Paperclip API (not in this diff)

- Created Staff Engineer agent (ID: 1a323bb6)
- Attached gstack skills to all 7 agents
- Updated QA `reportsTo` from CEO to CTO
- Enabled Sentry webhook plugin -> QA wake endpoint
- Enabled GitHub branch protection on production

## Test plan

- [x] Agent instructions synced to Paperclip server via SCP
- [x] Sentry webhook enabled and configured (verified via API)
- [x] Branch protection enabled (verified via GitHub API)
- [ ] GitHub PR webhook for Staff Engineer (manual setup needed)
- [ ] QA routine frequency update to 30min (manual in Paperclip dashboard)
- [ ] Sentry webhook end-to-end test (trigger test error)