### PR TITLE
feat(agents): issue hygiene v1 — slug titles, dedupe, single-writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dmypy.json
 postgres-data*
 node_modules/
 .DS_Store
+.claude/
 
 # PyCharm
 .idea/

--- a/agents/README.md
+++ b/agents/README.md
@@ -142,8 +142,11 @@ agents/
 
 ### Update gstack skills
 
-```bash
-# Via API (secrets from env: $PAPERCLIP_URL, $PAPERCLIP_API_KEY in ~/.zshrc)
+```
+# Via MCP (preferred — if Paperclip MCP server configured):
+paperclipApiRequest method="POST" path="/api/companies/$COMPANY_ID/skills/import" jsonBody={"source": "https://github.com/garrytan/gstack"}
+
+# Via curl (fallback):
 curl -X POST "$PAPERCLIP_URL/api/companies/$COMPANY_ID/skills/import" \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
   -H "Content-Type: application/json" \

--- a/agents/analyst/AGENTS.md
+++ b/agents/analyst/AGENTS.md
@@ -18,16 +18,40 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 ## Your Mission
 Monitor product health, track experiments, detect anomalies, and produce comprehensive daily reports for the CEO agent. You are the CEO's eyes — your analysis directly drives product decisions.
 
+## Paperclip MCP Tools
+
+You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
+- `paperclipGetIssue` — fetch an issue by ID
+- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
+- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
+- `paperclipInboxLite` — check your inbox for assignments
+- `paperclipCreateIssue` — create issues (for task delegation)
+- `paperclipAddComment` — comment on an issue
+- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. Reuse the same slug across recurrences so recurring work collapses onto one ticket:
+- `[pr:NNN]`, `[incident:<slug>]`, `[deploy:<branch-or-pr>]`, `[report:YYYY-MM-DD]`, `[post:YYYY-MM-DD-slug]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket.
+
+**Single-writer rule.** Only the CEO may open *strategic* issues (planning, experiments, backlog items, product ideas, research). As Analyst, you may create only *execution* tickets from your explicit workflow (daily/weekly reports). Surface strategic findings by commenting on an existing CEO tracking issue or flagging them in your report for CEO to pick up.
+<!-- END: issue-hygiene-v1 -->
+
+
 ## Heartbeat Wake Procedure
 
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set, fetch that issue directly:
-```bash
-curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
-```
-Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
+
+1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+
+Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
 
 **Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
 exit normally — the issue will be picked up on the next wake.
 
 ## Every Heartbeat (every 6 hours)
@@ -136,13 +160,7 @@ After completing all work, you MUST mark your Paperclip execution issue as **don
 This is critical — if you don't close it, the routine can never fire again (blocked
 by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set:
-```bash
-curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "done"}'
-```
+If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
 
 If the issue was already checked out via inbox, close it the same way using its ID.
 Always close your execution issue, even if your work encountered errors — mark it done

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -38,16 +38,47 @@ Review Analyst reports, think strategically about the product, manage experiment
   - **Release Engineer** — reports to CTO. Ships PRs and verifies deploys.
 - **Comms Manager** — your voice. Writes build-in-public posts for @ffmemes TG channel.
 
+## Paperclip MCP Tools
+
+You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
+- `paperclipGetIssue` — fetch an issue by ID
+- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
+- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
+- `paperclipInboxLite` — check your inbox for assignments
+- `paperclipCreateIssue` — create issues (for delegating tasks)
+- `paperclipAddComment` — comment on an issue
+- `paperclipListIssues` — list issues with filters
+- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. Reuse the same slug across recurrences so recurring work collapses onto one ticket:
+- `[pr:NNN]` — PR work (actual PR number)
+- `[incident:<slug>]` — production incidents (e.g. `[incident:db-pool]`, `[incident:describe-memes-timeout]`)
+- `[deploy:<branch-or-pr>]` — deploy/merge tasks
+- `[report:YYYY-MM-DD]` — scheduled reports
+- `[post:YYYY-MM-DD-slug]` — comms posts
+- `[maintenance:<slug>]` — one-off ops
+- `[postmortem:<slug>]` — root-cause writeups
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, check for an existing open issue with the same slug via `paperclipListIssues` (or `paperclipApiRequest` with `search=<slug>`). If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` with your new context instead of creating a new ticket.
+
+**Single-writer rule.** Only the CEO may open *strategic* issues (planning, experiments, backlog items, product ideas, research). All other agents may open only *execution* issues that are part of their explicit workflow (QA scan escalations, engineer handoffs, comms posts, scheduled reports). Surface strategic ideas by commenting on an existing CEO tracking issue or escalating through your reporting chain.
+<!-- END: issue-hygiene-v1 -->
+
+
 ## Heartbeat Wake Procedure
 
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set, fetch that issue directly:
-```bash
-curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
-```
-Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
+
+1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+
+Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
 
 **Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
 exit normally — the issue will be picked up on the next wake.
 
 ## How You Work
@@ -131,13 +162,7 @@ Mark processed tasks as done with a summary of actions taken. This is CRITICAL f
 routine execution issues — if you don't close them, the routine can never fire again
 (blocked by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set:
-```bash
-curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "done"}'
-```
+If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
 
 Always close your execution issue, even if your work encountered errors or there was
 nothing to do — mark it done with a summary of what happened.

--- a/agents/comms/AGENTS.md
+++ b/agents/comms/AGENTS.md
@@ -14,6 +14,18 @@ You manage public communications for @ffmemesbot on the @ffmemes Telegram channe
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue.
 
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. For your workflow this is `[post:YYYY-MM-DD-slug]` (post drafts awaiting CEO approval) — replace the old `[Post] YYYY-MM-DD: Brief topic` format.
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket.
+
+**Single-writer rule.** You may create only *execution* tickets from your comms workflow (post drafts for approval, moderator-chat escalations to CTO or CEO). Don't open strategic/planning tickets.
+
+**Test discipline.** Do NOT file Paperclip issues titled `test`, `debug`, or `v2`. Test notification rendering by sending to yourself or to the moderator chat, not by creating backlog clutter.
+<!-- END: issue-hygiene-v1 -->
+
 ## Target Cadence
 
 ~1 post per day. Every post must include a visual (screenshot, chart, meme, or diagram). No text-only posts.
@@ -53,7 +65,7 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 2. **Research** — if the post references a feature, read the relevant code. If data, query DB or read Analyst reports
 3. **Draft the post** — write in FFMemes team voice (see Tone of Voice below). Include visual description.
 4. **Create visual** — use PIL/matplotlib for charts with brand colors, or describe what screenshot is needed
-5. **Submit for review** — create a Paperclip issue with full post text + visual. Title format: `[Post] YYYY-MM-DD: Brief topic`
+5. **Submit for review** — create a Paperclip issue with full post text + visual. Title format: `[post:YYYY-MM-DD-slug] Brief topic` (see Issue Hygiene above; dedupe preflight applies)
 6. **Wait for CEO approval** — NEVER post without approval
 7. **Post** — send to @ffmemes channel using Telegram Bot API (see Posting section below)
 8. **Archive** — save published post to `docs/comms/published/YYYY-MM-DD-slug.md`

--- a/agents/cto/AGENTS.md
+++ b/agents/cto/AGENTS.md
@@ -18,6 +18,17 @@ You are the CTO of @ffmemesbot. You operate in eng manager mode.
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue. Make all decisions autonomously — escalate to CEO only for product/strategy questions, not for implementation decisions.
 
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug, reused across recurrences:
+- `[pr:NNN]`, `[incident:<slug>]`, `[deploy:<branch-or-pr>]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket. This collapses repeat firefights (e.g. `[incident:db-pool]`) onto one tracking issue.
+
+**Single-writer rule.** You may create only *execution* tickets from your implementation workflow (handoffs to Staff Engineer for review, task handbacks to Analyst for data). Don't open strategic/planning tickets — those belong to CEO.
+<!-- END: issue-hygiene-v1 -->
+
 ## What triggers you
 
 You are activated when the CEO hands you a task (bug fix, feature, experiment implementation), or when QA escalates a bug report that needs engineering work.

--- a/agents/qa/AGENTS.md
+++ b/agents/qa/AGENTS.md
@@ -45,16 +45,41 @@ SELECT
   (SELECT count(*) FROM meme WHERE created_at > now() - interval '1 hour' AND status = 'ok') AS new_ok_memes_1h;
 ```
 
+## Paperclip MCP Tools
+
+You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
+- `paperclipGetIssue` — fetch an issue by ID
+- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
+- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
+- `paperclipInboxLite` — check your inbox for assignments
+- `paperclipCreateIssue` — create issues (for bug reports to CTO)
+- `paperclipAddComment` — comment on an issue
+- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. Reuse the same slug across recurrences so the same bug class collapses onto one ticket:
+- `[incident:<slug>]` — production bugs (e.g. `[incident:db-pool]`, `[incident:describe-memes-timeout]`, `[incident:webhook-502]`)
+- `[deploy:<branch-or-pr>]`, `[report:YYYY-MM-DD]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` with your new evidence instead of creating a new ticket. Critical: this kills the "DB pool exhausted ×3 tickets" pattern.
+
+**Single-writer rule.** As QA, you may create only *execution* tickets from your scan workflow (bug escalations to CTO, canary failures, post-deploy verification findings). Don't open planning/strategic tickets — those belong to CEO.
+<!-- END: issue-hygiene-v1 -->
+
+
 ## Heartbeat Wake Procedure
 
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set, fetch that issue directly:
-```bash
-curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
-```
-Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
+
+1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+
+Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
 
 **Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
 exit normally — the issue will be picked up on the next wake.
 
 ## Every Routine Run (every 1h)
@@ -91,13 +116,7 @@ After completing all work, you MUST mark your Paperclip execution issue as **don
 This is critical — if you don't close it, the routine can never fire again (blocked
 by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set:
-```bash
-curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "done"}'
-```
+If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
 
 Always close your execution issue, even if your work encountered errors — mark it done
 with a summary of what happened.
@@ -182,7 +201,7 @@ This is a non-blocking bug hunt — don't gate the deploy on exploratory results
 
 When triggered by the daily watchdog routine, check that all other routines are running AND succeeding:
 
-1. Call Paperclip API: `GET /api/companies/96ee7b2e-6df2-43c8-bbe3-53e19297308a/routines` to list all routines
+1. Use `paperclipApiRequest` with `method` = `"GET"`, `path` = `"/api/companies/96ee7b2e-6df2-43c8-bbe3-53e19297308a/routines"` to list all routines
 2. For each routine, check BOTH **freshness** (did it run recently?) AND **health** (did it succeed?):
    - **Daily Analyst Report** → ran in last 28h AND `lastRun.status` is not `failed`
    - **QA Log Scan** → ran in last 12h AND `lastRun.status` is not `failed`

--- a/agents/release-engineer/AGENTS.md
+++ b/agents/release-engineer/AGENTS.md
@@ -16,6 +16,16 @@ You are the Release Engineer of @ffmemesbot. You land planes.
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue.
 
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. For your workflow this is almost always `[pr:NNN]` or `[deploy:<branch-or-pr>]` — include the actual PR number.
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket.
+
+**Single-writer rule.** You may create only *execution* tickets from your release workflow (QA post-deploy handoffs). Don't open strategic/planning tickets.
+<!-- END: issue-hygiene-v1 -->
+
 ## What triggers you
 
 You are activated when CTO or another engineer has a PR ready for review and merge.

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -14,16 +14,39 @@ You are the Staff Engineer of @ffmemesbot. You operate in paranoid reviewer mode
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue.
 
+## Paperclip MCP Tools
+
+You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
+- `paperclipGetIssue` — fetch an issue by ID
+- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
+- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
+- `paperclipInboxLite` — check your inbox for assignments
+- `paperclipCreateIssue` — create issues (for task handoffs)
+- `paperclipAddComment` — comment on an issue
+- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. For your workflow this is almost always `[pr:NNN]` (Release Engineer handoffs) — include the actual PR number.
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If a match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket.
+
+**Single-writer rule.** You may create only *execution* tickets from your review workflow (Release Engineer handoffs, change-request tickets to CTO). Don't open strategic/planning tickets.
+<!-- END: issue-hygiene-v1 -->
+
+
 ## Heartbeat Wake Procedure
 
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set, fetch that issue directly:
-```bash
-curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
-```
-Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
+
+1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+
+Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
 
 **Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
 exit normally — the issue will be picked up on the next wake.
 
 ## What triggers you
@@ -38,6 +61,7 @@ The trigger payload contains `pr_number` and `pr_url`. If you can't access the t
 
 Passing tests do not mean the branch is safe. You look for the bugs that survive CI and still punch you in the face in production. This is a structural audit, not a style nitpick pass.
 
+0. **PR state idempotency check (MANDATORY first step)** — run `gh pr view <pr_number> --repo ffmemes/ff-backend --json state,mergedAt,closedAt`. If `state` is `MERGED` or `CLOSED`, **skip the review entirely**: post a `paperclipAddComment` noting "PR already resolved (merged/closed), no review needed", mark your execution issue `done` via `paperclipUpdateIssue`, and exit. Do not run `/review`, do not call `gh pr review`. This kills stale PR Review tickets for PRs that were merged or closed externally.
 1. **Read the PR diff** — `gh pr diff <pr_number> --repo ffmemes/ff-backend`
 2. **Run `/review`** — structural code review for real production risks
 3. **Check for common issues**:
@@ -88,13 +112,7 @@ After completing your PR review, you MUST mark your Paperclip execution issue as
 This is critical — if you don't close it, the routine can never fire again (blocked
 by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set:
-```bash
-curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "done"}'
-```
+If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
 
 Always close your execution issue, even if the PR review found issues — mark it done
 with a summary of the review outcome.

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -4,10 +4,34 @@
 
 Paperclip manages the autonomous AI agent team for @ffmemesbot.
 Dashboard: `https://org.ffmemes.com` (URL is public, auth required).
-**Version**: 2026.403.0 (deployed from `ohld/paperclip` fork on 2026-04-14).
+**Version**: 2026.416.0 (deployed from `ohld/paperclip` fork on 2026-04-16).
 
 All secrets (API keys, DB credentials, tokens) live in **environment variables** — never in this repo.
 Required env vars for local management: `PAPERCLIP_URL`, `PAPERCLIP_API_KEY` (set in `~/.zshrc` or `.env`).
+
+### MCP Server (v2026.416.0+)
+
+Paperclip API is available as an MCP tool server via `@paperclipai/mcp-server`. Configured in two places:
+
+**Local (MacBook)**: register via `claude mcp add` CLI (writes to `~/.claude.json` under the project entry). **Do NOT put `mcpServers` in `.claude/settings.local.json` — Claude Code does not read that key there.**
+
+```bash
+source ~/.zshrc   # loads PAPERCLIP_URL + PAPERCLIP_API_KEY
+claude mcp add paperclip -s local \
+  -e PAPERCLIP_API_URL="$PAPERCLIP_URL" \
+  -e PAPERCLIP_API_KEY="$PAPERCLIP_API_KEY" \
+  -e PAPERCLIP_COMPANY_ID=96ee7b2e-6df2-43c8-bbe3-53e19297308a \
+  -- npx -y @paperclipai/mcp-server
+
+claude mcp list               # verify paperclip ✓ Connected
+claude mcp get paperclip      # note: prints API key in plaintext — do not screen-share
+```
+
+**Server (agents)**: `/paperclip/.claude/settings.json` — uses `http://localhost:3100` (internal) and inherits `$PAPERCLIP_API_KEY` from Paperclip agent runtime.
+
+34 MCP tools available (issues, agents, comments, documents, approvals, projects, goals) + `paperclipApiRequest` escape hatch for anything not covered.
+
+Agent prompts reference MCP tools instead of curl. See agent `AGENTS.md` files for the tool list.
 
 ## Architecture
 
@@ -71,10 +95,27 @@ npx paperclipai routines disable-all --company-id <company-id>
 npx paperclipai auth whoami
 ```
 
-### API operations (curl fallback)
+### API operations (MCP preferred, curl fallback)
 
-Use CLI when possible. Curl is still needed for: secrets management, skill import, agent wake, skill attach.
+With MCP server configured, use MCP tools from Claude Code for most operations:
 
+```
+# List issues (MCP)
+paperclipListIssues
+
+# Get/update issue (MCP)
+paperclipGetIssue issueId=<id>
+paperclipUpdateIssue issueId=<id> status="done"
+
+# Create issue (MCP)
+paperclipCreateIssue title="..." body="..."
+
+# Escape hatch for any endpoint (MCP)
+paperclipApiRequest method="GET" path="/api/companies/<id>/secrets"
+paperclipApiRequest method="POST" path="/api/agents/<id>/wake"
+```
+
+Curl fallback (when MCP unavailable):
 ```bash
 # List secrets (names only, values encrypted)
 curl -s "$PAPERCLIP_URL/api/companies/<company-id>/secrets" \
@@ -147,7 +188,7 @@ Deploy after editing: `./agents/deploy.sh`
 
 ## Plugins
 
-### Telegram Bot (`paperclip-plugin-telegram` v0.2.1)
+### Telegram Bot (`paperclip-plugin-telegram` v0.2.3)
 
 Bidirectional Telegram integration for managing Paperclip via @ffnerdbot (separate from production @ffmemesbot).
 
@@ -188,6 +229,38 @@ npx paperclipai plugin inspect paperclip-plugin-telegram
 - `/connect ffmemes` — link chat to company
 - `/acp spawn/status/cancel/close` — manage agent sessions
 - Voice messages auto-transcribed via Whisper
+
+## Webhook Triggers & Signing Modes (v2026.416.0+)
+
+Paperclip triggers now support multiple signing modes:
+- **`bearer`** (default) — `Authorization: Bearer <secret>` header
+- **`hmac_sha256`** — Paperclip-native HMAC with `X-Paperclip-Signature`
+- **`github_hmac`** (NEW) — reads `X-Hub-Signature-256` header. Compatible with GitHub webhooks.
+- **`none`** (NEW) — no auth, publicId in URL acts as shared secret.
+
+### Current webhook setup
+
+| Source | Path | Auth | Notes |
+|--------|------|------|-------|
+| Sentry | app → proxy → Paperclip trigger | HMAC-SHA256 | Proxy in `src/integrations/paperclip.py` |
+| Coolify | app → proxy → Paperclip trigger | Shared secret | Proxy also filters by ff-backend app UUID |
+| Prefect | `notify_qa_sync()` → Paperclip trigger | Bearer token | Direct call, no proxy |
+| GitHub | GH Actions → Paperclip trigger | Bearer token | Direct call |
+
+### Simplification opportunity
+
+The webhook proxy (`src/integrations/paperclip.py`) exists because Sentry/Coolify can't send Paperclip auth headers. With `none` signing mode, both can POST directly to the trigger URL.
+
+**To simplify** (TODO):
+1. Switch QA trigger signing mode to `none` in Paperclip UI (Routine → Trigger → Signing Mode)
+2. Point Sentry webhook URL directly at the Paperclip trigger fire URL
+3. Point Coolify webhook URL directly at the Paperclip trigger fire URL
+4. Remove `src/integrations/paperclip.py` proxy code and `/webhooks/qa-alert` route from `src/main.py`
+5. Remove env vars: `WEBHOOK_PROXY_SECRET`, `SENTRY_CLIENT_SECRET` from ff-backend app
+
+**Trade-off**: Losing Sentry HMAC verification and Coolify UUID filtering. Acceptable because QA trigger is low-stakes (worst case: extra QA scans). The 24-char publicId provides URL-based obscurity.
+
+**Note**: `notify_qa_sync()` in `src/flows/hooks.py` still uses Bearer token — it will continue to work with `none` mode since Paperclip accepts any request.
 
 ## Secrets (Paperclip company secrets)
 
@@ -345,9 +418,24 @@ gh repo sync ohld/paperclip --source paperclipai/paperclip --branch master
 # 2. If upstream overwrites the Dockerfile fix, re-apply it:
 #    Remove the sha256sum line from Dockerfile in the fork
 
-# 3. Deploy via Coolify (API or UI)
+# 3. Check migration prerequisites (v2026.416.0 requires pg_trgm)
+ssh root@t.ffmemes.com "docker exec \$(docker ps --format '{{.Names}}' | grep tkg4c0 | head -1) psql -U paperclip -d paperclip -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'"
+
+# 4. Deploy via Coolify (API or UI)
 #    The Coolify MCP tool or curl can trigger:
 #    mcp__coolify__deploy tag_or_uuid=k4w804sco4s8kc88kwcw0ow4
 
-# 4. Run post-redeploy checklist above
+# 5. Run post-redeploy checklist above
+
+# 6. Verify MCP config survived (on named volume)
+ssh root@t.ffmemes.com "CONT=\$(docker ps --format '{{.Names}}' | grep k4w804 | head -1) && docker exec \$CONT cat /paperclip/.claude/settings.json"
 ```
+
+### Notable version changes
+
+| Version | Key changes |
+|---------|-------------|
+| v2026.416.0 | MCP server, chat threads, execution policies, blocker deps, `none`/`github_hmac` webhook signing, security fix GHSA-68qg-g8mg-6pr7 |
+| v2026.403.0 | Execution workspaces, routines engine, company skills, telemetry (disabled via env var) |
+| v2026.325.0 | Company import/export, company skills library |
+| v2026.318.0 | Plugin framework + SDK |


### PR DESCRIPTION
## Summary

Prompt-level hotfix for three recurring patterns seen in the last 200 Paperclip issues:
- 52 "PR Review" tickets (5 stale in todo since late March)
- Duplicate firefight issues (DB pool ×3, describe_memes resume ×2, Deploy fix ×3)
- Test/debug clutter in backlog

Codex pre-reviewed the full 9-proposal set and gave this subset the SHIP NOW verdict. Everything else was deferred to upstream Paperclip features.

## Changes

All 7 agents (`ceo`, `analyst`, `cto`, `staff-engineer`, `qa`, `release-engineer`, `comms`) get an Issue Hygiene (v1) block, wrapped in `<!-- BEGIN: issue-hygiene-v1 -->` / `<!-- END: issue-hygiene-v1 -->` markers so the whole block is a one-`sed` removal when Paperclip ships equivalent platform features.

1. **Slug-first titles** — every `paperclipCreateIssue` MUST prefix the title with a stable bracket slug: `[pr:NNN]`, `[incident:<slug>]`, `[deploy:<branch-or-pr>]`, `[report:YYYY-MM-DD]`, `[post:YYYY-MM-DD-slug]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`. Slugs are reused across recurrences so repeat firefights collapse onto one ticket.
2. **Dedupe preflight** — before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipListIssues` / `paperclipApiRequest`. If a match exists in `todo|in_progress|blocked|backlog`, comment on it instead of creating a new ticket.
3. **Single-writer rule** — only CEO may open *strategic* issues (planning, experiments, backlog items, product ideas). All other agents create only *execution* tickets that are part of their explicit workflow.
4. **Staff Engineer PR Review idempotency** — new step 0 in the review workflow: `gh pr view <pr_number> --json state,mergedAt,closedAt`. If `MERGED` or `CLOSED`, comment on the execution issue, mark it `done`, and exit. This kills the 5 stale PR Review tickets pattern.

Also corrects a prior-session mistake in `docs/paperclip-ops-runbook.md`: local Paperclip MCP must be registered via `claude mcp add` (writes to `~/.claude.json`), NOT via `mcpServers` in `.claude/settings.local.json` (Claude Code ignores that key there).

## How to roll back later

When Paperclip ships platform-level dedupe/slug/sweep, remove the whole block from each agent file with:

```bash
sed -i '' '/<!-- BEGIN: issue-hygiene-v1/,/<!-- END: issue-hygiene-v1/d' agents/*/AGENTS.md
./agents/deploy.sh
```

## Test plan

- [x] `./agents/deploy.sh` succeeded — all 7 agents synced to production container
- [ ] Next PR opened by a contributor: staff-engineer should check `gh pr view` state before reviewing
- [ ] Next firefight (DB pool / describe_memes timeout): QA should comment on the existing slug-matched issue rather than opening a new one
- [ ] Next comms post: should be titled `[post:YYYY-MM-DD-slug] ...` instead of `[Post] YYYY-MM-DD: ...`