### PR TITLE
fix(ops): resolve describe_memes monitoring gap, fix Staff Engineer trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,6 @@ on:
     branches: [production]
 
 jobs:
-  notify-staff-engineer:
-    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger Staff Engineer review
-        run: |
-          curl -s -X POST \
-            "https://org.ffmemes.com/api/routine-triggers/public/910d844a954042dc060c56bf/fire" \
-            -H "Authorization: Bearer ${{ secrets.PAPERCLIP_TRIGGER_SECRET }}" \
-            -H "Content-Type: application/json" \
-            -d '{"pr_number": ${{ github.event.pull_request.number }}, "pr_url": "${{ github.event.pull_request.html_url }}"}'
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/staff-engineer-trigger.yml
+++ b/.github/workflows/staff-engineer-trigger.yml
@@ -1,0 +1,22 @@
+name: Staff Engineer Review Trigger
+
+# pull_request_target runs the workflow from the BASE branch (production),
+# not the PR's head branch. This ensures the trigger fires for ALL PRs,
+# even those created before this workflow existed.
+# Safe because this job only fires a webhook — no code checkout.
+on:
+  pull_request_target:
+    branches: [production]
+    types: [opened, reopened, synchronize]
+
+jobs:
+  notify-staff-engineer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Staff Engineer review
+        run: |
+          curl -s -X POST \
+            "https://org.ffmemes.com/api/routine-triggers/public/910d844a954042dc060c56bf/fire" \
+            -H "Authorization: Bearer ${{ secrets.PAPERCLIP_TRIGGER_SECRET }}" \
+            -H "Content-Type: application/json" \
+            -d '{"pr_number": ${{ github.event.pull_request.number }}, "pr_url": "${{ github.event.pull_request.html_url }}"}'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,32 @@
 - Weekly maintenance (Prefect flow health checks, data hygiene jobs, etc.) runs through the Prefect deployment definitions under `flow_deployments/`. Use Docker Compose (`docker-compose.yml`) plus Prefect CLI to register or trigger flows during scheduled operations.
 - For ad-hoc debugging, remember that Prefect logs surface in the worker containers defined in the Compose stack; keep an eye on OCR warnings for signal that the toggle needs to flip back on.
 
+## Describe Memes (OpenRouter Vision)
+
+The `describe_memes` flow (`src/flows/storage/describe_memes.py`) uses free OpenRouter vision models to extract text and descriptions from meme images. This is **separate from the legacy OCR** (Modal, `OCR_ENABLED` toggle).
+
+- **Schedule**: every 30 min, 30 memes/batch
+- **Throughput**: ~500-600 memes/day (limited by OpenRouter free tier: 20 rpm, ~1000 req/day)
+- **Priority**: processes most-liked memes first (`nlikes DESC`)
+- **Storage**: writes to `meme.ocr_result` JSONB with `calculated_at` timestamp
+- **Monitoring**: use `ocr_result->>'calculated_at'` to check recency, NOT `meme.created_at`
+- **Circuit breaker**: auto-pauses after 3 failures in 1 hour
+
+### Handling circuit breaker pauses
+
+When the circuit breaker fires, the deployment is paused and a Prefect automation event is emitted. To resume:
+
+```bash
+# Via Prefect API (preferred — no SSH needed):
+curl -s -X PATCH "https://prefect.swanrate.com/api/deployments/<deployment-id>" \
+  -u "$PREFECT_AUTH_STRING" \
+  -H "Content-Type: application/json" \
+  -d '{"paused": false}'
+```
+
+Auth credentials are in the Coolify environment variables (`PREFECT_AUTH_STRING`).
+Before resuming, verify the root cause is fixed (check recent flow run logs for error details).
+
 ## Key settings & environment toggles
 - Redis, Postgres, and Telegram configuration live in [`src/config.py`](src/config.py). Update `.env` or deployment secrets with:
   - `DATABASE_URL` / pooling parameters for Postgres.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,9 @@ docker compose exec app pytest tests/recommendations/test_blender.py
 - **DB**: PostgreSQL 14 (asyncpg + SQLAlchemy 2.0 raw `Table` objects, NOT declarative ORM)
 - **Cache/Queue**: Redis 6.2 (recommendation queues per user, user info cache, 1h TTL)
 - **Jobs**: Prefect 3.4 (parsing, stats, crossposting crons)
-- **OCR**: Modal microservice (toggle: `OCR_ENABLED`, currently off)
+- **OCR/Describe**: Two systems exist:
+  - **Legacy OCR**: Modal microservice (toggle: `OCR_ENABLED`, currently off)
+  - **Describe Memes**: OpenRouter free vision models (`describe_memes.py`), runs every 30 min, ~500-600 memes/day. Populates `meme.ocr_result` JSONB with description + text + language. Uses `calculated_at` field (NOT `meme.created_at`) for monitoring. Circuit breaker auto-pauses after 3 failures/hour
 - **Python**: 3.10 (dev), 3.12 (prod)
 
 ### Docker Compose Services

--- a/agents/analyst/AGENTS.md
+++ b/agents/analyst/AGENTS.md
@@ -36,6 +36,7 @@ Run queries from `docs/analyst/metrics.sql`. Focus on:
 - **Engine performance** — per-engine like rates AND session continuation (not just LR!)
 - **Growth** — share clicks, new users, retention trends
 - **Chat Agent** — agent calls, active chats, response times, token costs, group meme reactions
+- **OCR/Describe Memes** — memes described in last 24h, coverage by popularity tier, backlog size, last_described_at. Use `ocr_result->>'calculated_at'` (NOT `meme.created_at`) to find recently described memes. Alert if described_24h < 100 or last_described_at > 2 hours ago (flow may be paused by circuit breaker)
 - **Anomaly detection** — compare today vs 7-day average. Flag deviations >30%.
 
 **Important**: Like rate is NOT the only metric. The North Star is session length. Always consider multiple signals.

--- a/docs/analyst/metrics.sql
+++ b/docs/analyst/metrics.sql
@@ -287,6 +287,73 @@ ORDER BY day;
 
 
 -- =============================================
+-- SECTION: OCR / DESCRIBE MEMES (OpenRouter Vision)
+-- =============================================
+-- Tracks the describe_memes flow which uses free OpenRouter vision models
+-- to extract text + description from meme images.
+--
+-- Throughput: ~30 memes/batch, every 30 min, ~500-600 described/day
+-- Bottleneck: OpenRouter free tier limits (20 rpm, ~1000 req/day)
+-- Priority: processes most-liked memes first (nlikes DESC)
+--
+-- IMPORTANT: use ocr_result->>'calculated_at' to find recently described memes,
+-- NOT meme.created_at (the flow backfills old popular memes, not just new ones)
+
+-- Daily describe throughput and coverage
+SELECT
+  count(*) FILTER (
+    WHERE (ocr_result->>'calculated_at')::timestamp > now() - interval '24 hours'
+  ) AS described_24h,
+  count(*) FILTER (
+    WHERE (ocr_result->>'calculated_at')::timestamp > now() - interval '7 days'
+  ) AS described_7d,
+  count(*) FILTER (
+    WHERE ocr_result->>'description' IS NOT NULL
+  ) AS total_described,
+  count(*) FILTER (
+    WHERE type = 'image' AND status = 'ok'
+      AND (ocr_result IS NULL OR ocr_result->>'description' IS NULL)
+      AND COALESCE((ocr_result->>'describe_failures')::int, 0) < 3
+  ) AS backlog_remaining,
+  max((ocr_result->>'calculated_at')::timestamp) AS last_described_at
+FROM meme;
+
+-- Coverage by popularity tier (most important for Wrapped)
+WITH tiers AS (
+  SELECT
+    CASE
+      WHEN COALESCE(ms.nlikes, 0) >= 100 THEN '100+ likes'
+      WHEN COALESCE(ms.nlikes, 0) >= 50 THEN '50-99 likes'
+      WHEN COALESCE(ms.nlikes, 0) >= 20 THEN '20-49 likes'
+      ELSE 'under 20 likes'
+    END AS tier,
+    m.ocr_result->>'description' IS NOT NULL AS has_desc
+  FROM meme m
+  LEFT JOIN meme_stats ms ON ms.meme_id = m.id
+  WHERE m.type = 'image' AND m.status = 'ok'
+)
+SELECT
+  tier,
+  count(*) AS total,
+  count(*) FILTER (WHERE has_desc) AS described,
+  round(100.0 * count(*) FILTER (WHERE has_desc) / count(*)) AS coverage_pct
+FROM tiers
+GROUP BY tier
+ORDER BY
+  CASE tier
+    WHEN '100+ likes' THEN 1
+    WHEN '50-99 likes' THEN 2
+    WHEN '20-49 likes' THEN 3
+    ELSE 4
+  END;
+
+-- Permanently failed memes (3+ failures)
+SELECT count(*) AS permanently_failed_memes
+FROM meme
+WHERE (ocr_result->>'describe_failures')::int >= 3;
+
+
+-- =============================================
 -- SECTION: CHAT AGENT (Meme Sommelier)
 -- =============================================
 -- Tracks the AI chat agent in group chats.

--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -6,10 +6,16 @@ Populates meme.ocr_result JSONB with:
 - text: raw OCR text extracted from the image
 - language: detected language (ISO 639-1)
 - described_by: model used
-- described_at: timestamp
+- calculated_at: timestamp (use this field, NOT meme.created_at, for monitoring)
 
-Processes most popular memes first (by nmemes_sent).
+Processes most popular memes first (by nlikes DESC).
 Runs every 30 min via Prefect cron, ~30 memes per batch.
+
+Throughput: ~500-600 memes/day on OpenRouter free tier.
+Bottleneck: free model rate limits (20 rpm, ~1000 req/day with $10+ credits).
+Circuit breaker: auto-paused after 3 failures in 1 hour (see setup_automations.py).
+  To resume: prefect deployment resume "Describe Memes (OpenRouter Vision)/Describe Memes (OpenRouter)"
+  Or via Prefect API: PATCH /api/deployments/{id} with {"paused": false}
 """
 
 import asyncio

--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -13,9 +13,8 @@ Runs every 30 min via Prefect cron, ~30 memes per batch.
 
 Throughput: ~500-600 memes/day on OpenRouter free tier.
 Bottleneck: free model rate limits (20 rpm, ~1000 req/day with $10+ credits).
-Circuit breaker: auto-paused after 3 failures in 1 hour (see setup_automations.py).
-  To resume: prefect deployment resume "Describe Memes (OpenRouter Vision)/Describe Memes"
-  Or via Prefect API: PATCH /api/deployments/{id} with {"paused": false}
+Circuit breaker: auto-paused after 3 failures in 1 hour.
+  Resume: PATCH /api/deployments/{id} {"paused": false}
 """
 
 import asyncio

--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -14,7 +14,7 @@ Runs every 30 min via Prefect cron, ~30 memes per batch.
 Throughput: ~500-600 memes/day on OpenRouter free tier.
 Bottleneck: free model rate limits (20 rpm, ~1000 req/day with $10+ credits).
 Circuit breaker: auto-paused after 3 failures in 1 hour (see setup_automations.py).
-  To resume: prefect deployment resume "Describe Memes (OpenRouter Vision)/Describe Memes (OpenRouter)"
+  To resume: prefect deployment resume "Describe Memes (OpenRouter Vision)/Describe Memes"
   Or via Prefect API: PATCH /api/deployments/{id} with {"paused": false}
 """
 


### PR DESCRIPTION
## Summary
- **Staff Engineer trigger fix**: moved from `pull_request` to `pull_request_target` event so it fires for ALL PRs, even branches created before `ci.yml` existed (PR #141 had zero CI checks)
- **OCR/describe_memes monitoring**: added SQL metrics to analyst daily report — `described_24h`, coverage by popularity tier, backlog size, `last_described_at` with alert thresholds
- **Circuit breaker recovery docs**: AGENTS.md now has Prefect API instructions so agents can self-heal paused deployments without SSH
- **CLAUDE.md**: documents describe_memes as separate system from legacy OCR, with correct monitoring field (`calculated_at` not `created_at`)
- **Paperclip issues**: closed FFM-62 and FFM-65 via API (deployment already resumed, issues stuck in "blocked")

## Context
Agents created FFM-62/FFM-65 when describe_memes circuit breaker fired, but got stuck because:
1. No recovery instructions (only SSH command, agents can't SSH)
2. Analyst wasn't monitoring OCR metrics at all — nobody noticed 0 descriptions for 7 days
3. Staff Engineer never reviewed the fix PRs because `pull_request` event requires workflow on head branch

## Test plan
- [ ] `pull_request_target` triggers Staff Engineer review on this PR (self-test)
- [ ] Lint + tests pass in CI
- [ ] After merge: verify next analyst report includes OCR section
- [ ] Verify describe_memes flow continues running (currently healthy, ~567/day)