### PR TITLE
fix(agents): stagger schedules, fix routine lifecycle, add E2E fresh-user test

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -4,15 +4,21 @@ Autonomous AI team for @ffmemesbot, managed by [Paperclip](https://paperclip.ing
 
 ## Agents
 
-| Agent | Title | Reports To | Trigger | Heartbeat | Skills |
-|-------|-------|-----------|---------|-----------|--------|
-| CEO | Chief Executive Officer | — | Weekly routine (Mon 09:00 UTC) | 24h (daily) | plan-ceo-review, office-hours, autoplan |
-| Analyst | Data Analyst | CEO | Daily routine (06:00 UTC) | 6h | investigate, browse, retro |
-| CTO | Chief Technology Officer | CEO | On-demand (CEO task) | **off** | plan-eng-review, plan-design-review, retro, cso, codex, investigate |
-| Staff Engineer | Staff Engineer | CTO | PR webhook (GitHub Actions) | **off** | review, investigate |
-| QA Engineer | QA Engineer | CTO | Webhook (Sentry/Coolify proxy) + 6h schedule | 6h | browse, qa, qa-only, benchmark, canary, design-review, design-consultation, setup-browser-cookies |
-| Release Engineer | Release Engineer | CTO | On-demand (Staff Eng approval) | **off** | ship, land-and-deploy, document-release, setup-deploy |
-| Comms Manager | Communications | CEO | Daily heartbeat | 24h (daily) | browse, frontend-design |
+| Agent | Title | Reports To | Activation | Heartbeat | Skills |
+|-------|-------|-----------|------------|-----------|--------|
+| CEO | Chief Executive Officer | — | Weekly routine (Mon 09:00 UTC) + daily heartbeat | 24h | plan-ceo-review, office-hours, autoplan, retro |
+| Analyst | Data Analyst | CEO | **Routines only** (daily 06:00 + weekly Mon 09:00 UTC) | **off** | investigate, browse, retro |
+| CTO | Chief Technology Officer | CEO | On-demand (wakeOnDemand via task assignment) | **off** | plan-eng-review, plan-design-review, retro, cso, codex, investigate |
+| Staff Engineer | Staff Engineer | CTO | **Routines only** (PR webhook via GitHub Actions) | **off** | review, investigate |
+| QA Engineer | QA Engineer | CTO | **Routines only** (6h schedule + Sentry/Coolify webhooks) | **off** | browse, qa, qa-only, benchmark, canary, design-review, design-consultation, setup-browser-cookies |
+| Release Engineer | Release Engineer | CTO | On-demand (wakeOnDemand via task assignment) | **off** | ship, land-and-deploy, document-release, setup-deploy |
+| Comms Manager | Communications | CEO | Daily heartbeat | 24h | browse, frontend-design |
+
+### Heartbeats vs Routines
+
+- **Routines** = deterministic scheduled/triggered jobs with specific prompts. Preferred for all recurring work.
+- **Heartbeats** = generic "check inbox, do autonomous work" loops. Only for agents needing self-triage (CEO, Comms).
+- **wakeOnDemand** = instant wake when a task is assigned. Enabled on all agents regardless of heartbeat setting.
 
 ## Org Chart
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -45,10 +45,15 @@ Bug detected (Sentry webhook or QA scan)
           -> GitHub PR webhook triggers Staff Engineer
             -> Staff Engineer runs /review
               -> If issues: back to CTO
-              -> If clean: hands off to Release Engineer
-                -> Release Engineer runs /ship + /land-and-deploy
+              -> If clean: approves PR + tasks Release Engineer
+                -> Release Engineer runs /ship + /land-and-deploy (merge + deploy)
                   -> Coolify auto-deploys
-                    -> Deploy triggers QA /canary
+                    -> Deploy webhook triggers QA post-deploy verification:
+                      1. /canary (mandatory)
+                      2. Sentry scan (last 10 min)
+                      3. DB health check
+                      4. E2E smoke: returning user + fresh user (--fresh)
+                      5. Exploratory testing (5-10 min, improvised)
                       -> If issues: escalates to CTO
                       -> If clean: done
 ```
@@ -57,13 +62,15 @@ Bug detected (Sentry webhook or QA scan)
 
 | Routine | Agent | Schedule (UTC) | Trigger Type | What it does |
 |---------|-------|----------------|-------------|--------------|
-| Daily Analyst Report | Analyst | `0 6 * * *` | schedule + API | Query metrics, detect anomalies, write report for CEO |
-| QA Log Scan | QA | `0 */6 * * *` | schedule + 2 webhooks + API | Sentry + Coolify logs + DB health |
-| Process Health Check | QA | `0 12 * * *` | schedule | Watchdog: verify all routines are running on time |
-| Weekly CEO Review | CEO | `0 9 * * 1` | schedule | Retro, experiments, priorities, backlog review |
-| Weekly Analyst Summary | Analyst | `0 9 * * 1` | schedule | Weekly summary for CEO review |
-| gstack Update Check | CEO | `0 3 * * *` | schedule | Update skills, review changelog |
+| Daily Analyst Report | Analyst | `19 6 * * *` | schedule + API | Query metrics, detect anomalies, write report for CEO |
+| QA Log Scan | QA | `7 */6 * * *` | schedule + 2 webhooks + API | Sentry + Coolify logs + DB health + E2E smoke |
+| Process Health Check | QA | `37 12 * * *` | schedule | Watchdog: verify all routines are running and succeeding |
+| Weekly CEO Review | CEO | `11 9 * * 1` | schedule | Retro, experiments, priorities, backlog review |
+| Weekly Analyst Summary | Analyst | `23 9 * * 1` | schedule | Weekly summary for CEO review |
+| gstack Update Check | CEO | `17 3 * * *` | schedule | Update skills, review changelog |
 | PR Review | Staff Engineer | on PR event | 2 webhooks + API | Review PRs via GitHub Actions trigger |
+
+**Schedule design**: Prime-minute offsets ensure no two routines fire in the same minute. This avoids resource contention and makes debugging easier.
 
 ## Webhook Triggers
 
@@ -137,15 +144,19 @@ curl -s -X PATCH "$PAPERCLIP_URL/api/agents/<agent-id>" \
   -d '{"adapterConfig": {"paperclipSkillSync": {"desiredSkills": ["garrytan/gstack/skill-name"]}}}'
 ```
 
-### Sync instructions to server
+### Deploy instructions to server
 
-After editing AGENTS.md files locally:
+After editing AGENTS.md files locally, sync all agents to the live Paperclip container:
 
 ```bash
-CONTAINER=$(ssh root@t.ffmemes.com "docker ps --format '{{.Names}}' | grep k4w804")
-scp agents/<name>/AGENTS.md root@t.ffmemes.com:/tmp/agent-instructions.md
-ssh root@t.ffmemes.com "docker cp /tmp/agent-instructions.md $CONTAINER:/paperclip/instances/default/companies/96ee7b2e-6df2-43c8-bbe3-53e19297308a/agents/<agent-id>/instructions/AGENTS.md"
+./agents/deploy.sh
 ```
+
+This runs a backup first, then copies all AGENTS.md files to the container with size verification.
+Changes take effect on the next routine/heartbeat wake (Paperclip re-reads instructions from disk on each agent wake).
+
+Requires SSH key auth to the server (default: `root@t.ffmemes.com`).
+Override with: `PAPERCLIP_SSH_HOST=user@host ./agents/deploy.sh`
 
 ## Agent IDs
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -4,21 +4,15 @@ Autonomous AI team for @ffmemesbot, managed by [Paperclip](https://paperclip.ing
 
 ## Agents
 
-| Agent | Title | Reports To | Activation | Heartbeat | Skills |
-|-------|-------|-----------|------------|-----------|--------|
-| CEO | Chief Executive Officer | — | Weekly routine (Mon 09:00 UTC) + daily heartbeat | 24h | plan-ceo-review, office-hours, autoplan, retro |
-| Analyst | Data Analyst | CEO | **Routines only** (daily 06:00 + weekly Mon 09:00 UTC) | **off** | investigate, browse, retro |
-| CTO | Chief Technology Officer | CEO | On-demand (wakeOnDemand via task assignment) | **off** | plan-eng-review, plan-design-review, retro, cso, codex, investigate |
-| Staff Engineer | Staff Engineer | CTO | **Routines only** (PR webhook via GitHub Actions) | **off** | review, investigate |
-| QA Engineer | QA Engineer | CTO | **Routines only** (6h schedule + Sentry/Coolify webhooks) | **off** | browse, qa, qa-only, benchmark, canary, design-review, design-consultation, setup-browser-cookies |
-| Release Engineer | Release Engineer | CTO | On-demand (wakeOnDemand via task assignment) | **off** | ship, land-and-deploy, document-release, setup-deploy |
-| Comms Manager | Communications | CEO | Daily heartbeat | 24h | browse, frontend-design |
-
-### Heartbeats vs Routines
-
-- **Routines** = deterministic scheduled/triggered jobs with specific prompts. Preferred for all recurring work.
-- **Heartbeats** = generic "check inbox, do autonomous work" loops. Only for agents needing self-triage (CEO, Comms).
-- **wakeOnDemand** = instant wake when a task is assigned. Enabled on all agents regardless of heartbeat setting.
+| Agent | Title | Reports To | Trigger | Heartbeat | Skills |
+|-------|-------|-----------|---------|-----------|--------|
+| CEO | Chief Executive Officer | — | Weekly routine (Mon 09:00 UTC) | 24h (daily) | plan-ceo-review, office-hours, autoplan |
+| Analyst | Data Analyst | CEO | Daily routine (06:00 UTC) | 6h | investigate, browse, retro |
+| CTO | Chief Technology Officer | CEO | On-demand (CEO task) | **off** | plan-eng-review, plan-design-review, retro, cso, codex, investigate |
+| Staff Engineer | Staff Engineer | CTO | PR webhook (GitHub Actions) | **off** | review, investigate |
+| QA Engineer | QA Engineer | CTO | Webhook (Sentry/Coolify proxy) + 6h schedule | 6h | browse, qa, qa-only, benchmark, canary, design-review, design-consultation, setup-browser-cookies |
+| Release Engineer | Release Engineer | CTO | On-demand (Staff Eng approval) | **off** | ship, land-and-deploy, document-release, setup-deploy |
+| Comms Manager | Communications | CEO | Daily heartbeat | 24h (daily) | browse, frontend-design |
 
 ## Org Chart
 

--- a/agents/analyst/AGENTS.md
+++ b/agents/analyst/AGENTS.md
@@ -23,6 +23,10 @@ curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Be
 ```
 Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
 
+**Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
+a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+exit normally — the issue will be picked up on the next wake.
+
 ## Every Heartbeat (every 6 hours)
 
 ### 1. Review Historical Context
@@ -103,6 +107,24 @@ Append an entry to `experiments/log.jsonl`:
 
 ### 10. Create Task for CEO
 Create a Paperclip issue assigned to @ceo with the report summary, key metrics, anomalies, and recommended actions. Set priority "high" if anomalies >30%.
+
+### 11. Close Your Execution Issue
+
+After completing all work, you MUST mark your Paperclip execution issue as **done**.
+This is critical — if you don't close it, the routine can never fire again (blocked
+by a unique constraint on open execution issues).
+
+If `PAPERCLIP_TASK_ID` is set:
+```bash
+curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "done"}'
+```
+
+If the issue was already checked out via inbox, close it the same way using its ID.
+Always close your execution issue, even if your work encountered errors — mark it done
+with a summary of what happened.
 
 ## Important Context
 - **North Star**: session length (median memes per session). Higher = better. NOT like rate.

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -18,6 +18,7 @@ Review Analyst reports, think strategically about the product, manage experiment
 
 ## HARD RULES
 - You NEVER edit .py, .sql, .yml, .sh, or any code files. If you find yourself about to edit code, STOP immediately and create a task for CTO instead.
+- You NEVER cancel a routine execution issue (issues created by routine triggers). Always complete them as "done" with a summary. If the task isn't applicable, mark it done with "No action required — [reason]".
 - For non-trivial features: use `/autoplan` (runs CEO + design + eng review automatically)
 - For quick strategic checks: use `/plan-ceo-review`
 - For brainstorming new ideas: use `/office-hours` first, then decide
@@ -43,6 +44,10 @@ Review Analyst reports, think strategically about the product, manage experiment
 curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
 ```
 Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+
+**Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
+a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+exit normally — the issue will be picked up on the next wake.
 
 ## How You Work
 
@@ -71,7 +76,7 @@ Use `/office-hours` or `/plan-ceo-review` when the decision is non-trivial.
 Read `experiments/active/`. For each experiment:
 - **Continue**: Not enough data yet. Note why in the experiment file.
 - **Complete**: Clear results. Move from `active/` to `completed/`, fill in "Metrics After" and "Conclusion".
-- **Cancel**: Causing harm. Move to `completed/` with status=cancelled and explanation.
+- **Cancel experiment**: Update the experiment file status to cancelled and move from `experiments/active/` to `experiments/completed/`. Do NOT cancel the Paperclip issue — mark it "done" and note which experiment was cancelled in the summary.
 
 ### 4. Take Action (ALWAYS delegate, never code)
 
@@ -118,7 +123,21 @@ Append to `experiments/log.jsonl`:
 ```
 
 ### 9. Close Your Paperclip Tasks
-Mark processed tasks as done with a summary of actions taken.
+
+Mark processed tasks as done with a summary of actions taken. This is CRITICAL for
+routine execution issues — if you don't close them, the routine can never fire again
+(blocked by a unique constraint on open execution issues).
+
+If `PAPERCLIP_TASK_ID` is set:
+```bash
+curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "done"}'
+```
+
+Always close your execution issue, even if your work encountered errors or there was
+nothing to do — mark it done with a summary of what happened.
 
 ## Decision Framework
 

--- a/agents/deploy.sh
+++ b/agents/deploy.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Sync agent instructions from git to live Paperclip container
+# Usage: ./agents/deploy.sh
+#
+# Prerequisites: SSH key auth to the server
+# Override server: PAPERCLIP_SSH_HOST=user@host ./agents/deploy.sh
+#
+# What it does:
+#   1. Runs backup.sh first (safety net)
+#   2. For each agent with AGENTS.md, copies it to the Paperclip container
+#   3. Verifies file sizes match after copy
+#
+# Paperclip re-reads instructions from disk on each agent wake (routine or heartbeat).
+# No container restart needed — changes take effect on the next routine/heartbeat fire.
+
+set -euo pipefail
+
+SERVER="${PAPERCLIP_SSH_HOST:-root@t.ffmemes.com}"
+COMPANY_ID="96ee7b2e-6df2-43c8-bbe3-53e19297308a"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# Agent name -> ID mapping (these are public — already in agents/README.md)
+AGENT_NAMES="ceo analyst cto staff-engineer qa release-engineer comms"
+agent_id() {
+  case "$1" in
+    ceo)              echo "e782143b-5ecf-484c-ad87-939592c79dbb" ;;
+    analyst)          echo "9c87d840-7041-49d8-8436-00b6dcb10971" ;;
+    cto)              echo "ebdad67a-e5fa-4b1f-ad40-86a64a43f45f" ;;
+    staff-engineer)   echo "1a323bb6-2b4d-46bf-9c33-7971fa1673d5" ;;
+    qa)               echo "4b02ab32-596b-4339-a397-eb88559a266f" ;;
+    release-engineer) echo "b5b71b81-eeed-4767-8970-8523786779d7" ;;
+    comms)            echo "eac86c1e-8708-469c-af17-2925e356e4fb" ;;
+    *)                echo "" ;;
+  esac
+}
+
+echo "Deploying agent instructions to $SERVER..."
+
+# Find Paperclip container
+CONT=$(ssh "$SERVER" "docker ps --format '{{.Names}}' | grep k4w804 | head -1")
+if [ -z "$CONT" ]; then
+  echo "ERROR: Paperclip container not found on $SERVER" >&2
+  exit 1
+fi
+echo "Container: $CONT"
+echo ""
+
+# Run backup first
+if [ -x "$SCRIPT_DIR/backup/backup.sh" ]; then
+  echo "Running backup..."
+  "$SCRIPT_DIR/backup/backup.sh"
+  echo ""
+fi
+
+# Sync each agent
+SYNCED=0
+ERRORS=0
+for agent in $AGENT_NAMES; do
+  AGENTS_FILE="$SCRIPT_DIR/$agent/AGENTS.md"
+  if [ ! -f "$AGENTS_FILE" ]; then
+    continue
+  fi
+
+  AGENT_ID=$(agent_id "$agent")
+  if [ -z "$AGENT_ID" ]; then
+    echo "  SKIP $agent — unknown agent ID" >&2
+    continue
+  fi
+
+  REMOTE_PATH="/paperclip/instances/default/companies/$COMPANY_ID/agents/$AGENT_ID/instructions/AGENTS.md"
+
+  # Copy to server, ensure target dir exists, copy into container
+  scp -q "$AGENTS_FILE" "$SERVER:/tmp/deploy-$agent.md"
+  ssh "$SERVER" "docker exec $CONT mkdir -p '$(dirname "$REMOTE_PATH")' && docker cp /tmp/deploy-$agent.md '$CONT:$REMOTE_PATH' && rm -f /tmp/deploy-$agent.md"
+
+  # Verify file size matches (wc runs inside the container)
+  REMOTE_SIZE=$(ssh "$SERVER" "docker exec $CONT sh -c 'wc -c < \"$REMOTE_PATH\"' 2>/dev/null || echo 0")
+  LOCAL_SIZE=$(wc -c < "$AGENTS_FILE")
+  if [ "$REMOTE_SIZE" -eq "$LOCAL_SIZE" ]; then
+    echo "  OK  $agent ($AGENT_ID) — $LOCAL_SIZE bytes"
+  else
+    echo "  ERR $agent — size mismatch (local=$LOCAL_SIZE remote=$REMOTE_SIZE)" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+  SYNCED=$((SYNCED + 1))
+done
+
+echo ""
+echo "Synced $SYNCED agents. Changes take effect on next routine/heartbeat wake."
+if [ "$ERRORS" -gt 0 ]; then
+  echo "WARNING: $ERRORS agents had size mismatches — check manually." >&2
+  exit 1
+fi

--- a/agents/qa/AGENTS.md
+++ b/agents/qa/AGENTS.md
@@ -50,6 +50,10 @@ curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Be
 ```
 Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
 
+**Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
+a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+exit normally — the issue will be picked up on the next wake.
+
 ## Every Routine Run (every 6h)
 
 ### 1. Scan All Log Sources
@@ -76,6 +80,23 @@ For Critical/High: create Paperclip task for **CTO** with title, error, log sour
 ```
 
 ### 5. Log to JSONL + Alert CEO if RED
+
+### 6. Close Your Execution Issue
+
+After completing all work, you MUST mark your Paperclip execution issue as **done**.
+This is critical — if you don't close it, the routine can never fire again (blocked
+by a unique constraint on open execution issues).
+
+If `PAPERCLIP_TASK_ID` is set:
+```bash
+curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "done"}'
+```
+
+Always close your execution issue, even if your work encountered errors — mark it done
+with a summary of what happened.
 
 ## Key Coolify UUIDs
 | Service | UUID |
@@ -123,18 +144,50 @@ Requires env vars: `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, `TELEGRAM_SESSION_STR
 
 **Session string exclusivity:** The Telegram session string can only be used by one process at a time. Do not run E2E smoke tests concurrently with any other Telethon client using the same session. If the session is invalidated, regenerate with `python scripts/generate_session_string.py`.
 
+### Fresh-User Onboarding Test
+
+After the standard smoke passes, test the onboarding flow for new users:
+
+```bash
+python scripts/e2e_smoke.py --fresh
+```
+
+This sends `/delete` to clear the test user's state (DB + Redis), then runs `/start`
+as if it's a brand new user. Verifies the full onboarding: language selection, first
+meme, buttons. Use this after deploying features that touch the onboarding flow or
+cold start path.
+
+### Exploratory Testing (post-deploy, non-blocking)
+
+After deterministic smoke passes, spend 5-10 minutes testing the bot as a real
+user would. This is NOT scripted. Improvise. Try things a real user would try:
+
+- Send random text messages (not commands)
+- Send stickers, photos, voice messages
+- Rapid-fire like/dislike buttons
+- Send /start multiple times in a row
+- Try /lang mid-session
+- Send deep links (t.me/ffmemesbot?start=xxx)
+- Try the share button
+- Test in different languages if configured
+
+File any bugs found as tasks for CTO with reproduction steps and screenshots.
+This is a non-blocking bug hunt — don't gate the deploy on exploratory results.
+
 ## Process Health Check (Watchdog)
 
-When triggered by the daily watchdog routine, check that all other routines are running:
+When triggered by the daily watchdog routine, check that all other routines are running AND succeeding:
 
-1. Call Paperclip API: `GET /api/routines` to list all routines with their lastRun timestamps
-2. Check each routine ran within 2x its expected interval:
-   - **Daily Analyst Report** → should have run in the last 12h
-   - **QA Log Scan** → should have run in the last 12h
-   - **Weekly CEO Review** → should have run in the last 14 days
-   - **gstack Update Check** → should have run in the last 48h
+1. Call Paperclip API: `GET /api/companies/96ee7b2e-6df2-43c8-bbe3-53e19297308a/routines` to list all routines
+2. For each routine, check BOTH **freshness** (did it run recently?) AND **health** (did it succeed?):
+   - **Daily Analyst Report** → ran in last 28h AND `lastRun.status` is not `failed`
+   - **QA Log Scan** → ran in last 12h AND `lastRun.status` is not `failed`
+   - **Weekly CEO Review** → ran in last 14 days AND `lastRun.status` is not `failed`
+   - **Weekly Analyst Summary** → ran in last 14 days AND `lastRun.status` is not `failed`
+   - **gstack Update Check** → ran in last 48h AND `lastRun.status` is not `failed`
    - **PR Review** → event-driven, skip unless no runs in 7 days
-3. If any routine is stale → create **HIGH** priority task for CEO with: which routine is stale, when it last ran, what the expected interval is
+   - **Process Health Check** → skip (that's you)
+3. If any routine is STALE (hasn't run in time) or FAILED (`lastRun.status == "failed"`) → create **HIGH** priority task for CEO with: which routine, when it last ran, what the status was, and the `failureReason` if available
 4. If all routines are healthy → log "Process health: GREEN" in your QA report
 
 ## What NOT To Do

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -11,6 +11,18 @@ skills:
 
 You are the Staff Engineer of @ffmemesbot. You operate in paranoid reviewer mode.
 
+## Heartbeat Wake Procedure
+
+**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set, fetch that issue directly:
+```bash
+curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+```
+Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+
+**Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
+a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+exit normally — the issue will be picked up on the next wake.
+
 ## What triggers you
 
 You are activated when a PR is created or updated on the `production` branch — either from CTO's implementation work or from any other contributor. You review every PR before it can be merged.
@@ -40,9 +52,11 @@ Passing tests do not mean the branch is safe. You look for the bugs that survive
    - Always also post a detailed comment: `gh pr comment <pr_number> --repo ffmemes/ff-backend -b "..."`
 6. **Check CI status**: `gh pr checks <pr_number> --repo ffmemes/ff-backend`
    - If CI fails → post a comment on the PR explaining which checks failed and what needs fixing. Do NOT merge.
-7. **Check PR author before merging**:
-   - **Internal PRs** (author is `ohld`): If CI passes AND review is clean → merge: `gh pr merge <pr_number> --squash --repo ffmemes/ff-backend`
-   - **External PRs** (author is anyone else): **NEVER merge**. Only review and comment. The owner (ohld) merges external PRs manually.
+7. **After review**:
+   - If CI passes AND review is clean → approve the PR and create a Paperclip task
+     for **Release Engineer** with `pr_number`, `pr_url`, and your review summary.
+     Do NOT merge — Release Engineer owns the merge + deploy + verify cycle.
+   - **External PRs** (author is anyone other than an agent): **NEVER merge**. Only review and comment. The owner (ohld) merges external PRs manually.
 
 ## What you produce
 
@@ -64,6 +78,23 @@ A GitHub PR with either:
 - **Public GitHub repo**: NEVER approve PRs that contain secrets
 - **North Star**: session length, not like rate
 - **Dislike != bad**: dislike button means "next meme"
+
+## Closing Your Execution Issue
+
+After completing your PR review, you MUST mark your Paperclip execution issue as **done**.
+This is critical — if you don't close it, the routine can never fire again (blocked
+by a unique constraint on open execution issues).
+
+If `PAPERCLIP_TASK_ID` is set:
+```bash
+curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "done"}'
+```
+
+Always close your execution issue, even if the PR review found issues — mark it done
+with a summary of the review outcome.
 
 ## What NOT To Do
 

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -79,31 +79,39 @@ docker exec -it $CONT codex login --device-auth
 docker exec -it $CONT gh auth login
 
 # Upload agent instructions after editing locally
-scp agents/<name>/AGENTS.md root@t.ffmemes.com:/tmp/agent.md
-ssh root@t.ffmemes.com "docker cp /tmp/agent.md $CONT:/paperclip/instances/default/companies/<company-id>/agents/<agent-id>/instructions/AGENTS.md"
+# Preferred: use the deploy script (syncs all agents + runs backup)
+./agents/deploy.sh
+# Manual (single agent):
+# scp agents/<name>/AGENTS.md root@t.ffmemes.com:/tmp/agent.md
+# ssh root@t.ffmemes.com "docker cp /tmp/agent.md $CONT:/paperclip/instances/default/companies/<company-id>/agents/<agent-id>/instructions/AGENTS.md"
 ```
 
 ## Agent Team
 
-| Agent | Role | Reports To | Heartbeat | Model |
-|-------|------|-----------|-----------|-------|
-| CEO | Strategic decisions, experiments | — | Daily | opus |
-| Analyst | Metrics, anomaly detection | CEO | 6h | sonnet |
-| CTO | Engineering, PRs | CEO | On-demand | sonnet |
-| QA Engineer | Log monitoring, bug reports | CEO | 6h | sonnet |
-| Release Engineer | PR merge, deploy verify | CTO | On-demand | sonnet |
-| Comms Manager | Public TG channel updates | CEO | On-demand | sonnet |
+| Agent | Role | Reports To | Activation | Model |
+|-------|------|-----------|------------|-------|
+| CEO | Strategic decisions, experiments | — | Weekly routine + daily heartbeat | opus |
+| Analyst | Metrics, anomaly detection | CEO | Routines only (heartbeat off) | sonnet |
+| CTO | Engineering, PRs | CEO | On-demand (wakeOnDemand) | sonnet |
+| Staff Engineer | PR review | CTO | Routines only (PR webhook) | sonnet |
+| QA Engineer | Log monitoring, bug reports | CTO | Routines only (6h schedule + webhooks) | sonnet |
+| Release Engineer | PR merge, deploy verify | CTO | On-demand (wakeOnDemand) | sonnet |
+| Comms Manager | Public TG channel updates | CEO | Daily heartbeat | sonnet |
 
 Agent instructions: `agents/<name>/AGENTS.md` in this repo.
+Deploy after editing: `./agents/deploy.sh`
 
 ## Routines
 
-| Routine | Agent | Schedule (UTC) | What it does |
-|---------|-------|----------------|-------------|
-| Daily Analyst Report | Analyst | `0 6 * * *` | Query metrics, detect anomalies, write report |
-| QA Log Scan | QA | `0 */6 * * *` | Sentry, Coolify logs, DB health |
-| Weekly CEO Review | CEO | `0 9 * * 1` | Retro, experiments, priorities |
-| gstack Update Check | CEO | `0 3 * * *` | Update skills, review changelog |
+| Routine | Agent | Schedule (UTC) | Trigger Type | What it does |
+|---------|-------|----------------|-------------|--------------|
+| Daily Analyst Report | Analyst | `19 6 * * *` | schedule + API | Query metrics, detect anomalies, write report |
+| QA Log Scan | QA | `7 */6 * * *` | schedule + 2 webhooks + API | Sentry, Coolify logs, DB health, E2E smoke |
+| Process Health Check | QA | `37 12 * * *` | schedule | Watchdog: verify all routines are running and succeeding |
+| Weekly CEO Review | CEO | `11 9 * * 1` | schedule | Retro, experiments, priorities |
+| Weekly Analyst Summary | Analyst | `23 9 * * 1` | schedule | Weekly summary for CEO review |
+| gstack Update Check | CEO | `17 3 * * *` | schedule | Update skills, review changelog |
+| PR Review | Staff Engineer | on PR event | 2 webhooks + API | Review PRs via GitHub Actions trigger |
 
 ## Plugins
 

--- a/scripts/e2e_smoke.py
+++ b/scripts/e2e_smoke.py
@@ -14,8 +14,10 @@ Optional:
 
 Usage:
     pip install -r requirements-e2e.txt
-    python scripts/e2e_smoke.py
+    python scripts/e2e_smoke.py           # returning user flow
+    python scripts/e2e_smoke.py --fresh   # reset state + onboarding flow
 """
+import argparse
 import asyncio
 import os
 import sys
@@ -131,8 +133,73 @@ async def test_like(client, bot, meme_msg):
         return "WARN", "Bot responded after like but with unexpected content"
 
 
+# --- Fresh user tests ---
+async def test_delete(client, bot):
+    """Send /delete, click confirmation, verify state cleared."""
+    before_id = await get_latest_msg_id(client, bot)
+    await client.send_message(bot, "/delete")
+    msg = await wait_for_response(client, bot, before_id)
+
+    if msg is None:
+        return "FAIL", "Bot did not respond to /delete"
+
+    # Click the confirmation button ("Delete everything")
+    if msg.reply_markup:
+        for row in msg.reply_markup.rows:
+            for btn in row.buttons:
+                if btn.data and b"delete" in btn.data.lower():
+                    await msg.click(data=btn.data)
+                    confirm_msg = await wait_for_response(client, bot, msg.id)
+                    if confirm_msg and ("ciao" in (confirm_msg.text or "").lower() or "start" in (confirm_msg.text or "").lower()):
+                        return "PASS", f"State deleted: {(confirm_msg.text or '')[:80]}"
+                    return "WARN", f"Delete clicked but unexpected response: {(confirm_msg.text if confirm_msg else 'no response')[:80]}"
+
+    if "sure" in (msg.text or "").lower() or "delete" in (msg.text or "").lower():
+        return "WARN", f"Got confirmation prompt but no button found: {(msg.text or '')[:80]}"
+    return "WARN", f"Unexpected /delete response: {(msg.text or '')[:80]}"
+
+
+async def test_fresh_onboarding(client, bot):
+    """After /reset, send /start and verify onboarding flow for new user.
+    Returns (status, detail, meme_msg).
+    """
+    before_id = await get_latest_msg_id(client, bot)
+    await client.send_message(bot, "/start")
+    # New users may get language selection or onboarding popup before first meme
+    # Wait longer for the full onboarding sequence
+    msg = await wait_for_response(client, bot, before_id, timeout=15)
+
+    if msg is None:
+        return "FAIL", "Bot did not respond to /start after reset", None
+
+    # Check if we got a meme (fast path) or onboarding content
+    has_media = msg.media is not None
+    has_buttons = has_reaction_buttons(msg)
+
+    if has_media and has_buttons:
+        return "PASS", "Fresh user: meme received with buttons (fast onboarding)", msg
+
+    # May need to interact with onboarding (language selection, etc.)
+    # Wait for more messages — onboarding may send multiple
+    await asyncio.sleep(2)
+    messages = await client.get_messages(bot, limit=5)
+    for m in messages:
+        if m.id > before_id and not m.out and m.media and has_reaction_buttons(m):
+            return "PASS", "Fresh user: meme received after onboarding sequence", m
+
+    if has_media:
+        return "WARN", "Fresh user: got media but no reaction buttons", msg
+    if msg.text:
+        return "WARN", f"Fresh user: onboarding text (may need interaction): {msg.text[:100]}", msg
+    return "WARN", "Fresh user: unexpected onboarding response", msg
+
+
 # --- Runner ---
 async def main():
+    parser = argparse.ArgumentParser(description="E2E smoke tests for @ffmemesbot")
+    parser.add_argument("--fresh", action="store_true", help="Reset user state and test onboarding")
+    args = parser.parse_args()
+
     if not all([API_ID, API_HASH, SESSION_STRING]):
         print("SKIP: Telegram E2E credentials not configured")
         print("  Set TELEGRAM_API_ID, TELEGRAM_API_HASH, TELEGRAM_SESSION_STRING")
@@ -154,12 +221,26 @@ async def main():
         bot = await client.get_entity(BOT_USERNAME)
         results = []
 
-        # Test 1: /start → get a meme
-        status, detail, meme_msg = await test_start(client, bot)
-        results.append(("start", status, detail))
-        print(f"  [{status}] start: {detail}")
+        if args.fresh:
+            # Fresh user flow: delete → onboard → first meme → like
+            status, detail = await test_delete(client, bot)
+            results.append(("delete", status, detail))
+            print(f"  [{status}] delete: {detail}")
 
-        # Test 2: click like on that meme → get next meme (no extra /start)
+            if status == "FAIL":
+                print("\nRESULT: FAIL — /delete not working")
+                sys.exit(1)
+
+            status, detail, meme_msg = await test_fresh_onboarding(client, bot)
+            results.append(("onboarding", status, detail))
+            print(f"  [{status}] onboarding: {detail}")
+        else:
+            # Returning user flow: /start → meme
+            status, detail, meme_msg = await test_start(client, bot)
+            results.append(("start", status, detail))
+            print(f"  [{status}] start: {detail}")
+
+        # Both flows: click like on the meme → get next meme
         status, detail = await test_like(client, bot, meme_msg)
         results.append(("like", status, detail))
         print(f"  [{status}] like: {detail}")
@@ -175,7 +256,8 @@ async def main():
             print("\nRESULT: WARN — bot responds but with unexpected content")
             sys.exit(0)
         else:
-            print("\nRESULT: PASS — bot fully functional")
+            mode = "fresh user" if args.fresh else "returning user"
+            print(f"\nRESULT: PASS — bot fully functional ({mode} flow)")
             sys.exit(0)
 
     except Exception as e:

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -388,7 +388,8 @@ async def cold_start_explore(
             AND MS.lr_smoothed >= 0.10
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
 
-        ORDER BY (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0)) DESC, (MS.nlikes + MS.ndislikes) DESC
+        ORDER BY (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0)) DESC,
+                 (MS.nlikes + MS.ndislikes) DESC
         LIMIT :limit
     """
     return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))

--- a/src/tgbot/handlers/admin/service.py
+++ b/src/tgbot/handlers/admin/service.py
@@ -17,6 +17,12 @@ from src.database import (
     user_tg,
     user_tg_chat_membership,
 )
+from src.redis import (
+    clear_meme_queue_by_key,
+    get_meme_queue_key,
+    get_user_info_key,
+    redis_client,
+)
 from src.tgbot.constants import UserType
 
 
@@ -34,6 +40,9 @@ async def delete_user(user_id: int) -> None:
     )
     await execute(user_deep_link_log.delete().where(user_deep_link_log.c.user_id == user_id))
     await execute(user_popup_logs.delete().where(user_popup_logs.c.user_id == user_id))
+    # Clear Redis caches so next /start is fully clean
+    await redis_client.delete(get_user_info_key(user_id))
+    await clear_meme_queue_by_key(get_meme_queue_key(user_id))
 
 
 async def get_user_by_tg_username(

--- a/src/tgbot/handlers/chat/agent/tools.py
+++ b/src/tgbot/handlers/chat/agent/tools.py
@@ -13,7 +13,7 @@ def get_tools() -> list:
     return [search_memes, send_meme, get_chat_history]
 
 
-@function_tool
+@function_tool(strict_mode=False)
 async def search_memes(
     ctx: RunContextWrapper,
     query: str,
@@ -56,7 +56,7 @@ async def search_memes(
     return "\n".join(lines)
 
 
-@function_tool
+@function_tool(strict_mode=False)
 async def send_meme(ctx: RunContextWrapper, meme_id: int) -> str:
     """Send a meme to the chat by its ID. Use after search_memes to pick one."""
     context = ctx.context
@@ -107,7 +107,7 @@ async def send_meme(ctx: RunContextWrapper, meme_id: int) -> str:
         return f"Failed to send meme: {e}"
 
 
-@function_tool
+@function_tool(strict_mode=False)
 async def get_chat_history(ctx: RunContextWrapper, limit: int = 50) -> str:
     """Fetch more messages from the current chat for additional context."""
     context = ctx.context

--- a/tests/tgbot/test_agent_tools.py
+++ b/tests/tgbot/test_agent_tools.py
@@ -9,18 +9,13 @@ from agents.tool import ToolContext
 from src.tgbot.handlers.chat.agent.runner import ChatAgentContext
 
 
-def _make_tool_ctx(bot=None, chat_id=123, user_id=1, tool_arguments="{}"):
+def _make_tool_ctx(bot=None, chat_id=123, user_id=1):
     """Build a ToolContext wrapping a ChatAgentContext for tool tests."""
     if bot is None:
         bot = MagicMock()
         bot.send_photo = AsyncMock()
     ctx = ChatAgentContext(bot=bot, chat_id=chat_id, user_id=user_id)
-    return ToolContext(
-        context=ctx,
-        tool_name="test",
-        tool_call_id="test",
-        tool_arguments=tool_arguments,
-    )
+    return ToolContext(context=ctx, tool_name="test", tool_call_id="test")
 
 
 @pytest.mark.asyncio
@@ -58,8 +53,8 @@ async def test_send_meme_coerces_string_meme_id():
             # LLM sends meme_id as string in JSON — must be coerced to int
             result = await send_meme.on_invoke_tool(tool_ctx, json.dumps({"meme_id": "6091977"}))
 
-    assert isinstance(
-        captured_params["meme_id"], int
-    ), "meme_id must be cast to int before SQL — asyncpg rejects str for integer columns"
+    assert isinstance(captured_params["meme_id"], int), (
+        "meme_id must be cast to int before SQL — asyncpg rejects str for integer columns"
+    )
     assert captured_params["meme_id"] == 6091977
     assert "Sent" in result

--- a/tests/tgbot/test_agent_tools.py
+++ b/tests/tgbot/test_agent_tools.py
@@ -9,13 +9,18 @@ from agents.tool import ToolContext
 from src.tgbot.handlers.chat.agent.runner import ChatAgentContext
 
 
-def _make_tool_ctx(bot=None, chat_id=123, user_id=1):
+def _make_tool_ctx(bot=None, chat_id=123, user_id=1, tool_arguments="{}"):
     """Build a ToolContext wrapping a ChatAgentContext for tool tests."""
     if bot is None:
         bot = MagicMock()
         bot.send_photo = AsyncMock()
     ctx = ChatAgentContext(bot=bot, chat_id=chat_id, user_id=user_id)
-    return ToolContext(context=ctx, tool_name="test", tool_call_id="test")
+    return ToolContext(
+        context=ctx,
+        tool_name="test",
+        tool_call_id="test",
+        tool_arguments=tool_arguments,
+    )
 
 
 @pytest.mark.asyncio
@@ -53,8 +58,8 @@ async def test_send_meme_coerces_string_meme_id():
             # LLM sends meme_id as string in JSON — must be coerced to int
             result = await send_meme.on_invoke_tool(tool_ctx, json.dumps({"meme_id": "6091977"}))
 
-    assert isinstance(captured_params["meme_id"], int), (
-        "meme_id must be cast to int before SQL — asyncpg rejects str for integer columns"
-    )
+    assert isinstance(
+        captured_params["meme_id"], int
+    ), "meme_id must be cast to int before SQL — asyncpg rejects str for integer columns"
     assert captured_params["meme_id"] == 6091977
     assert "Sent" in result


### PR DESCRIPTION
## Summary
- Stagger all routine cron schedules to avoid simultaneous agent wakes
- Fix routine execution issue lifecycle (agents now close issues + CEO never cancels)
- Add inbox retry workaround for Paperclip TASK_ID race (upstream fix: PR paperclipai/paperclip#2024)
- Staff Engineer stops merging, hands off to Release Engineer
- `e2e_smoke.py --fresh` tests onboarding from scratch via existing `/delete`
- `delete_user()` now clears Redis cache for clean E2E state
- QA gets exploratory testing instructions + watchdog checks health status
- `agents/deploy.sh` for one-command instruction sync to Paperclip

## Test plan
- [x] Manually triggered Weekly Analyst Summary — completed as done (FFM-113)
- [x] Manually triggered Weekly CEO Review — completed as done, NOT cancelled (FFM-114)
- [x] Staggered schedules applied via Paperclip API (verified all 6 triggers)
- [x] Agent instructions deployed via deploy.sh (7/7 agents synced)
- [ ] Next scheduled routine fires at staggered time (not :00)
- [ ] Staff Engineer approves PR without merging, tasks Release Engineer
- [ ] QA runs `e2e_smoke.py --fresh` post-deploy on production