### PR TITLE
fix: prioritize OCR for recently uploaded memes

### DIFF
--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -76,9 +76,12 @@ ALL_FAILED = "__all_failed"
 
 
 async def get_memes_to_describe(limit: int = 30) -> list[dict]:
-    """Get image memes without descriptions, ordered by likes (most liked first).
+    """Get image memes without descriptions.
 
-    Prioritizes memes that active users have liked — directly improves Wrapped coverage.
+    Priority order:
+    1. Recently uploaded memes (last 24h) — enables dedup for user uploads
+    2. Most liked memes — improves Wrapped coverage
+
     Skips memes that have failed 3+ times (tracked in ocr_result.describe_failures).
     """
     from sqlalchemy import text
@@ -92,6 +95,7 @@ async def get_memes_to_describe(limit: int = 30) -> list[dict]:
             M.language_code
         FROM meme M
         LEFT JOIN meme_stats MS ON MS.meme_id = M.id
+        LEFT JOIN meme_source SRC ON SRC.id = M.meme_source_id
         WHERE M.type = 'image'
             AND M.status = 'ok'
             AND M.telegram_file_id IS NOT NULL
@@ -100,7 +104,12 @@ async def get_memes_to_describe(limit: int = 30) -> list[dict]:
                 OR M.ocr_result->>'description' IS NULL
             )
             AND COALESCE((M.ocr_result->>'describe_failures')::int, 0) < 3
-        ORDER BY COALESCE(MS.nlikes, 0) DESC, M.id DESC
+        ORDER BY
+            CASE WHEN SRC.type = 'user upload'
+                 AND M.created_at > now() - interval '24 hours'
+                 THEN 0 ELSE 1 END,
+            COALESCE(MS.nlikes, 0) DESC,
+            M.id DESC
         LIMIT :limit
     """
     ).bindparams(limit=limit)


### PR DESCRIPTION
## Summary

- Uploaded memes with 0 likes were never getting OCR'd because `describe_memes` batch ordered by `nlikes DESC`
- Now recently uploaded memes (last 24h) are processed first in the OCR batch via a `CASE WHEN` boost in ORDER BY
- This enables text-based dedup for uploaded memes (future uploads/parses can match against OCR'd uploaded memes)

## Context

Investigation found that two similar memes (#10119258 and #10119248) weren't deduplicated because:
1. Dedup for uploads is commented out in `moderation.py`
2. Both memes had NULL `ocr_result` — uploaded memes never got OCR'd due to 0 likes
3. Different `telegram_file_id`s, so file_id dedup couldn't help

This is the first step: get OCR running on uploads so dedup has data to work with.

## Test plan

- [ ] Verify the SQL query runs correctly (LEFT JOIN meme_source + CASE WHEN ordering)
- [ ] Check that recently uploaded memes appear at top of `get_memes_to_describe()` results
- [ ] Confirm no regression for non-upload memes (still ordered by nlikes DESC)