### PR TITLE
fix(agents): enforce git identity, merge policy, and mod chat monitoring

### DIFF
--- a/agents/comms/AGENTS.md
+++ b/agents/comms/AGENTS.md
@@ -159,11 +159,12 @@ On first activation (or when CEO requests), browse the public channel previews t
 
 ## Posting to Telegram
 
-Use the **production bot token** from env var `FFMEMES_PROD_TELEGRAM_BOT_TOKEN` to send messages to the @ffmemes channel.
+⚠️ **CRITICAL: Use ONLY the env var `FFMEMES_PROD_TELEGRAM_BOT_TOKEN` for posting.**
 
-⚠️ **This token is for posting to the public channel ONLY. Never use it for testing, debugging, or any other purpose.**
+This is the **@ffmemesbot** production bot (ID starts with `1123681771`). Do NOT use any other bot token — the @ffnerdbot (6469330294) does NOT have posting permissions in the channel.
 
 Channel ID (RU): `-1001152876229`
+Moderator chat ID: `-1001305866294`
 
 To send a text post with an image:
 ```bash
@@ -181,6 +182,66 @@ curl -s -X POST "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/
   -F "text=Post text here" \
   -F "parse_mode=HTML"
 ```
+
+## Moderator Chat Monitoring
+
+**Chat ID**: `-1001305866294`
+
+Moderators forward problematic memes (duplicates, ads, 18+, spam) to this chat. The bot auto-replies with meme stats. All messages are logged in `message_tg` table.
+
+### Routine (every heartbeat)
+
+1. **Read new messages** from the moderator chat since your last check:
+```sql
+SELECT id, message_id, date, user_id, text, reply_to_message_id
+FROM message_tg
+WHERE chat_id = -1001305866294
+AND date > NOW() - INTERVAL '6 hours'
+ORDER BY date ASC;
+```
+
+2. **Extract meme IDs** from text using pattern `#(\d+)`:
+   - Bot auto-replies contain `Fast Food Memes #12345` — these reference `meme.id`
+   - Moderators often send two memes in a row to flag duplicates
+
+3. **Look up flagged memes** for context:
+```sql
+SELECT m.id, m.status, m.type, m.language_code, m.telegram_file_id,
+       ms.nlikes, ms.ndislikes
+FROM meme m LEFT JOIN meme_stats ms ON m.id = ms.meme_id
+WHERE m.id IN (...extracted IDs...);
+```
+
+4. **Classify the flag**:
+   - Two similar memes back-to-back → **duplicate report**
+   - Text contains ad/promo content → **ad/spam report**
+   - Text contains 18+/NSFW markers → **content moderation**
+   - Discussion messages → **user feedback** (summarize themes)
+
+5. **Respond to moderators** — use the bot token to send a reply:
+```bash
+curl -s -X POST "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -F "chat_id=-1001305866294" \
+  -F "reply_to_message_id=<message_id>" \
+  -F "text=Спасибо! Отмечено: [краткое описание действия]" \
+  -F "parse_mode=HTML"
+```
+
+6. **Create action items** if needed — escalate to CTO (for duplicate detection bugs) or CEO (for policy decisions)
+
+### What to look for
+
+- **Patterns**: same source producing lots of flagged memes → potential source quality issue
+- **Duplicate clusters**: moderators flagging the same meme repeatedly → dedup pipeline issue
+- **Feedback themes**: moderators discussing bot quality → product insight for CEO
+- **Ad infiltration**: ads getting through filters → parser/filter issue for CTO
+
+### Important
+
+- Keep responses brief and friendly in Russian
+- Don't overwhelm moderators — they're volunteers
+- If no new messages since last check, skip silently
+- Use this intel for C-category content posts (data insights with moderator context)
 
 ## What NOT To Do
 

--- a/agents/cto/AGENTS.md
+++ b/agents/cto/AGENTS.md
@@ -30,6 +30,10 @@ You are activated when the CEO hands you a task (bug fix, feature, experiment im
 ## Git Workflow (CRITICAL)
 
 ```bash
+# FIRST: set correct git identity (MANDATORY before any commit)
+git config user.name "Daniil Okhlopkov"
+git config user.email "5613295+ohld@users.noreply.github.com"
+
 # Always work on a branch, never push to production directly
 git checkout -b fix/issue-description
 # ... make changes ...
@@ -38,6 +42,8 @@ git commit -m "fix: description of the change"
 git push origin fix/issue-description
 gh pr create --title "Fix: description" --body "Fixes FFM-N. ..."
 ```
+
+**Git identity**: ALL commits MUST be authored as `Daniil Okhlopkov <5613295+ohld@users.noreply.github.com>`. Never use agent names like "CTO Agent" or "FFmemes AI Team".
 
 **NEVER push directly to `production` branch.** Always create a PR.
 

--- a/agents/release-engineer/AGENTS.md
+++ b/agents/release-engineer/AGENTS.md
@@ -19,10 +19,17 @@ You are activated when CTO or another engineer has a PR ready for review and mer
 
 ## What you do
 
-1. **Review the PR** — check that CI passes, code looks clean, no secrets committed
-2. **Merge** — merge the PR into `production` branch
-3. **Verify deploy** — Coolify auto-deploys on push to production. Check that deploy succeeded
-4. **Hand off to QA** — if the change needs verification, create a task for QA Engineer
+1. **Check PR author** — determine if this is an internal PR (from ohld or agents) or external (from a stranger)
+2. **Review the PR** — check that CI passes, code looks clean, no secrets committed
+3. **Merge** — merge the PR into `production` branch (ONLY internal PRs — see merge policy below)
+4. **Verify deploy** — Coolify auto-deploys on push to production. Check that deploy succeeded
+5. **Hand off to QA** — if the change needs verification, create a task for QA Engineer
+
+## Merge Policy (CRITICAL)
+
+- **Internal PRs** (author is `ohld` or created by Paperclip agents): merge after Staff Engineer approval + CI passes
+- **External PRs** (author is anyone else): **NEVER merge**. Only review and comment. The project owner (ohld) must merge external PRs manually
+- When in doubt about PR authorship, do NOT merge — escalate to CEO
 
 ## Process
 

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -39,8 +39,10 @@ Passing tests do not mean the branch is safe. You look for the bugs that survive
    - If issues: `gh pr review <pr_number> --request-changes --repo ffmemes/ff-backend -b "Issues found"`
    - Always also post a detailed comment: `gh pr comment <pr_number> --repo ffmemes/ff-backend -b "..."`
 6. **Check CI status**: `gh pr checks <pr_number> --repo ffmemes/ff-backend`
-   - If CI passes AND review is clean → merge: `gh pr merge <pr_number> --squash --repo ffmemes/ff-backend`
    - If CI fails → post a comment on the PR explaining which checks failed and what needs fixing. Do NOT merge.
+7. **Check PR author before merging**:
+   - **Internal PRs** (author is `ohld`): If CI passes AND review is clean → merge: `gh pr merge <pr_number> --squash --repo ffmemes/ff-backend`
+   - **External PRs** (author is anyone else): **NEVER merge**. Only review and comment. The owner (ohld) merges external PRs manually.
 
 ## What you produce
 


### PR DESCRIPTION
## Summary

- **Git identity**: CTO must set `git config user.name/email` to ohld before every commit — stops "CTO Agent" and "FFmemes AI Team" authorship
- **Merge policy**: Staff Engineer and Release Engineer now check PR author before merging. External PRs are review-only — only ohld merges them manually
- **Comms Manager**: added moderator chat monitoring routine (reads `message_tg` for chat -1001305866294, extracts meme IDs, classifies flags). Also fixed bot token docs — explicit warning that only `FFMEMES_PROD_TELEGRAM_BOT_TOKEN` (@ffmemesbot) works for channel posting

## Test plan

- [ ] Verify CTO agent creates commits with ohld identity on next PR
- [ ] Verify Staff Engineer does not merge external PRs
- [ ] Verify Comms Manager reads moderator chat on next heartbeat