### PR TITLE
fix(alembic): resolve migration cycle from duplicate revision ID

### DIFF
--- a/alembic/versions/2026-04-01_deep_link_log_index.py
+++ b/alembic/versions/2026-04-01_deep_link_log_index.py
@@ -5,7 +5,7 @@ sequential scan of user_deep_link_log on every stats run (hourly). The pattern
 has a constant prefix 's_' so a B-tree index is sufficient for the planner to
 use an index scan.
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 6c67d32f7db5
 Revises: f6a7b8c9d0e1
 Create Date: 2026-04-01 00:00:00.000000
 
@@ -14,7 +14,7 @@ Create Date: 2026-04-01 00:00:00.000000
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "a1b2c3d4e5f6"
+revision = "6c67d32f7db5"
 down_revision = "f6a7b8c9d0e1"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- `2026-04-01_deep_link_log_index.py` reused revision ID `a1b2c3d4e5f6` already taken by `2026-03-15_engagement_score.py`
- This created a cycle that blocked `alembic upgrade head`, breaking all CI tests for 3+ days
- Assigned new unique revision ID `6c67d32f7db5`

## Impact
- **CI**: Unblocks all tests (migration cycle was the only failure)
- **Prod DB**: Currently at `e5f6a7b8c9d0` (before both April 1 migrations). Next deploy will apply the two pending index migrations cleanly. No manual `alembic_version` update needed.

## Test plan
- [ ] CI passes (migration cycle resolved, tests can create tables)
- [ ] Verify `alembic upgrade head` works on fresh DB