### PR TITLE
fix(wrapped): improve loading UX — delete stale button, better copy

### DIFF
--- a/src/tgbot/handlers/stats/wrapped.py
+++ b/src/tgbot/handlers/stats/wrapped.py
@@ -38,21 +38,20 @@ WRAPPED_MIN_REACTIONS = 30
 WRAPPED_MIN_DESCRIPTIONS = 5
 
 LOADING_MESSAGES = [
-    "⏳ Ещё генерирую... нажми через пару секунд 👇",
-    "🧠 DeepSeek думает... ещё чуть-чуть 👇",
-    "🔬 Анализирую твой юмор... почти готово 👇",
-    "⚡ Скоро будет! Нажми ещё раз 👇",
-    "🎯 Уже скоро... нажми через пару секунд 👇",
-    "🔄 Ещё немного... терпение! 👇",
+    "🔬 Анализируем твои мемы...",
+    "👀 Смотрим на лайки...",
+    "📊 Много же ты листал...",
+    "🤖 AI смотрит твои мемы...",
+    "🧠 Изучаем твой юмор...",
+    "🎭 Определяем твой вайб...",
 ]
 
 LOADING_BUTTONS = [
-    "Дальше →",
-    "Ну давай уже →",
     "Готово? →",
     "Проверить →",
+    "Ну давай уже →",
+    "Уже? →",
     "Ещё раз →",
-    "Жмяк →",
 ]
 
 
@@ -461,6 +460,13 @@ async def handle_wrapped_button(
         key = 0
 
     _log(f"user={user_id} key={key}")
+
+    # Delete the loading/button message before showing results
+    if update.callback_query and key == 0:
+        try:
+            await update.callback_query.message.delete()
+        except Exception:
+            pass
 
     try:
         await context.bot.send_chat_action(


### PR DESCRIPTION
## Summary
- Delete the loading/button message when Wrapped results are ready, so it doesn't stay in the chat feed
- Replace generic loading text ("Скоро будет! Нажми ещё раз") with descriptive messages: "Анализируем твои мемы", "Смотрим на лайки", "AI смотрит твои мемы", etc.

Supersedes #135 (had merge conflicts from Staff Engineer CI fix commits).

## Test plan
- [ ] Run `/wrapped` — see loading message with new copy
- [ ] Press button when results ready — loading message deleted, slide 0 appears clean
- [ ] No orphan loading messages left in chat after full flow