### PR TITLE
fix(describe_memes): graceful exit on OpenRouter quota exhaustion + ruff format

### DIFF
--- a/specs/describe-memes.md
+++ b/specs/describe-memes.md
@@ -89,6 +89,7 @@ Stored in `meme.ocr_result` JSONB:
 
 - **Per-meme**: 3 failures tracked in `ocr_result.describe_failures`, then skipped
 - **Per-batch**: 3 consecutive failures → batch stops early
+- **Quota exhausted**: HTTP 402 → immediate batch exit on first occurrence (no model fallback — 402 is account-wide)
 - **Rate limit**: all models return 429 → batch stops, waits for next cron run
 - **Circuit breaker**: Prefect automation pauses deployment after 3 flow failures/hour
 

--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -76,6 +76,7 @@ DESCRIBE_PROMPT = (
 # Sentinel return values from call_openrouter_vision
 RATE_LIMITED = "__rate_limited"
 ALL_FAILED = "__all_failed"
+QUOTA_EXHAUSTED = "__quota_exhausted"
 
 
 async def get_memes_to_describe(limit: int = 30) -> list[dict]:
@@ -204,6 +205,14 @@ async def call_openrouter_vision(image_b64: str, log, *, deadline: float | None 
                     json=payload,
                 )
 
+                if response.status_code == 402:
+                    log.warning(
+                        "OpenRouter quota exhausted (HTTP 402). "
+                        "Balance likely below $0 — all models blocked. "
+                        "Check https://openrouter.ai/settings/credits"
+                    )
+                    return {QUOTA_EXHAUSTED: True}
+
                 if response.status_code == 429:
                     log.debug("Model %s rate-limited, trying next...", model_id)
                     rate_limited_count += 1
@@ -300,6 +309,9 @@ async def describe_single_meme(meme_row: dict, log, *, deadline: float | None = 
 
     if result.get(RATE_LIMITED):
         return "rate_limited"
+
+    if result.get(QUOTA_EXHAUSTED):
+        return "quota_exhausted"
 
     if result.get(ALL_FAILED):
         await _increment_describe_failures(meme_id, existing_ocr, "all models failed")
@@ -433,7 +445,17 @@ async def describe_memes_flow(batch_size: int = 20) -> None:
             log.info("Described meme %d (%d/%d)", meme_row["id"], i + 1, len(memes))
         elif status == "rate_limited":
             log.warning(
-                "All models rate-limited at meme %d (%d/%d). Stopping batch — quota exhausted.",
+                "All models rate-limited at meme %d (%d/%d). Stopping batch.",
+                meme_row["id"],
+                i + 1,
+                len(memes),
+            )
+            break
+        elif status == "quota_exhausted":
+            log.warning(
+                "OpenRouter quota exhausted at meme %d (%d/%d). "
+                "Stopping batch — balance likely below $0. "
+                "Top up at https://openrouter.ai/settings/credits",
                 meme_row["id"],
                 i + 1,
                 len(memes),

--- a/src/storage/etl.py
+++ b/src/storage/etl.py
@@ -382,10 +382,10 @@ async def update_or_create_memes(transformed_memes, memes_not_in_memes_table):
             FROM meme_source
             JOIN meme_raw_ig MRI
               ON MRI.meme_source_id = meme_source.id
-              AND MRI.id = meme.raw_meme_id
             WHERE meme.status = 'broken_content_link'
               AND meme_source.id = meme.meme_source_id
               AND meme_source.type = 'instagram'
+              AND MRI.id = meme.raw_meme_id
               AND COALESCE(MRI.updated_at, MRI.created_at) >= NOW() - INTERVAL '24 hours'
             """
         )
@@ -399,10 +399,10 @@ async def update_or_create_memes(transformed_memes, memes_not_in_memes_table):
             FROM meme_source
             JOIN meme_raw_ig MRI
               ON MRI.meme_source_id = meme_source.id
-              AND MRI.id = meme.raw_meme_id
             WHERE meme.status = 'broken_content_link'
               AND meme_source.id = meme.meme_source_id
               AND meme_source.type = 'instagram'
+              AND MRI.id = meme.raw_meme_id
               AND COALESCE(MRI.updated_at, MRI.created_at) < NOW() - INTERVAL '24 hours'
             """
         )

--- a/tests/recommendations/test_engine_contracts.py
+++ b/tests/recommendations/test_engine_contracts.py
@@ -186,9 +186,9 @@ async def test_best_uploaded_memes_only_from_user_upload_source(base_data):
     results = await retriever.get_candidates("best_uploaded_memes", USER_ID, limit=50)
     assert len(results) > 0
     for r in results:
-        assert r["id"] in range(10006, 10009), (
-            f"best_uploaded_memes returned meme {r['id']} not from user upload source"
-        )
+        assert r["id"] in range(
+            10006, 10009
+        ), f"best_uploaded_memes returned meme {r['id']} not from user upload source"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **`9483196` fix(describe_memes): graceful exit on OpenRouter quota exhaustion (HTTP 402)** — prevents describe_memes from crashing when OpenRouter returns 402 (quota exhausted)
- **`91b4105` style: fix ruff formatting in test_engine_contracts.py** — formatting only

## Context

Follow-up to PR #170 (IG retry SQL fix). These are the remaining 2 of 3 post-PR#169 hotfixes from `feat/goat-recency-filter-reacted-at`.

## Test plan

- [x] Ruff lint + format passes
- [ ] Verify describe_memes handles 402 gracefully in production logs after deploy