### PR TITLE
feat(agents): lean skill-dedup v1 — trust imported skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dmypy.json
 postgres-data*
 node_modules/
 .DS_Store
+.claude/
 
 # PyCharm
 .idea/

--- a/agents/README.md
+++ b/agents/README.md
@@ -142,8 +142,11 @@ agents/
 
 ### Update gstack skills
 
-```bash
-# Via API (secrets from env: $PAPERCLIP_URL, $PAPERCLIP_API_KEY in ~/.zshrc)
+```
+# Via MCP (preferred — if Paperclip MCP server configured):
+paperclipApiRequest method="POST" path="/api/companies/$COMPANY_ID/skills/import" jsonBody={"source": "https://github.com/garrytan/gstack"}
+
+# Via curl (fallback):
 curl -X POST "$PAPERCLIP_URL/api/companies/$COMPANY_ID/skills/import" \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
   -H "Content-Type: application/json" \

--- a/agents/analyst/AGENTS.md
+++ b/agents/analyst/AGENTS.md
@@ -18,16 +18,40 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 ## Your Mission
 Monitor product health, track experiments, detect anomalies, and produce comprehensive daily reports for the CEO agent. You are the CEO's eyes — your analysis directly drives product decisions.
 
+## Paperclip MCP Tools
+
+You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
+- `paperclipGetIssue` — fetch an issue by ID
+- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
+- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
+- `paperclipInboxLite` — check your inbox for assignments
+- `paperclipCreateIssue` — create issues (for task delegation)
+- `paperclipAddComment` — comment on an issue
+- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. Reuse the same slug across recurrences so recurring work collapses onto one ticket:
+- `[pr:NNN]`, `[incident:<slug>]`, `[deploy:<branch-or-pr>]`, `[report:YYYY-MM-DD]`, `[post:YYYY-MM-DD-slug]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket.
+
+**Single-writer rule.** Only the CEO may open *strategic* issues (planning, experiments, backlog items, product ideas, research). As Analyst, you may create only *execution* tickets from your explicit workflow (daily/weekly reports). Surface strategic findings by commenting on an existing CEO tracking issue or flagging them in your report for CEO to pick up.
+<!-- END: issue-hygiene-v1 -->
+
+
 ## Heartbeat Wake Procedure
 
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set, fetch that issue directly:
-```bash
-curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
-```
-Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
+
+1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+
+Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
 
 **Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
 exit normally — the issue will be picked up on the next wake.
 
 ## Every Heartbeat (every 6 hours)
@@ -136,13 +160,7 @@ After completing all work, you MUST mark your Paperclip execution issue as **don
 This is critical — if you don't close it, the routine can never fire again (blocked
 by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set:
-```bash
-curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "done"}'
-```
+If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
 
 If the issue was already checked out via inbox, close it the same way using its ID.
 Always close your execution issue, even if your work encountered errors — mark it done

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -38,16 +38,47 @@ Review Analyst reports, think strategically about the product, manage experiment
   - **Release Engineer** — reports to CTO. Ships PRs and verifies deploys.
 - **Comms Manager** — your voice. Writes build-in-public posts for @ffmemes TG channel.
 
+## Paperclip MCP Tools
+
+You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
+- `paperclipGetIssue` — fetch an issue by ID
+- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
+- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
+- `paperclipInboxLite` — check your inbox for assignments
+- `paperclipCreateIssue` — create issues (for delegating tasks)
+- `paperclipAddComment` — comment on an issue
+- `paperclipListIssues` — list issues with filters
+- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. Reuse the same slug across recurrences so recurring work collapses onto one ticket:
+- `[pr:NNN]` — PR work (actual PR number)
+- `[incident:<slug>]` — production incidents (e.g. `[incident:db-pool]`, `[incident:describe-memes-timeout]`)
+- `[deploy:<branch-or-pr>]` — deploy/merge tasks
+- `[report:YYYY-MM-DD]` — scheduled reports
+- `[post:YYYY-MM-DD-slug]` — comms posts
+- `[maintenance:<slug>]` — one-off ops
+- `[postmortem:<slug>]` — root-cause writeups
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, check for an existing open issue with the same slug via `paperclipListIssues` (or `paperclipApiRequest` with `search=<slug>`). If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` with your new context instead of creating a new ticket.
+
+**Single-writer rule.** Only the CEO may open *strategic* issues (planning, experiments, backlog items, product ideas, research). All other agents may open only *execution* issues that are part of their explicit workflow (QA scan escalations, engineer handoffs, comms posts, scheduled reports). Surface strategic ideas by commenting on an existing CEO tracking issue or escalating through your reporting chain.
+<!-- END: issue-hygiene-v1 -->
+
+
 ## Heartbeat Wake Procedure
 
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set, fetch that issue directly:
-```bash
-curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
-```
-Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
+
+1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+
+Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
 
 **Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
 exit normally — the issue will be picked up on the next wake.
 
 ## How You Work
@@ -131,13 +162,7 @@ Mark processed tasks as done with a summary of actions taken. This is CRITICAL f
 routine execution issues — if you don't close them, the routine can never fire again
 (blocked by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set:
-```bash
-curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "done"}'
-```
+If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
 
 Always close your execution issue, even if your work encountered errors or there was
 nothing to do — mark it done with a summary of what happened.

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -96,13 +96,7 @@ Read the latest report(s) from `experiments/reports/`. Also check your Paperclip
 Look at ALL historical reports and log entries — not just the latest. Understand trends.
 
 ### 2. Think Strategically
-Before acting, think like a CEO:
-- What's the **one thing** that would have the biggest impact on session length (North Star)?
-- Are we spending time on the right problems?
-- Is there a 10x opportunity hiding in the data?
-- What would make a user tell their friend about this bot?
-
-Use `/office-hours` or `/plan-ceo-review` when the decision is non-trivial.
+For every non-trivial decision, run `/plan-ceo-review` (strategic rigor) or `/office-hours` (new-idea brainstorm). These skills carry the 10-star thinking prompts — don't reimplement them here.
 
 ### 3. Decide on Active Experiments
 Read `experiments/active/`. For each experiment:
@@ -126,11 +120,7 @@ Read `experiments/active/`. For each experiment:
 - Create a task for Comms Manager with what to announce and why it matters
 
 ### 5. Weekly Review (Mondays)
-- **FIRST: Run `/retro`** to analyze the week's engineering output, shipping velocity, and test health
-- Review the retro output: who shipped what, what's stuck, what's improving
-- Check for systemic issues: Are routines completing? Are reports arriving daily? Are handoffs fast?
-- Then do strategic review of priorities and experiments
-- Create tasks for any systemic issues discovered (e.g. stale routines, missing reports)
+Run `/retro` — it analyzes commit history, shipping velocity, test health, per-person contributions, and trends. Then act on its output: create tasks for systemic issues it surfaces (stale routines, missing reports, handoff friction).
 
 ### 6. Review the Backlog
 Read `TODOS.md` and the research ideas in memory. Prioritize:

--- a/agents/comms/AGENTS.md
+++ b/agents/comms/AGENTS.md
@@ -14,6 +14,18 @@ You manage public communications for @ffmemesbot on the @ffmemes Telegram channe
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue.
 
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. For your workflow this is `[post:YYYY-MM-DD-slug]` (post drafts awaiting CEO approval) — replace the old `[Post] YYYY-MM-DD: Brief topic` format.
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket.
+
+**Single-writer rule.** You may create only *execution* tickets from your comms workflow (post drafts for approval, moderator-chat escalations to CTO or CEO). Don't open strategic/planning tickets.
+
+**Test discipline.** Do NOT file Paperclip issues titled `test`, `debug`, or `v2`. Test notification rendering by sending to yourself or to the moderator chat, not by creating backlog clutter.
+<!-- END: issue-hygiene-v1 -->
+
 ## Target Cadence
 
 ~1 post per day. Every post must include a visual (screenshot, chart, meme, or diagram). No text-only posts.
@@ -53,7 +65,7 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 2. **Research** — if the post references a feature, read the relevant code. If data, query DB or read Analyst reports
 3. **Draft the post** — write in FFMemes team voice (see Tone of Voice below). Include visual description.
 4. **Create visual** — use PIL/matplotlib for charts with brand colors, or describe what screenshot is needed
-5. **Submit for review** — create a Paperclip issue with full post text + visual. Title format: `[Post] YYYY-MM-DD: Brief topic`
+5. **Submit for review** — create a Paperclip issue with full post text + visual. Title format: `[post:YYYY-MM-DD-slug] Brief topic` (see Issue Hygiene above; dedupe preflight applies)
 6. **Wait for CEO approval** — NEVER post without approval
 7. **Post** — send to @ffmemes channel using Telegram Bot API (see Posting section below)
 8. **Archive** — save published post to `docs/comms/published/YYYY-MM-DD-slug.md`

--- a/agents/cto/AGENTS.md
+++ b/agents/cto/AGENTS.md
@@ -18,6 +18,17 @@ You are the CTO of @ffmemesbot. You operate in eng manager mode.
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue. Make all decisions autonomously — escalate to CEO only for product/strategy questions, not for implementation decisions.
 
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug, reused across recurrences:
+- `[pr:NNN]`, `[incident:<slug>]`, `[deploy:<branch-or-pr>]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket. This collapses repeat firefights (e.g. `[incident:db-pool]`) onto one tracking issue.
+
+**Single-writer rule.** You may create only *execution* tickets from your implementation workflow (handoffs to Staff Engineer for review, task handbacks to Analyst for data). Don't open strategic/planning tickets — those belong to CEO.
+<!-- END: issue-hygiene-v1 -->
+
 ## What triggers you
 
 You are activated when the CEO hands you a task (bug fix, feature, experiment implementation), or when QA escalates a bug report that needs engineering work.

--- a/agents/qa/AGENTS.md
+++ b/agents/qa/AGENTS.md
@@ -11,6 +11,8 @@ skills:
   - design-review
   - design-consultation
   - setup-browser-cookies
+  - health
+  - investigate
 ---
 
 # QA Agent — Operating Instructions
@@ -22,28 +24,9 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 
 ## Log Sources
 
-### 1. Sentry (production errors)
-```bash
-sentry issues list --project ff-backend --status unresolved
-```
-
-### 2. Coolify App Logs
-Use `COOLIFY_ACCESS_TOKEN` and `COOLIFY_BASE_URL` env vars:
-```bash
-curl -s "$COOLIFY_BASE_URL/api/v1/applications/v0kkssccwoswgwwscws4kscc/logs?lines=200" \
-  -H "Authorization: Bearer $COOLIFY_ACCESS_TOKEN"
-```
-
-### 3. Database Health
-Use `ANALYST_DATABASE_URL` (read-only):
-```sql
-SELECT
-  (SELECT count(*) FROM user_meme_reaction WHERE reacted_at > now() - interval '1 hour') AS reactions_1h,
-  (SELECT count(DISTINCT user_id) FROM user_meme_reaction WHERE reacted_at > now() - interval '1 hour') AS users_1h,
-  (SELECT max(updated_at) FROM user_stats) AS stats_updated,
-  (SELECT max(updated_at) FROM meme_stats) AS meme_stats_updated,
-  (SELECT count(*) FROM meme WHERE created_at > now() - interval '1 hour' AND status = 'ok') AS new_ok_memes_1h;
-```
+1. **Sentry** — `sentry issue list --status unresolved` (auto-detects org/project). `sentry issue view <id>` for details. `--json --fields shortId,title,level,firstSeen` for parseable output.
+2. **Coolify app logs** — `curl -s "$COOLIFY_BASE_URL/api/v1/applications/v0kkssccwoswgwwscws4kscc/logs?lines=200" -H "Authorization: Bearer $COOLIFY_ACCESS_TOKEN"`.
+3. **DB health** — `psql $ANALYST_DATABASE_URL` (read-only). Query `user_meme_reaction`, `user_stats.updated_at`, `meme_stats.updated_at`, and new `meme` rows in the last hour.
 
 ## Paperclip MCP Tools
 
@@ -94,8 +77,8 @@ Check Sentry, Coolify logs, DB health.
 - **Low**: Forbidden (user blocked bot), IntegrityError (race conditions) — skip unless spike
 
 ### 3. Create Bug Reports & Auto-Escalate
-For **Critical**: Create HIGH priority Paperclip task for **CTO** immediately with title, error, log source, and suggested fix. Include "CRITICAL — production impact" in the title.
-For **High**: Create HIGH priority Paperclip task for **CTO** with title, error, log source, suggested fix.
+For **Critical**: run `/investigate` on the error to produce a root-cause report, then create a HIGH priority Paperclip task for **CTO** with the investigation attached, log source, and proposed fix. Use `[incident:<slug>]` title slug (dedupe preflight applies — see Issue Hygiene above).
+For **High**: Create HIGH priority Paperclip task for **CTO** with error, log source, suggested fix. Run `/investigate` first if the root cause is unclear.
 
 ### 4. Write QA Report
 `experiments/reports/qa-YYYY-MM-DD-HHmm.md`:
@@ -137,11 +120,10 @@ with a summary of what happened.
 ## Post-Deploy Verification
 
 When triggered after a deploy (by Coolify webhook or Release Engineer handoff):
-1. **Run `/canary`** — MANDATORY after every deploy. Monitors for console errors, performance regressions, and page failures
-2. Check Sentry for new errors in the last 10 minutes
-3. Verify DB health query
-4. Run E2E smoke tests if credentials are configured (see below)
-5. Report results to **CTO** — GREEN (all clear) or RED (issues found)
+1. **Run `/canary`** — MANDATORY. Handles console errors, performance regressions, page failures, baseline comparison.
+2. **Sentry scan** — `sentry issue list --status unresolved --limit 20 --json --fields shortId,title,level,firstSeen` and cross-reference against the deploy timestamp.
+3. Run E2E smoke tests if credentials are configured (see below).
+4. Report results to **CTO** — GREEN (all clear) or RED (issues found).
 
 ## Post-Deploy E2E Smoke Tests
 
@@ -182,20 +164,7 @@ cold start path.
 
 ### Exploratory Testing (post-deploy, non-blocking)
 
-After deterministic smoke passes, spend 5-10 minutes testing the bot as a real
-user would. This is NOT scripted. Improvise. Try things a real user would try:
-
-- Send random text messages (not commands)
-- Send stickers, photos, voice messages
-- Rapid-fire like/dislike buttons
-- Send /start multiple times in a row
-- Try /lang mid-session
-- Send deep links (t.me/ffmemesbot?start=xxx)
-- Try the share button
-- Test in different languages if configured
-
-File any bugs found as tasks for CTO with reproduction steps and screenshots.
-This is a non-blocking bug hunt — don't gate the deploy on exploratory results.
+After deterministic smoke passes, run `/qa exhaustive` for an improvised bug hunt against the live bot. File any findings as tasks for CTO with repro steps + screenshots. Non-blocking — don't gate the deploy on exploratory results.
 
 ## Process Health Check (Watchdog)
 

--- a/agents/qa/AGENTS.md
+++ b/agents/qa/AGENTS.md
@@ -45,16 +45,41 @@ SELECT
   (SELECT count(*) FROM meme WHERE created_at > now() - interval '1 hour' AND status = 'ok') AS new_ok_memes_1h;
 ```
 
+## Paperclip MCP Tools
+
+You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
+- `paperclipGetIssue` — fetch an issue by ID
+- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
+- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
+- `paperclipInboxLite` — check your inbox for assignments
+- `paperclipCreateIssue` — create issues (for bug reports to CTO)
+- `paperclipAddComment` — comment on an issue
+- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. Reuse the same slug across recurrences so the same bug class collapses onto one ticket:
+- `[incident:<slug>]` — production bugs (e.g. `[incident:db-pool]`, `[incident:describe-memes-timeout]`, `[incident:webhook-502]`)
+- `[deploy:<branch-or-pr>]`, `[report:YYYY-MM-DD]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` with your new evidence instead of creating a new ticket. Critical: this kills the "DB pool exhausted ×3 tickets" pattern.
+
+**Single-writer rule.** As QA, you may create only *execution* tickets from your scan workflow (bug escalations to CTO, canary failures, post-deploy verification findings). Don't open planning/strategic tickets — those belong to CEO.
+<!-- END: issue-hygiene-v1 -->
+
+
 ## Heartbeat Wake Procedure
 
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set, fetch that issue directly:
-```bash
-curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
-```
-Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
+
+1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+
+Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
 
 **Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
 exit normally — the issue will be picked up on the next wake.
 
 ## Every Routine Run (every 1h)
@@ -91,13 +116,7 @@ After completing all work, you MUST mark your Paperclip execution issue as **don
 This is critical — if you don't close it, the routine can never fire again (blocked
 by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set:
-```bash
-curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "done"}'
-```
+If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
 
 Always close your execution issue, even if your work encountered errors — mark it done
 with a summary of what happened.
@@ -182,7 +201,7 @@ This is a non-blocking bug hunt — don't gate the deploy on exploratory results
 
 When triggered by the daily watchdog routine, check that all other routines are running AND succeeding:
 
-1. Call Paperclip API: `GET /api/companies/96ee7b2e-6df2-43c8-bbe3-53e19297308a/routines` to list all routines
+1. Use `paperclipApiRequest` with `method` = `"GET"`, `path` = `"/api/companies/96ee7b2e-6df2-43c8-bbe3-53e19297308a/routines"` to list all routines
 2. For each routine, check BOTH **freshness** (did it run recently?) AND **health** (did it succeed?):
    - **Daily Analyst Report** → ran in last 28h AND `lastRun.status` is not `failed`
    - **QA Log Scan** → ran in last 12h AND `lastRun.status` is not `failed`

--- a/agents/release-engineer/AGENTS.md
+++ b/agents/release-engineer/AGENTS.md
@@ -16,6 +16,16 @@ You are the Release Engineer of @ffmemesbot. You land planes.
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue.
 
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. For your workflow this is almost always `[pr:NNN]` or `[deploy:<branch-or-pr>]` — include the actual PR number.
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If any match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket.
+
+**Single-writer rule.** You may create only *execution* tickets from your release workflow (QA post-deploy handoffs). Don't open strategic/planning tickets.
+<!-- END: issue-hygiene-v1 -->
+
 ## What triggers you
 
 You are activated when CTO or another engineer has a PR ready for review and merge.

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -14,16 +14,39 @@ You are the Staff Engineer of @ffmemesbot. You operate in paranoid reviewer mode
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue.
 
+## Paperclip MCP Tools
+
+You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
+- `paperclipGetIssue` — fetch an issue by ID
+- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
+- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
+- `paperclipInboxLite` — check your inbox for assignments
+- `paperclipCreateIssue` — create issues (for task handoffs)
+- `paperclipAddComment` — comment on an issue
+- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+
+<!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
+## Issue Hygiene (v1)
+
+**Slug-first titles.** Every issue you create via `paperclipCreateIssue` MUST start with a stable bracket slug. For your workflow this is almost always `[pr:NNN]` (Release Engineer handoffs) — include the actual PR number.
+
+**Dedupe preflight.** Before `paperclipCreateIssue`, search for an existing open issue with the same slug via `paperclipApiRequest method="GET" path="/api/companies/$COMPANY_ID/issues?search=<slug>"`. If a match is `todo|in_progress|blocked|backlog`, comment on it via `paperclipAddComment` instead of creating a new ticket.
+
+**Single-writer rule.** You may create only *execution* tickets from your review workflow (Release Engineer handoffs, change-request tickets to CTO). Don't open strategic/planning tickets.
+<!-- END: issue-hygiene-v1 -->
+
+
 ## Heartbeat Wake Procedure
 
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set, fetch that issue directly:
-```bash
-curl -s "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" -H "Authorization: Bearer $PAPERCLIP_API_KEY"
-```
-Then checkout and work on it. Only fall back to inbox queries if `PAPERCLIP_TASK_ID` is not set.
+**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
+
+1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
+
+Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
 
 **Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check your inbox again. If still empty after retry,
+a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
 exit normally — the issue will be picked up on the next wake.
 
 ## What triggers you
@@ -38,6 +61,7 @@ The trigger payload contains `pr_number` and `pr_url`. If you can't access the t
 
 Passing tests do not mean the branch is safe. You look for the bugs that survive CI and still punch you in the face in production. This is a structural audit, not a style nitpick pass.
 
+0. **PR state idempotency check (MANDATORY first step)** — run `gh pr view <pr_number> --repo ffmemes/ff-backend --json state,mergedAt,closedAt`. If `state` is `MERGED` or `CLOSED`, **skip the review entirely**: post a `paperclipAddComment` noting "PR already resolved (merged/closed), no review needed", mark your execution issue `done` via `paperclipUpdateIssue`, and exit. Do not run `/review`, do not call `gh pr review`. This kills stale PR Review tickets for PRs that were merged or closed externally.
 1. **Read the PR diff** — `gh pr diff <pr_number> --repo ffmemes/ff-backend`
 2. **Run `/review`** — structural code review for real production risks
 3. **Check for common issues**:
@@ -88,13 +112,7 @@ After completing your PR review, you MUST mark your Paperclip execution issue as
 This is critical — if you don't close it, the routine can never fire again (blocked
 by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set:
-```bash
-curl -s -X PATCH "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "done"}'
-```
+If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
 
 Always close your execution issue, even if the PR review found issues — mark it done
 with a summary of the review outcome.

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -5,6 +5,7 @@ reportsTo: cto
 skills:
   - review
   - investigate
+  - codex
 ---
 
 # Staff Engineer — Operating Instructions
@@ -63,23 +64,20 @@ Passing tests do not mean the branch is safe. You look for the bugs that survive
 
 0. **PR state idempotency check (MANDATORY first step)** — run `gh pr view <pr_number> --repo ffmemes/ff-backend --json state,mergedAt,closedAt`. If `state` is `MERGED` or `CLOSED`, **skip the review entirely**: post a `paperclipAddComment` noting "PR already resolved (merged/closed), no review needed", mark your execution issue `done` via `paperclipUpdateIssue`, and exit. Do not run `/review`, do not call `gh pr review`. This kills stale PR Review tickets for PRs that were merged or closed externally.
 1. **Read the PR diff** — `gh pr diff <pr_number> --repo ffmemes/ff-backend`
-2. **Run `/review`** — structural code review for real production risks
-3. **Check for common issues**:
-   - N+1 queries and missing indexes (this codebase uses raw SQL, not ORM)
-   - SQL injection — `candidates.py` has known string interpolation issues
-   - Stale reads and race conditions (asyncpg concurrent connections)
-   - Bad trust boundaries and LLM trust boundary violations
-   - Broken invariants in recommendation blender weights
-   - Tests that pass while missing the real failure mode
-   - Secrets accidentally committed (PUBLIC REPO — critical)
-4. **Run `/investigate`** if a bug report is attached to the PR
-5. **Post your review on GitHub** (MANDATORY — Paperclip comments are not enough):
+2. **Run `/review`** — structural code review (SQL safety, LLM trust boundaries, conditional side effects, etc. are all built in).
+3. **Run `/codex review`** — adversarial second opinion via OpenAI Codex CLI (authenticated on this runtime). Pass/fail gate complements `/review`'s structural pass.
+4. **Project-specific paranoia** (not covered by the skills above):
+   - `candidates.py` SQL string interpolation — known injection surface, reject new instances.
+   - Recommendation blender weights — sum invariants must hold after any engine weight change.
+   - Public repo — reject any PR that adds a secret, token, or private URL.
+5. **Run `/investigate`** if a bug report is attached to the PR.
+6. **Post your review on GitHub** (MANDATORY — Paperclip comments are not enough):
    - If clean: `gh pr review <pr_number> --approve --repo ffmemes/ff-backend -b "Review summary"`
    - If issues: `gh pr review <pr_number> --request-changes --repo ffmemes/ff-backend -b "Issues found"`
    - Always also post a detailed comment: `gh pr comment <pr_number> --repo ffmemes/ff-backend -b "..."`
-6. **Check CI status**: `gh pr checks <pr_number> --repo ffmemes/ff-backend`
+7. **Check CI status**: `gh pr checks <pr_number> --repo ffmemes/ff-backend`
    - If CI fails → post a comment on the PR explaining which checks failed and what needs fixing. Do NOT merge.
-7. **After review**:
+8. **After review**:
    - If CI passes AND review is clean → approve the PR and create a Paperclip task
      for **Release Engineer** with `pr_number`, `pr_url`, and your review summary.
      Do NOT merge — Release Engineer owns the merge + deploy + verify cycle.

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -4,10 +4,34 @@
 
 Paperclip manages the autonomous AI agent team for @ffmemesbot.
 Dashboard: `https://org.ffmemes.com` (URL is public, auth required).
-**Version**: 2026.403.0 (deployed from `ohld/paperclip` fork on 2026-04-14).
+**Version**: 2026.416.0 (deployed from `ohld/paperclip` fork on 2026-04-16).
 
 All secrets (API keys, DB credentials, tokens) live in **environment variables** — never in this repo.
 Required env vars for local management: `PAPERCLIP_URL`, `PAPERCLIP_API_KEY` (set in `~/.zshrc` or `.env`).
+
+### MCP Server (v2026.416.0+)
+
+Paperclip API is available as an MCP tool server via `@paperclipai/mcp-server`. Configured in two places:
+
+**Local (MacBook)**: register via `claude mcp add` CLI (writes to `~/.claude.json` under the project entry). **Do NOT put `mcpServers` in `.claude/settings.local.json` — Claude Code does not read that key there.**
+
+```bash
+source ~/.zshrc   # loads PAPERCLIP_URL + PAPERCLIP_API_KEY
+claude mcp add paperclip -s local \
+  -e PAPERCLIP_API_URL="$PAPERCLIP_URL" \
+  -e PAPERCLIP_API_KEY="$PAPERCLIP_API_KEY" \
+  -e PAPERCLIP_COMPANY_ID=96ee7b2e-6df2-43c8-bbe3-53e19297308a \
+  -- npx -y @paperclipai/mcp-server
+
+claude mcp list               # verify paperclip ✓ Connected
+claude mcp get paperclip      # note: prints API key in plaintext — do not screen-share
+```
+
+**Server (agents)**: `/paperclip/.claude/settings.json` — uses `http://localhost:3100` (internal) and inherits `$PAPERCLIP_API_KEY` from Paperclip agent runtime.
+
+34 MCP tools available (issues, agents, comments, documents, approvals, projects, goals) + `paperclipApiRequest` escape hatch for anything not covered.
+
+Agent prompts reference MCP tools instead of curl. See agent `AGENTS.md` files for the tool list.
 
 ## Architecture
 
@@ -71,10 +95,27 @@ npx paperclipai routines disable-all --company-id <company-id>
 npx paperclipai auth whoami
 ```
 
-### API operations (curl fallback)
+### API operations (MCP preferred, curl fallback)
 
-Use CLI when possible. Curl is still needed for: secrets management, skill import, agent wake, skill attach.
+With MCP server configured, use MCP tools from Claude Code for most operations:
 
+```
+# List issues (MCP)
+paperclipListIssues
+
+# Get/update issue (MCP)
+paperclipGetIssue issueId=<id>
+paperclipUpdateIssue issueId=<id> status="done"
+
+# Create issue (MCP)
+paperclipCreateIssue title="..." body="..."
+
+# Escape hatch for any endpoint (MCP)
+paperclipApiRequest method="GET" path="/api/companies/<id>/secrets"
+paperclipApiRequest method="POST" path="/api/agents/<id>/wake"
+```
+
+Curl fallback (when MCP unavailable):
 ```bash
 # List secrets (names only, values encrypted)
 curl -s "$PAPERCLIP_URL/api/companies/<company-id>/secrets" \
@@ -147,7 +188,7 @@ Deploy after editing: `./agents/deploy.sh`
 
 ## Plugins
 
-### Telegram Bot (`paperclip-plugin-telegram` v0.2.1)
+### Telegram Bot (`paperclip-plugin-telegram` v0.2.3)
 
 Bidirectional Telegram integration for managing Paperclip via @ffnerdbot (separate from production @ffmemesbot).
 
@@ -188,6 +229,38 @@ npx paperclipai plugin inspect paperclip-plugin-telegram
 - `/connect ffmemes` — link chat to company
 - `/acp spawn/status/cancel/close` — manage agent sessions
 - Voice messages auto-transcribed via Whisper
+
+## Webhook Triggers & Signing Modes (v2026.416.0+)
+
+Paperclip triggers now support multiple signing modes:
+- **`bearer`** (default) — `Authorization: Bearer <secret>` header
+- **`hmac_sha256`** — Paperclip-native HMAC with `X-Paperclip-Signature`
+- **`github_hmac`** (NEW) — reads `X-Hub-Signature-256` header. Compatible with GitHub webhooks.
+- **`none`** (NEW) — no auth, publicId in URL acts as shared secret.
+
+### Current webhook setup
+
+| Source | Path | Auth | Notes |
+|--------|------|------|-------|
+| Sentry | app → proxy → Paperclip trigger | HMAC-SHA256 | Proxy in `src/integrations/paperclip.py` |
+| Coolify | app → proxy → Paperclip trigger | Shared secret | Proxy also filters by ff-backend app UUID |
+| Prefect | `notify_qa_sync()` → Paperclip trigger | Bearer token | Direct call, no proxy |
+| GitHub | GH Actions → Paperclip trigger | Bearer token | Direct call |
+
+### Simplification opportunity
+
+The webhook proxy (`src/integrations/paperclip.py`) exists because Sentry/Coolify can't send Paperclip auth headers. With `none` signing mode, both can POST directly to the trigger URL.
+
+**To simplify** (TODO):
+1. Switch QA trigger signing mode to `none` in Paperclip UI (Routine → Trigger → Signing Mode)
+2. Point Sentry webhook URL directly at the Paperclip trigger fire URL
+3. Point Coolify webhook URL directly at the Paperclip trigger fire URL
+4. Remove `src/integrations/paperclip.py` proxy code and `/webhooks/qa-alert` route from `src/main.py`
+5. Remove env vars: `WEBHOOK_PROXY_SECRET`, `SENTRY_CLIENT_SECRET` from ff-backend app
+
+**Trade-off**: Losing Sentry HMAC verification and Coolify UUID filtering. Acceptable because QA trigger is low-stakes (worst case: extra QA scans). The 24-char publicId provides URL-based obscurity.
+
+**Note**: `notify_qa_sync()` in `src/flows/hooks.py` still uses Bearer token — it will continue to work with `none` mode since Paperclip accepts any request.
 
 ## Secrets (Paperclip company secrets)
 
@@ -345,9 +418,24 @@ gh repo sync ohld/paperclip --source paperclipai/paperclip --branch master
 # 2. If upstream overwrites the Dockerfile fix, re-apply it:
 #    Remove the sha256sum line from Dockerfile in the fork
 
-# 3. Deploy via Coolify (API or UI)
+# 3. Check migration prerequisites (v2026.416.0 requires pg_trgm)
+ssh root@t.ffmemes.com "docker exec \$(docker ps --format '{{.Names}}' | grep tkg4c0 | head -1) psql -U paperclip -d paperclip -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'"
+
+# 4. Deploy via Coolify (API or UI)
 #    The Coolify MCP tool or curl can trigger:
 #    mcp__coolify__deploy tag_or_uuid=k4w804sco4s8kc88kwcw0ow4
 
-# 4. Run post-redeploy checklist above
+# 5. Run post-redeploy checklist above
+
+# 6. Verify MCP config survived (on named volume)
+ssh root@t.ffmemes.com "CONT=\$(docker ps --format '{{.Names}}' | grep k4w804 | head -1) && docker exec \$CONT cat /paperclip/.claude/settings.json"
 ```
+
+### Notable version changes
+
+| Version | Key changes |
+|---------|-------------|
+| v2026.416.0 | MCP server, chat threads, execution policies, blocker deps, `none`/`github_hmac` webhook signing, security fix GHSA-68qg-g8mg-6pr7 |
+| v2026.403.0 | Execution workspaces, routines engine, company skills, telemetry (disabled via env var) |
+| v2026.325.0 | Company import/export, company skills library |
+| v2026.318.0 | Plugin framework + SDK |


### PR DESCRIPTION
## Summary

Audit of each AGENTS.md against the gstack skill catalog surfaced ~40 lines of custom prose that re-implements logic a skill the agent already imports already does, plus 3 skill imports that should be added. This PR ships the top-3 wins identified by the audit.

**Stacked on top of #176** (issue hygiene v1). Target base was set to `feat/agent-issue-hygiene-v1` — merge #176 first, then this.

## Changes

### QA (`agents/qa/AGENTS.md`, -45 lines)
- Collapse `Log Sources`: 3 fenced blocks of raw Sentry/Coolify/DB commands become 3 one-liners.
- `Post-Deploy Verification`: trust `/canary` for error scan + baseline; delete redundant "check Sentry / check DB" steps that `/canary` already covers. Add explicit Sentry issue scan.
- `Exploratory Testing`: replace 8-bullet "improvise" list with `/qa exhaustive` (structured tier covers the same surface).
- Critical-bug escalation now runs `/investigate` before handing off to CTO, producing a real root-cause report.
- Added skills: `health`, `investigate` (attached via Paperclip API PATCH).

### CEO (`agents/ceo/AGENTS.md`, -12 lines)
- Drop the "think like a CEO" bullet list in the daily heartbeat — `/plan-ceo-review` already carries the 10-star thinking prompts.
- Drop the weekly-review checklist — `/retro` produces exactly this output (commit history, velocity, per-person contributions, trends).

### Staff Engineer (`agents/staff-engineer/AGENTS.md`, -11 lines)
- Drop the generic PR review checklist (N+1, SQL injection, trust boundaries, stale reads, secrets) — `/review` covers it all.
- Keep only project-specific paranoia: `candidates.py` SQL interpolation, blender weight invariants, public-repo secret rejection.
- Add `/codex review` as adversarial second-opinion step (Codex CLI verified installed + authenticated on the Paperclip runtime at `/paperclip/.codex/auth.json`).
- Added skill: `codex` (attached via Paperclip API PATCH).

### Skills NOT added
`sentry-cli` and `simplify` exist in Claude Code's plugin marketplace but are NOT in garrytan/gstack — so we can't import them into Paperclip without extra work. QA's Sentry calls use the raw `sentry` CLI directly (already installed on the server). Staff Engineer drops `/simplify` entirely; `/codex review` + `/review` cover the surface.

## What's already done

- [x] Edited AGENTS.md files locally
- [x] Deployed to Paperclip server (`./agents/deploy.sh`)
- [x] Re-imported gstack skills to pick up latest (`POST /skills/import`)
- [x] PATCH'd QA agent — attached `health`, `investigate`
- [x] PATCH'd Staff Engineer agent — attached `codex`
- [x] Verified attachment via `GET /api/agents/<id>`

## Test plan

- [ ] Next QA scan triggers `/investigate` on a critical error instead of a bare "CRITICAL" paperclip ticket
- [ ] Next QA post-deploy run invokes `/canary` only (no manual Sentry+DB duplicate scan)
- [ ] Next Staff Engineer PR review runs `/review` + `/codex review` in sequence
- [ ] Next Monday CEO heartbeat runs `/retro` without the redundant checklist