### PR TITLE
fix(reaction): await update_user_last_active_at to reduce DB pool contention

### DIFF
--- a/src/tgbot/handlers/reaction.py
+++ b/src/tgbot/handlers/reaction.py
@@ -31,7 +31,7 @@ async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     # do that in sync since we'll use counters in next_message
     user_info = await update_user_info_counters(user_id)
     await maybe_send_moderator_invite(context.bot, user_id, user_info)
-    _fire_and_forget(update_user_last_active_at(user_id))
+    await update_user_last_active_at(user_id)
     _fire_and_forget(reward_user_for_daily_activity(user_id))
 
     reaction_is_new = await update_user_meme_reaction(


### PR DESCRIPTION
## Summary
- Await `update_user_last_active_at` instead of fire-and-forget in `handle_reaction`
- Reduces concurrent DB pool connections during reaction handling
- Fixes recurring asyncpg "cannot switch to state" errors (FF-BACKEND-V9, 8 events since Mar 18)

## Context
`_fire_and_forget` creates background asyncio tasks that grab DB pool connections concurrently with the main handler. Under high webhook load, this causes asyncpg to report "cannot switch to state 15; another operation is in progress" when the pool hands out a connection before its previous operation fully completes.

`update_user_last_active_at` is a simple `UPDATE user SET last_active_at = ...` — no reason for it to be fire-and-forget. `reward_user_for_daily_activity` stays fire-and-forget because it may call `bot.send_message()`.

## Test plan
- [ ] Verify reaction handling still works (like/dislike sends next meme)
- [ ] Monitor Sentry FF-BACKEND-V9 for reduced occurrence