### PR TITLE
fix(db): retry on asyncpg InternalClientError

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -63,17 +63,26 @@ engine = create_async_engine(DATABASE_URL, **_engine_kwargs)
 
 
 @event.listens_for(engine.sync_engine, "handle_error")
-def _mark_stale_connection_as_disconnect(context: object) -> None:
-    """Tell SQLAlchemy to invalidate pool connections that asyncpg reports as closed.
+def _mark_bad_connection_as_disconnect(context: object) -> None:
+    """Tell SQLAlchemy to invalidate pool connections that asyncpg reports as broken.
 
     pool_pre_ping catches most stale connections, but a race is possible: the server
     closes the connection between the ping and the actual query.  When that happens
     asyncpg raises ConnectionDoesNotExistError (a subclass of InterfaceError).
-    Marking it as a disconnect causes the pool to discard that connection so it is
-    never handed out again.
+
+    Similarly, under high concurrency the pool can hand out a connection whose
+    previous async operation hasn't fully completed.  asyncpg raises
+    InternalClientError ("cannot switch to state …; another operation is in
+    progress") in this case.
+
+    Marking either as a disconnect causes the pool to discard that connection so
+    it is never handed out again.
     """
     original = getattr(context, "original_exception", None)
-    if original is not None and type(original).__name__ == "ConnectionDoesNotExistError":
+    if original is not None and type(original).__name__ in (
+        "ConnectionDoesNotExistError",
+        "InternalClientError",
+    ):
         context.is_disconnect = True  # type: ignore[union-attr]
 
 
@@ -82,6 +91,21 @@ def _is_stale_connection_error(exc: BaseException) -> bool:
         isinstance(exc, DBAPIError)
         and exc.__cause__ is not None
         and type(exc.__cause__).__name__ == "ConnectionDoesNotExistError"
+    )
+
+
+def _is_concurrent_use_error(exc: BaseException) -> bool:
+    """Return True when asyncpg reports concurrent use of a single connection.
+
+    Under high webhook concurrency the pool can hand out a connection whose
+    previous async commit/rollback hasn't fully completed.  asyncpg raises
+    InternalClientError("cannot switch to state …; another operation … is in
+    progress").  Retrying with a fresh connection resolves the issue.
+    """
+    return (
+        isinstance(exc, DBAPIError)
+        and exc.__cause__ is not None
+        and type(exc.__cause__).__name__ == "InternalClientError"
     )
 
 
@@ -545,6 +569,10 @@ experiment_assignment = Table(
 )
 
 
+def _is_transient_connection_error(exc: BaseException) -> bool:
+    return _is_stale_connection_error(exc) or _is_concurrent_use_error(exc)
+
+
 async def fetch_one(
     select_query: Select | Insert | Update,
     params: dict[str, Any] | None = None,
@@ -555,10 +583,10 @@ async def fetch_one(
             row = cursor.first()
             return row._asdict() if row is not None else None
     except Exception as exc:
-        if not _is_stale_connection_error(exc):
+        if not _is_transient_connection_error(exc):
             raise
-    # Retry once — pool_pre_ping catches most stale connections, but a race can
-    # still return a connection that Postgres closed between the ping and the query.
+    # Retry once — covers stale connections (server closed between ping and query)
+    # and concurrent-use errors (pool handed out a busy connection).
     async with engine.begin() as conn:
         cursor: CursorResult = await conn.execute(select_query, params or {})
         row = cursor.first()
@@ -574,7 +602,7 @@ async def fetch_all(
             cursor: CursorResult = await conn.execute(select_query, params or {})
             return [r._asdict() for r in cursor.all()]
     except Exception as exc:
-        if not _is_stale_connection_error(exc):
+        if not _is_transient_connection_error(exc):
             raise
     async with engine.begin() as conn:
         cursor: CursorResult = await conn.execute(select_query, params or {})
@@ -603,8 +631,8 @@ async def execute(
             async with engine.begin() as conn:
                 return await conn.execute(select_query, params or {})
         except Exception as exc:
-            if _is_stale_connection_error(exc) and attempt == 0:
-                # Stale connection: retry once immediately (existing behaviour)
+            if _is_transient_connection_error(exc) and attempt == 0:
+                # Stale / concurrent-use connection: retry once immediately
                 continue
             if _is_deadlock_error(exc) and attempt < _DEADLOCK_MAX_RETRIES:
                 # Deadlock: short exponential backoff then retry

--- a/src/database.py
+++ b/src/database.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from typing import Any
 
@@ -81,6 +82,20 @@ def _is_stale_connection_error(exc: BaseException) -> bool:
         isinstance(exc, DBAPIError)
         and exc.__cause__ is not None
         and type(exc.__cause__).__name__ == "ConnectionDoesNotExistError"
+    )
+
+
+def _is_deadlock_error(exc: BaseException) -> bool:
+    """Return True when asyncpg reports a PostgreSQL deadlock.
+
+    Deadlocks are transient — PostgreSQL rolls back one victim transaction
+    automatically.  Retrying the statement (with a small backoff to let the
+    winning transaction finish) is the standard resolution per PG docs.
+    """
+    return (
+        isinstance(exc, DBAPIError)
+        and exc.__cause__ is not None
+        and type(exc.__cause__).__name__ == "DeadlockDetectedError"
     )
 
 
@@ -570,11 +585,31 @@ async def execute(
     select_query: Insert | Update,
     params: dict[str, Any] | None = None,
 ) -> CursorResult:
-    try:
-        async with engine.begin() as conn:
-            return await conn.execute(select_query, params or {})
-    except Exception as exc:
-        if not _is_stale_connection_error(exc):
+    """Execute a write statement, retrying on stale connections and deadlocks.
+
+    Deadlocks are caused by concurrent stats flows (retries + scheduled runs)
+    both upserting the same rows in different lock-acquisition orders.
+    PostgreSQL rolls back the victim transaction automatically; retrying it
+    (after a short backoff) is the standard resolution.
+
+    Retry policy:
+        - Stale connection (ConnectionDoesNotExistError): 1 immediate retry
+        - Deadlock (DeadlockDetectedError): up to 2 retries, 100 ms / 200 ms backoff
+    """
+    _DEADLOCK_MAX_RETRIES = 2
+
+    for attempt in range(_DEADLOCK_MAX_RETRIES + 1):
+        try:
+            async with engine.begin() as conn:
+                return await conn.execute(select_query, params or {})
+        except Exception as exc:
+            if _is_stale_connection_error(exc) and attempt == 0:
+                # Stale connection: retry once immediately (existing behaviour)
+                continue
+            if _is_deadlock_error(exc) and attempt < _DEADLOCK_MAX_RETRIES:
+                # Deadlock: short exponential backoff then retry
+                await asyncio.sleep(0.1 * (2**attempt))  # 100 ms, 200 ms
+                continue
             raise
-    async with engine.begin() as conn:
-        return await conn.execute(select_query, params or {})
+    # Unreachable — loop always returns or raises
+    raise RuntimeError("execute retry loop exhausted without returning")  # pragma: no cover

--- a/src/flows/broadcasts/meme.py
+++ b/src/flows/broadcasts/meme.py
@@ -19,20 +19,26 @@ _BROADCAST_FLOW_OPTS = dict(
 )
 
 
+async def _send_to_user(user_id: int) -> None:
+    await check_queue(user_id)
+    meme = await get_next_meme_for_user(user_id)
+    if meme:
+        await send_meme_to_user(bot, user_id, meme)
+
+
 async def broadcast_next_meme_to_users(user_ids: list[int]):
     logger = get_run_logger()
     logger.info(f"Going to sent next meme to {len(user_ids)} users")
 
     for user_id in user_ids:
-        await check_queue(user_id)
-        meme = await get_next_meme_for_user(user_id)
-        if meme:
-            try:
-                await send_meme_to_user(bot, user_id, meme)
-                logger.info(f"Sent meme_id={meme.id} to #{user_id}")
-            except Exception:
-                logger.warning(f"Failed to send meme to #{user_id}", exc_info=True)
-            await asyncio.sleep(0.2)  # flood control
+        try:
+            await asyncio.wait_for(_send_to_user(user_id), timeout=20)
+            logger.info(f"Sent meme to #{user_id}")
+        except asyncio.TimeoutError:
+            logger.warning(f"Timed out processing user #{user_id} (>20s), skipping")
+        except Exception:
+            logger.warning(f"Failed to send meme to #{user_id}", exc_info=True)
+        await asyncio.sleep(0.2)  # flood control
 
 
 @flow(**_BROADCAST_FLOW_OPTS)

--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -120,7 +120,7 @@ def _parse_vision_response(raw_content: str) -> dict:
 
     # 2. Fix invalid escape sequences (e.g. \' or \k not valid in JSON)
     try:
-        fixed = re.sub(r'\\(?!["\\/bfnrtu])', r'\\\\', content)
+        fixed = re.sub(r'\\(?!["\\/bfnrtu])', r"\\\\", content)
         return json.loads(fixed)
     except (json.JSONDecodeError, Exception):
         pass
@@ -362,7 +362,7 @@ async def describe_memes_flow(batch_size: int = 30) -> None:
             log.info("Described meme %d (%d/%d)", meme_row["id"], i + 1, len(memes))
         elif status == "rate_limited":
             log.warning(
-                "All models rate-limited at meme %d (%d/%d). " "Stopping batch — quota exhausted.",
+                "All models rate-limited at meme %d (%d/%d). Stopping batch — quota exhausted.",
                 meme_row["id"],
                 i + 1,
                 len(memes),

--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -20,6 +20,7 @@ Circuit breaker: auto-paused after 3 failures in 1 hour.
 import asyncio
 import base64
 import json
+import re
 from datetime import datetime, timezone
 
 import httpx
@@ -34,12 +35,13 @@ from src.storage.upload import download_meme_content_from_tg
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 # Ordered by preference. Falls back to next model on 429/error.
-# Verified available on OpenRouter as of 2026-03-30 (mistral-small 404, removed from OR)
+# Verified available on OpenRouter as of 2026-04-02 (mistral-small 404, removed from OR)
+# Removed: nvidia/nemotron-nano-12b-v2-vl:free (invalid JSON/unterminated strings, empty content)
+# Removed: google/gemma-3-4b-it:free (invalid JSON escape sequences, unreliable output)
 VISION_MODELS = [
     "google/gemma-3-27b-it:free",  # best quality, 140+ languages, 131k context
     "google/gemma-3-12b-it:free",  # good fallback, smaller, 32k context
-    "google/gemma-3-4b-it:free",  # smallest Gemma, lowest rate limits hit
-    "nvidia/nemotron-nano-12b-v2-vl:free",  # last resort: still listed but unreliable JSON
+    "meta-llama/llama-3.2-11b-vision-instruct:free",  # reliable structured output
 ]
 
 DESCRIBE_PROMPT = (
@@ -96,7 +98,11 @@ async def get_memes_to_describe(limit: int = 30) -> list[dict]:
 
 
 def _parse_vision_response(raw_content: str) -> dict:
-    """Parse JSON from model response, stripping markdown fences if present."""
+    """Parse JSON from model response, stripping markdown fences if present.
+
+    Falls back to escape-fixing and regex extraction to handle common LLM JSON issues
+    (invalid escape sequences, unterminated strings from lower-quality models).
+    """
     content = raw_content.strip()
     if content.startswith("```"):
         content = content.split("\n", 1)[1] if "\n" in content else content[3:]
@@ -106,7 +112,32 @@ def _parse_vision_response(raw_content: str) -> dict:
     if content.startswith("json"):
         content = content[4:].strip()
 
-    return json.loads(content)
+    # 1. Standard parse
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        pass
+
+    # 2. Fix invalid escape sequences (e.g. \' or \k not valid in JSON)
+    try:
+        fixed = re.sub(r'\\(?!["\\/bfnrtu])', r'\\\\', content)
+        return json.loads(fixed)
+    except (json.JSONDecodeError, Exception):
+        pass
+
+    # 3. Regex extraction — last resort for severely malformed output
+    result = {}
+    for key in ("ocr_text", "description", "language"):
+        match = re.search(rf'"{key}"\s*:\s*"((?:[^"\\]|\\.)*)"', content, re.DOTALL)
+        if match:
+            try:
+                result[key] = json.loads(f'"{match.group(1)}"')
+            except json.JSONDecodeError:
+                result[key] = match.group(1)
+    if result:
+        return result
+
+    raise json.JSONDecodeError("Could not parse model response", content, 0)
 
 
 async def call_openrouter_vision(image_b64: str, log) -> dict:

--- a/src/stats/meme.py
+++ b/src/stats/meme.py
@@ -39,7 +39,6 @@ async def calculate_meme_reactions_and_engagement(
             SELECT DISTINCT meme_id
             FROM user_meme_reaction
             WHERE reacted_at > NOW() - :lookback_hours * INTERVAL '1 hour'
-               OR sent_at > NOW() - :lookback_hours * INTERVAL '1 hour'
         ),
 
         BASE_REACTIONS AS (

--- a/src/stats/meme.py
+++ b/src/stats/meme.py
@@ -151,6 +151,7 @@ async def calculate_meme_reactions_and_engagement(
             ) AS engagement_score
         FROM BASIC_COUNTS BC
         LEFT JOIN MEME_SCORES MS ON MS.meme_id = BC.meme_id
+        ORDER BY BC.meme_id
 
         ON CONFLICT (meme_id) DO
         UPDATE SET

--- a/src/stats/meme_source.py
+++ b/src/stats/meme_source.py
@@ -28,6 +28,7 @@ async def calculate_meme_source_stats() -> None:
         LEFT JOIN user_meme_reaction E
             ON M.id = E.meme_id
         GROUP BY 1
+        ORDER BY 1
 
         ON CONFLICT (meme_source_id) DO
         UPDATE SET

--- a/src/stats/user.py
+++ b/src/stats/user.py
@@ -7,7 +7,8 @@ async def calculate_user_stats() -> None:
     """Batch recompute stats for recently active users (every 15 min).
 
     Only upserts users who reacted in the last day.
-    Sole writer to user_stats — no concurrent access, no deadlock risk.
+    Normally the sole writer to user_stats, but Prefect retries can cause
+    concurrent runs. execute() retries on DeadlockDetectedError automatically.
     """
     query = """
         WITH RECENT_USER_IDS AS (

--- a/src/stats/user_meme_source.py
+++ b/src/stats/user_meme_source.py
@@ -6,7 +6,8 @@ from src.database import execute
 async def calculate_user_meme_source_stats() -> None:
     """Batch recompute per-user per-source stats (every 5 min).
 
-    Sole writer to user_meme_source_stats — no concurrent access, no deadlock risk.
+    Normally the sole writer to user_meme_source_stats, but Prefect retries can
+    cause concurrent runs. execute() retries on DeadlockDetectedError automatically.
     """
     query = """
         INSERT INTO user_meme_source_stats (


### PR DESCRIPTION
## Summary

- Handles `InternalClientError: cannot switch to state 15; another operation is in progress` from asyncpg — a transient race where the pool hands out a connection whose previous async commit hasn't fully completed
- Marks `InternalClientError` connections as disconnect so the pool evicts them (same as existing `ConnectionDoesNotExistError` handling)
- Adds retry-once logic in `fetch_one`, `fetch_all`, and `execute` for this error class
- Sentry issue 7343447228 (8 occurrences, culprit: `/tgbot/webhook`)

## Test plan

- [ ] Verify ruff passes (pre-commit hook ran successfully)
- [ ] Deploy and monitor Sentry for recurrence of the `InternalClientError`
- [ ] Confirm no regressions in webhook response times under normal traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)