### PR TITLE
fix(reco): lower cold_start_explore threshold to fix empty pool

### DIFF
--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -349,16 +349,18 @@ async def cold_start_explore(
 ):
     """Phase 1 cold start: quality-first selection for new user first impression.
 
-    Serves memes with proven social proof (>=20 explicit reactions) and high
-    like rate (>=40%). New users need the bot's best content first — maximising
-    per-meme quality gives the best chance of a good first impression before
-    Phase 2 adapts to their taste via real reactions.
+    Serves memes with proven social proof (>=20 explicit reactions) and
+    positive user-bias-corrected like rate. New users need the bot's best
+    content first — maximising per-meme quality gives the best chance of a
+    good first impression before Phase 2 adapts to their taste via real
+    reactions.
 
-    Threshold rationale: nlikes+ndislikes counts only explicit like/dislike
-    reactions, not skips. With typical reaction rates ~30-40% of sends, a meme
-    sent 50-70 times accumulates ~20 explicit reactions — enough statistical
-    signal for lr_smoothed to be reliable. The old >=50 threshold required
-    ~150+ sends and left the pool empty on launch.
+    lr_smoothed is user-bias-corrected and centered around 0 (not a raw
+    like rate). A value of 0.10 means the meme is liked ~10pp above what
+    each user's personal average would predict — a strong positive signal.
+    The previous threshold of 0.40 was far too high and left the pool empty
+    because even universally-liked memes rarely exceed ~0.20 after bias
+    correction.
 
     Used for memes 1-5 (first impression).
     """
@@ -383,7 +385,7 @@ async def cold_start_explore(
             AND M.status = 'ok'
             AND R.meme_id IS NULL
             AND (MS.nlikes + MS.ndislikes) >= 20
-            AND MS.lr_smoothed >= 0.40
+            AND MS.lr_smoothed >= 0.10
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
 
         ORDER BY MS.lr_smoothed DESC, (MS.nlikes + MS.ndislikes) DESC

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -161,7 +161,7 @@ async def generate_recommendations(
 
         Cold start (<30 memes) uses 3-phase adaptive approach:
           Phase 1 (0-5):  Quality-first — top-liked memes with social proof
-                          (>=50 reactions, >=40% LR)
+                          (>=20 reactions, lr_smoothed >= 0.10)
           Phase 2 (6-15): Adapt — weight sources by user's raw reactions
           Phase 3 (16-30): Transition — blend adapt + growing engines
 


### PR DESCRIPTION
## Summary

- `lr_smoothed` threshold lowered from 0.40 to 0.10 in `cold_start_explore` engine
- `lr_smoothed` is user-bias-corrected and centered around 0, not a raw like rate
- Even universally-liked memes rarely exceed ~0.20 after correction, so 0.40 was unreachable
- New threshold 0.10 = "liked 10pp above user's personal average" — still selective, but produces results
- Updated stale docstrings to match actual values

Resolves FFM-83 (cold_start_explore pool empty, blocking cold_start_v2 experiment Phase 1).

## Test plan
- [ ] Verify `cold_start_explore` returns non-empty results: `docker compose exec app pytest tests/recommendations/`
- [ ] Check prod pool size after deploy: query `SELECT count(*) FROM meme_stats WHERE (nlikes+ndislikes) >= 20 AND lr_smoothed >= 0.10`