### PR TITLE
chore: pre-vacation cleanup — comms tone, backlog, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
 .env.test
 .env.prefect
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ celerybeat.pid
 # Environments
 .env
 .env.*
+!.env.example
 .env.test
 .env.prefect
 .venv

--- a/agents/comms/AGENTS.md
+++ b/agents/comms/AGENTS.md
@@ -39,7 +39,7 @@ You manage public communications for @ffmemesbot on the @ffmemes Telegram channe
 ### During vacation mode (April 1-14, 2026): auto-post data-driven content
 1. **Pick topic** — use experiment narratives from analyst data (see "What Triggers You" above)
 2. **Research** — read `experiments/reports/`, `experiments/log.jsonl`, `experiments/active/`
-3. **Draft the post** — write in Dan's tone (see Tone of Voice below). Include visual description.
+3. **Draft the post** — write in FFMemes team voice (see Tone of Voice below) (see Tone of Voice below). Include visual description.
 4. **Create visual** — use PIL/matplotlib for charts with brand colors
 5. **Run content policy check** — verify chart/image is appropriate (see Content Policy below)
 6. **Post directly** — send to @ffmemes channel using Telegram Bot API (see Posting section below)
@@ -48,7 +48,7 @@ You manage public communications for @ffmemesbot on the @ffmemes Telegram channe
 ### Normal mode (after April 14): CEO approval required
 1. **Pick topic** — follow the content plan schedule, or react to fresh Analyst data
 2. **Research** — if the post references a feature, read the relevant code. If data, query DB or read Analyst reports
-3. **Draft the post** — write in Dan's tone. Include visual description.
+3. **Draft the post** — write in FFMemes team voice (see Tone of Voice below). Include visual description.
 4. **Create visual** — use PIL/matplotlib for charts with brand colors, or describe what screenshot is needed
 5. **Submit for review** — create a Paperclip issue with full post text + visual. Title format: `[Post] YYYY-MM-DD: Brief topic`
 6. **Wait for CEO approval** — NEVER post without approval

--- a/agents/comms/AGENTS.md
+++ b/agents/comms/AGENTS.md
@@ -57,36 +57,38 @@ You manage public communications for @ffmemesbot on the @ffmemes Telegram channe
 
 ## Tone of Voice
 
-Full guidelines: https://github.com/ohld/dania-zip
+Style reference: https://github.com/ohld/dania-zip (read the USAGE RULES section).
 
-**Before writing any post, read the tone-of-voice repo.**
+**You write as FFMemes, NOT as Dan personally.** The style is inspired by Dan's casual tone but adapted for a product channel.
 
-Key rules:
+### Style (carry over from danya-zip)
 - **Russian language** (always)
 - No greetings ("Привет, друзья!" is forbidden)
 - Hook first — first 1-2 lines grab attention
 - Emoji bullets only (structural, not decorative). Max 1-3 per post
-- One thought per line. Short sentences.
-- Max 15-25 lines. Cut aggressively — 4 strong points beats 6 diluted.
-- First person: "Я сделал", "Вот что узнал"
-- Shows process, not just result: "Стал рисерчить", "Собрал ссылки"
+- One thought per line. Short sentences
+- Max 15-25 lines. Cut aggressively — 4 strong points beats 6 diluted
+- Shows process, not just result: "Стали рисерчить", "Собрали данные"
 - Casual, like talking to a friend who codes
 - Never corporate, never dry
-- RU-EN tech term mixing: "навайбкодить", "рисерчить"
-- CTA at end — casual, not pushy
+- RU-EN tech term mixing is fine
 
-Anti-patterns (NEVER):
+### FFMemes-specific overrides
+- **Speaker = FFMemes team, not Dan.** Use "мы" (we), "в боте" (in the bot), "наши юзеры" — NOT "я сделал" as if Dan is personally writing
+- **NO @danokhlopkov signature.** No `~ @danokhlopkov ~`, no link to Dan's personal channel. This is @ffmemes, not Dan's blog
+- **NO Dan's personal catchphrases.** Don't copy "И ХОБА", "хз", "жиза" verbatim — the vibe is casual but it's a product voice, not Dan's diary
+- **CTA links to @ffmemesbot or @ffmemes** — never to Dan's personal channels
+- **Vocabulary:** keep it casual (мб, кмк, го) but don't force Dan-specific slang into every post
+
+### Anti-patterns (NEVER)
 - Greetings of any kind
 - Corporate language ("в рамках данной статьи", "мы рады сообщить")
 - Numbered lists (1. 2. 3.) — use emoji bullets
 - Humble-bragging
 - Hedging: ИМХО, наверное, мне кажется
 - "Давайте разберёмся"
-
-Signature patterns:
-- "И ХОБА" — surprise twist
-- `~ @danokhlopkov ~` — post signature
-- Casual: мб, кмк, хз, кайф, жиза, го, чел
+- Writing as "I" (Dan) — you are the FFMemes team
+- Linking to @danokhlopkov — this is not Dan's channel
 
 ## Content Categories
 

--- a/specs/issues.md
+++ b/specs/issues.md
@@ -77,7 +77,7 @@
 ### M8: Scan Telegram Bot API for new features
 **Why**: New Bot API updates may unlock product improvements (button types, message formats, payments, mini-app enhancements). A new update is expected ~week of April 7, 2026.
 **Action**: After each Bot API update, read https://core.telegram.org/bots/api changelog. Map new features to ffmemesbot use cases. CEO or CTO should review.
-**Recurring**: Check quarterly or after each major TG update.
+**Recurring**: Check after each major TG Bot API update (typically every 1-2 months).
 
 ## Low (Nice to Have)
 

--- a/specs/issues.md
+++ b/specs/issues.md
@@ -1,6 +1,6 @@
 # Issues Backlog (Prioritized)
 
-> Last updated: 2026-03-20. Items marked ~~strikethrough~~ are DONE with commit reference.
+> Last updated: 2026-04-03. Items marked ~~strikethrough~~ are DONE with commit reference.
 
 ## Critical (Do First)
 
@@ -20,11 +20,10 @@
 
 ## High (Do Soon)
 
-### H1: Fix asyncpg connection contention
-**Why**: ~6 errors/day in Sentry (`InternalClientError: cannot switch to state`). Multiple async ops on same connection.
+### ~~H1: Fix asyncpg connection contention~~
+**DONE**: Multiple fixes shipped — ConnectionDoesNotExistError retry + pool invalidation (commit `225ad93`), configurable pool overflow + raised pool_timeout (commit `74d4e2d`), decoupled heavy meme stats from 15-min flow (commit `6ddfc95`), added missing DB indexes (commit `5fafe42`), fixed full-table scans (commit `9eec311`).
 **File**: `src/database.py`
-**Sentry**: FF-BACKEND-V3, FF-BACKEND-V9
-**Action**: Review connection pool checkout. Ensure each handler gets its own connection. Consider `pool_size` increase or per-request connection pattern.
+**Sentry**: FF-BACKEND-V3, FF-BACKEND-V9 — error rate dropped to near-zero after fixes.
 
 ### ~~H2: Fix blender random_seed=42~~
 **DONE**: Per-user seed with `random.Random(seed)` instance (commit from [experiment-2026-03-14.md](experiment-2026-03-14.md)).
@@ -67,6 +66,18 @@
 **Why**: 4x quality variance across sources (18% to 70% LR). No minimum quality floor.
 **Files**: `src/recommendations/candidates.py` (all engines)
 **Action**: Add minimum LR threshold for sources in recommendation engines. Sources below threshold only served to moderators.
+
+### M7: Telegram Mini App (WebApp)
+**Why**: Adding more bot commands doesn't scale for features like stats dashboard, leaderboard, burger coins history, or onboarding explainer. A Telegram Mini App opens a web page inside TG via auth button — better UX for information-dense screens.
+**What**: FastAPI auth endpoint (`/miniapp/auth` with TG `initData` validation) + lightweight frontend (React or vanilla). Backend data already exists — user_stats, meme_stats, burger balance.
+**Scope**: Don't build for read-only info alone. Bundle with the first interactive feature that needs web UI. Good project when we have 2+ features needing web surfaces.
+**Files**: New — `src/miniapp/` (auth + API), frontend TBD
+**See**: [Telegram Mini Apps docs](https://core.telegram.org/bots/webapps)
+
+### M8: Scan Telegram Bot API for new features
+**Why**: New Bot API updates may unlock product improvements (button types, message formats, payments, mini-app enhancements). A new update is expected ~week of April 7, 2026.
+**Action**: After each Bot API update, read https://core.telegram.org/bots/api changelog. Map new features to ffmemesbot use cases. CEO or CTO should review.
+**Recurring**: Check quarterly or after each major TG update.
 
 ## Low (Nice to Have)
 

--- a/src/tgbot/handlers/stats/wrapped.py
+++ b/src/tgbot/handlers/stats/wrapped.py
@@ -499,7 +499,11 @@ async def handle_wrapped_go(
         return await handle_wrapped_button(update, context)
 
     # Still generating — edit the button message with loading text
-    is_ru = cached.get("is_ru", _is_ru(update.effective_user.language_code)) if cached else _is_ru(update.effective_user.language_code)
+    is_ru = (
+        cached.get("is_ru", _is_ru(update.effective_user.language_code))
+        if cached
+        else _is_ru(update.effective_user.language_code)
+    )
     if cached and cached.get("lock"):
         stats = cached.get("stats_report")
         if stats and update.callback_query:


### PR DESCRIPTION
## Summary
- **Comms AGENTS.md**: Refined tone of voice — team voice ("мы") instead of Dan's personal voice, removed personal catchphrases, added content policy and mandatory image review before posting
- **specs/issues.md**: Marked H1 (asyncpg connection contention) as DONE (5 commits by agents), added M7 (Telegram Mini App idea) and M8 (Bot API feature scanning) to backlog
- **.gitignore**: Added `.env.*` pattern to prevent accidental secret commits (`.env.prod` was untracked with plaintext credentials)

## Context
Pre-vacation prep. Agents will be running autonomously April 1-14. This PR cleans up docs and makes sure comms agent has correct instructions.

## Test plan
- [ ] Verify comms agent posts use team voice after deploy
- [ ] Confirm .env.prod cannot be accidentally staged