### PR TITLE
feat(comms): single-message publishing + editorial_posts stats + HTML whitelist

### DIFF
--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -35,6 +35,23 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 
 **Daily routine** (cron: `0 7 * * *` / 10:00 MSK):
 
+### Step 0 — Read yesterday's channel performance
+Read `experiments/reports/channel-stats-YYYY-MM-DD.md` (regenerated at 06:55
+UTC by the `Write Channel Stats Report` Prefect deployment). It contains:
+
+- Median views across the last 30 days of editorial posts
+- Top 5 and weakest 3 posts with category/entity
+- Reaction emoji mix
+- Category frequency + last-7 category/entity combos (rotation hint)
+
+Use this as a taste signal: formats/topics that landed above the median →
+do more of that. Weak ones → avoid the same framing. Entity combos from
+the last 7 posts are enforced by code as a hard rotation check (see
+"Posting" below), but you should also aim for variety beyond that.
+
+If the file is missing (first run, or cron failed), proceed without it —
+the rotation check still runs against the database.
+
 ### Step 1 — Read today's anomaly report (primary input)
 Read `experiments/reports/anomalies-YYYY-MM-DD.md` written by the Analyst agent
 earlier this morning. This file ranks the day's most surprising findings
@@ -79,12 +96,19 @@ Your topic must NOT be any of:
   chatter, CEO/CTO/Analyst agent coordination
 - **Outages** — OpenRouter, Cloudflare, Telegram Bot API, Hetzner, any upstream
 
-Also reject any draft whose text contains these substrings (case-insensitive):
-`describe_memes`, `describe memes`, `circuit breaker`, `openrouter`, `free tier`,
-`402`, `rate limit`, `deploy`, `rollback`, `crashed`, `fixed bug`, `ab test`,
-`a/b test`, `эксперимент` (as a topic, not a word in passing).
+The substring and pattern bans are **enforced by code** inside
+`publish_editorial_post` (see `src/comms/publishing.py` →
+`BANNED_SUBSTRINGS`, `BANNED_PATTERNS`). The current list covers
+`describe_memes`, `circuit breaker`, `openrouter`, `free tier`, `rate limit`,
+`402 error`, `deploy rollback`, `rollback`, `crashed`, `fixed bug`, `ab test`,
+`a/b test`, plus the iteration-update pattern `день N/M` and
+`итерация эксперимента`. Publishing will fail with `EditorialValidationError`
+if any match — you'll get the error list back, throw the draft away and
+pick a different anomaly.
 
-If your draft matches any, **throw it away and start over on a different anomaly**.
+Don't try to route around the substring ban with synonyms. If the *topic*
+is infra firefighting or an experiment in progress, the answer is:
+**wait for the conclusive learning and post that instead.**
 
 ### Step 4 — Draft the post (anomaly-teller style)
 Write in the voice: "чуваки, мы тут на данных нашли странное" — surprised
@@ -117,7 +141,8 @@ Use `src/comms/visuals.py` primitives ONLY. Do not write raw matplotlib.
 See `docs/comms/brand-guide.md` for the full decision tree and constraints.
 
 ### Step 7 — Post, archive, log
-1. Post to @ffmemes via Bot API (see Posting section)
+1. Publish via `publish_editorial_post(...)` (see Posting section — this is
+   the ONLY sanctioned path, raw `curl` / Bot API calls are banned)
 2. Archive to `docs/comms/published/YYYY-MM-DD-slug.md` with: topic, category,
    entity_id, anomaly source (which finding from anomalies-*.md)
 3. Log to `experiments/log.jsonl` with `action: "daily_post"`
@@ -293,29 +318,101 @@ On first activation (or when CEO requests), browse the public channel previews t
 
 ## Posting to Telegram
 
-⚠️ **CRITICAL: Use ONLY the env var `FFMEMES_PROD_TELEGRAM_BOT_TOKEN` for posting.**
+⚠️ **The ONLY sanctioned way to publish is `publish_editorial_post`.** Raw
+`curl` / `sendPhoto` / `sendMessage` calls are banned. They caused split
+messages (photo without caption, text as a separate message) and skipped
+stats tracking. Not again.
 
-This is the **@ffmemesbot** production bot (ID starts with `1123681771`). Do NOT use any other bot token — the @ffnerdbot (6469330294) does NOT have posting permissions in the channel.
+```python
+from src.comms.publishing import publish_editorial_post, EditorialValidationError
 
-Channel ID (RU @ffmemes): `-1001472939243`
-Moderator chat ID: `-1001305866294`
-
-To send a text post with an image:
-```bash
-curl -s -X POST "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/sendPhoto" \
-  -F "chat_id=-1001472939243" \
-  -F "photo=@/path/to/image.png" \
-  -F "caption=Post text here" \
-  -F "parse_mode=HTML"
+try:
+    result = await publish_editorial_post(
+        text=final_post_text,           # HTML-formatted, see "Post Formatting"
+        channel="ru",                    # or "en" for @fast_food_memes
+        category="C",                    # A/B/C/D/E/F — see "Content Categories"
+        entity_id="dau_delta_2026_04_24",# stable slug for the specific anomaly/topic
+        photo_file_id=telegram_file_id,  # OR photo_url — always include a visual
+        topic_slug="dau-delta-anomaly",
+        button_text=None, button_url=None,  # optional inline button
+    )
+    # result.message_id / result.editorial_post_id / result.already_posted
+except EditorialValidationError as e:
+    # e.errors is a list of strings. Fix the draft and retry — don't bypass.
+    ...
 ```
 
-To send a text-only post (avoid — every post should have a visual):
-```bash
-curl -s -X POST "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/sendMessage" \
-  -F "chat_id=-1001472939243" \
-  -F "text=Post text here" \
-  -F "parse_mode=HTML"
+What the function does for you (you cannot replicate these with raw curl, so
+don't try):
+
+- **One message, always.** sendPhoto with the caption embedded, via
+  `post_editorial_to_channel`. Splitting into photo-then-text is impossible
+  through this API.
+- **Caption length check.** Rejects drafts > 1024 chars with media. Shorten,
+  or move the long detail into `<blockquote expandable>` (it still counts
+  toward the 1024 cap, but you should be nowhere near it).
+- **HTML whitelist.** Only `<b>`, `<strong>`, `<i>`, `<em>`, `<code>`,
+  `<a href="...">`, `<blockquote>` are allowed. Anything else → rejected.
+- **Expandable-by-default blockquotes.** Every `<blockquote>` is rewritten
+  to `<blockquote expandable>`.
+- **Substring/pattern ban.** The HARD BAN list from Step 3 is enforced here.
+- **Rotation check.** `(category, entity_id)` is compared against the last
+  14 editorial posts in the database. Duplicate key → rejected.
+- **Idempotency.** Same `(channel, text, photo, category, entity_id)` →
+  same `draft_hash` → no double-post. Safe to retry.
+- **Stats registration.** Inserts into `editorial_posts` so the stats
+  collector (every 6h) picks up views/forwards/reactions automatically.
+
+Channel constants (for reference, but you pass `channel="ru"` / `"en"`, not
+raw IDs):
+
+- `@ffmemes` (RU) → `-1001472939243`
+- `@fast_food_memes` (EN) → `-1001152876229`
+- Moderator chat → `-1001305866294` (separate flow, see "Moderator Chat
+  Monitoring")
+
+## Post Formatting (HTML)
+
+Parse mode is always HTML. Allowed tags:
+
+| Tag | Use for | Notes |
+|-----|---------|-------|
+| `<b>` (or `<strong>`) | Bold — hook words, key numbers | Max 2-3 per post |
+| `<i>` (or `<em>`) | Italic — quotes, emphasis | Use sparingly |
+| `<code>` | Code / metric name / identifier | Monospaced in Telegram |
+| `<a href="...">...</a>` | Links | `href` is mandatory |
+| `<blockquote>...</blockquote>` | Collapsed details | Auto-expandable |
+
+**Taste rules** (not enforced, but if you violate them the post looks like
+clown content):
+
+- Max one `<blockquote>` per post. Don't nest. Telegram won't render nesting
+  anyway — the validator rejects it.
+- Don't bold more than 2-3 spans per post. If everything is bold, nothing is.
+- Never write "нажми чтобы развернуть" or "тапни чтобы развернуть" next to
+  a blockquote. Users figure it out. Saying it is the tell of a bot.
+- `<code>` is for identifiers/metrics (`meme_id`, `lr_smoothed`,
+  `session_length`), not for quoting normal prose. Don't stylize.
+- Links go to `@ffmemesbot`, `@ffmemes`, or direct `t.me/ffmemes/<id>` URLs.
+  Never to `@danokhlopkov` or other personal channels.
+
+**Pattern: short hook + expandable detail.** The hook is the 1-3 lines a
+scrolling reader sees. Anything that needs more context goes inside the
+blockquote and is hidden until they tap.
+
+```html
+<b>Интересное:</b> сессия +18% за неделю у юзеров, пришедших с /start через share-link.
+
+Думали — это рандом. Посмотрели: у них в первый день +4 лайка к медиане.
+
+<blockquote>Гипотеза: share-link предискейлит мотивацию — человек приходит с конкретным мемом
+от друга, сразу цепляется. На обычном /start у нас 30% дропают до мема #5.
+Будем копать дальше — если подтвердится, сделаем onboarding-вариант «посмотри что твой друг
+лайкнул» для cold-start.</blockquote>
 ```
+
+**Anti-pattern:** wrapping the whole post in a blockquote. The hook is the
+whole point of a hook — it cannot be hidden.
 
 ## Moderator Chat Monitoring
 
@@ -379,10 +476,22 @@ curl -s -X POST "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/
 
 ## What NOT To Do
 
+- Do NOT post via raw `curl` / `sendPhoto` / `sendMessage` — only
+  `publish_editorial_post`. Split messages (photo without caption, text as a
+  separate message) are physically impossible through the sanctioned API
+- Do NOT try to bypass `EditorialValidationError` with synonyms or
+  workarounds. If validation fails, fix the topic — don't fight the code
 - Do NOT post about describe_memes, circuit breakers, OpenRouter, A/B tests in
-  progress, or any infra firefighting — the HARD BAN is absolute (see Step 3)
-- Do NOT skip the rotation check — posts must differ from the last 7 on
-  category AND entity_id
+  progress, or any infra firefighting — the HARD BAN is enforced by code
+- Do NOT write iteration updates like "день 11/14" for an experiment — post
+  the conclusive learning when it's done, not the progress bar
+- Do NOT skip the rotation check — posts must differ from the last 14 on
+  category AND entity_id (enforced)
+- Do NOT nest `<blockquote>` inside another `<blockquote>` — Telegram doesn't
+  render it and the validator rejects it
+- Do NOT write "нажми чтобы развернуть" / "тапни чтобы развернуть" —
+  blockquotes are auto-expandable and users know how to tap
+- Do NOT bold more than 2-3 spans per post — it stops being emphasis
 - Do NOT write raw matplotlib — use `src/comms/visuals.py` primitives only
 - Do NOT post without CEO approval (exception: vacation mode April 1-14, data-driven posts only)
 - Do NOT post images without downloading and visually inspecting them first
@@ -393,4 +502,5 @@ curl -s -X POST "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/
 - Do NOT commit secrets to git
 - Do NOT post text-only — always include a visual
 - Do NOT use corporate language or greetings
-- Do NOT exceed ~400 characters of post text — cut aggressively
+- Do NOT exceed ~400 visible characters of post text — cut aggressively, put
+  long detail in `<blockquote>`

--- a/alembic/versions/2026-04-24_editorial_posts.py
+++ b/alembic/versions/2026-04-24_editorial_posts.py
@@ -1,7 +1,7 @@
 """Add editorial_posts + editorial_post_snapshots tables
 
 Revision ID: a1b4c7d0e3f6
-Revises: 5a9d22dbecb6
+Revises: a7b8c9d0e1f2
 Create Date: 2026-04-24 00:00:00.000000
 
 """
@@ -21,7 +21,11 @@ def upgrade() -> None:
         "editorial_posts",
         sa.Column("id", sa.Integer(), sa.Identity(), primary_key=True),
         sa.Column("channel", sa.String(), nullable=False),
-        sa.Column("telegram_message_id", sa.BigInteger(), nullable=False),
+        # NULL means "claim taken, Telegram send not confirmed yet". Set to
+        # the real message_id immediately after the Bot API call returns.
+        # Allows publish_editorial_post to insert before posting (and so
+        # idempotently survive a crash between the TG send and the DB write).
+        sa.Column("telegram_message_id", sa.BigInteger(), nullable=True),
         sa.Column("draft_hash", sa.String(), nullable=False),
         sa.Column("category", sa.String()),
         sa.Column("entity_id", sa.String()),

--- a/alembic/versions/2026-04-24_editorial_posts.py
+++ b/alembic/versions/2026-04-24_editorial_posts.py
@@ -87,9 +87,15 @@ def upgrade() -> None:
         "editorial_post_snapshots",
         ["channel", "telegram_message_id"],
     )
+    op.create_index(
+        "ix_editorial_post_snapshots_editorial_post_id",
+        "editorial_post_snapshots",
+        ["editorial_post_id"],
+    )
 
 
 def downgrade() -> None:
+    op.drop_index("ix_editorial_post_snapshots_editorial_post_id")
     op.drop_index("ix_editorial_post_snapshots_channel_msg")
     op.drop_table("editorial_post_snapshots")
     op.drop_index("ix_editorial_posts_created_at")

--- a/alembic/versions/2026-04-24_editorial_posts.py
+++ b/alembic/versions/2026-04-24_editorial_posts.py
@@ -1,0 +1,97 @@
+"""Add editorial_posts + editorial_post_snapshots tables
+
+Revision ID: a1b4c7d0e3f6
+Revises: 5a9d22dbecb6
+Create Date: 2026-04-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "a1b4c7d0e3f6"
+down_revision = "5a9d22dbecb6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "editorial_posts",
+        sa.Column("id", sa.Integer(), sa.Identity(), primary_key=True),
+        sa.Column("channel", sa.String(), nullable=False),
+        sa.Column("telegram_message_id", sa.BigInteger(), nullable=False),
+        sa.Column("draft_hash", sa.String(), nullable=False),
+        sa.Column("category", sa.String()),
+        sa.Column("entity_id", sa.String()),
+        sa.Column("topic_slug", sa.String()),
+        sa.Column("text", sa.String(), nullable=False),
+        sa.Column("has_media", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("validation_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("views", sa.Integer()),
+        sa.Column("forwards", sa.Integer()),
+        sa.Column("reactions", sa.Integer()),
+        sa.Column("comments", sa.Integer()),
+        sa.Column("reactions_detail", JSONB),
+        sa.Column("stats_updated_at", sa.DateTime()),
+        sa.UniqueConstraint("draft_hash", name="uq_editorial_posts_draft_hash"),
+        sa.UniqueConstraint(
+            "channel",
+            "telegram_message_id",
+            name="uq_editorial_posts_channel_msg",
+        ),
+    )
+    op.create_index(
+        "ix_editorial_posts_telegram_message_id",
+        "editorial_posts",
+        ["telegram_message_id"],
+    )
+    op.create_index(
+        "ix_editorial_posts_created_at",
+        "editorial_posts",
+        ["created_at"],
+    )
+
+    op.create_table(
+        "editorial_post_snapshots",
+        sa.Column("id", sa.Integer(), sa.Identity(), primary_key=True),
+        sa.Column("channel", sa.String(), nullable=False),
+        sa.Column(
+            "editorial_post_id",
+            sa.Integer(),
+            sa.ForeignKey("editorial_posts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("telegram_message_id", sa.BigInteger(), nullable=False),
+        sa.Column("views", sa.Integer()),
+        sa.Column("forwards", sa.Integer()),
+        sa.Column("reactions", sa.Integer()),
+        sa.Column("comments", sa.Integer()),
+        sa.Column("reactions_detail", JSONB),
+        sa.Column(
+            "snapshot_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_editorial_post_snapshots_channel_msg",
+        "editorial_post_snapshots",
+        ["channel", "telegram_message_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_editorial_post_snapshots_channel_msg")
+    op.drop_table("editorial_post_snapshots")
+    op.drop_index("ix_editorial_posts_created_at")
+    op.drop_index("ix_editorial_posts_telegram_message_id")
+    op.drop_table("editorial_posts")

--- a/alembic/versions/2026-04-24_editorial_posts.py
+++ b/alembic/versions/2026-04-24_editorial_posts.py
@@ -11,7 +11,7 @@ from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB
 
 revision = "a1b4c7d0e3f6"
-down_revision = "5a9d22dbecb6"
+down_revision = "a7b8c9d0e1f2"
 branch_labels = None
 depends_on = None
 

--- a/scripts/serve_flows.py
+++ b/scripts/serve_flows.py
@@ -11,6 +11,8 @@ Usage:
 from prefect import serve
 from prefect.client.schemas.schedules import CronSchedule
 
+from src.comms.performance import write_channel_stats_report
+
 # Broadcasts
 from src.flows.broadcasts.meme import (
     broadcast_next_meme_to_active_1w_ago,
@@ -148,13 +150,20 @@ if __name__ == "__main__":
             name="Collect Channel Stats",
             schedules=[CronSchedule(cron="0 */6 * * *", timezone=LON)],
         ),
-        # ── Editorial (on-demand + weekly report) ──
+        # ── Editorial (on-demand + weekly report + daily stats digest) ──
         post_editorial_to_channel.to_deployment(
             name="Post Editorial",
         ),
         post_weekly_burger_report.to_deployment(
             name="Weekly Burger Report",
             schedules=[CronSchedule(cron="0 14 * * 0", timezone=MSK)],
+        ),
+        # Materialize channel-stats-YYYY-MM-DD.md 5 minutes before Comms Agent
+        # fires at 07:00 UTC (10:00 MSK) so agent reads a fresh digest.
+        write_channel_stats_report.to_deployment(
+            name="Write Channel Stats Report",
+            schedules=[CronSchedule(cron="55 6 * * *", timezone=LON)],
+            parameters={"channel": "ru", "days": 30},
         ),
         # ── Rewards (weekly) ──
         reward_ru_users_for_weekly_top_uploaded_memes.to_deployment(

--- a/src/comms/performance.py
+++ b/src/comms/performance.py
@@ -1,0 +1,230 @@
+"""
+Editorial post performance helpers.
+
+Two layers:
+  1. `get_recent_editorial_performance(channel, days)` — DB query returning
+     rows with category, entity_id, text preview, views, forwards, reactions.
+  2. `write_channel_stats_report(channel, days, output_dir)` — materializes
+     `experiments/reports/channel-stats-YYYY-MM-DD.md`. The Comms Agent reads
+     this file as its first input of the day (Step 0 of its routine).
+
+The report is deliberately short (LLM-friendly): top/bottom by views,
+reaction-mix summary, category/entity frequency. Numbers are the source of
+truth; the markdown is a curated snapshot.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from prefect import flow, get_run_logger
+from sqlalchemy import desc, select
+
+from src.database import editorial_posts, fetch_all
+from src.flows.hooks import notify_telegram_on_failure
+
+REPORTS_DIR = Path("experiments/reports")
+
+
+@dataclass
+class EditorialRow:
+    id: int
+    channel: str
+    created_at: datetime
+    category: str | None
+    entity_id: str | None
+    topic_slug: str | None
+    text: str
+    views: int
+    forwards: int
+    reactions: int
+    reactions_detail: dict[str, int] | None
+    telegram_message_id: int
+
+
+async def get_recent_editorial_performance(
+    channel: str = "ru",
+    days: int = 30,
+) -> list[EditorialRow]:
+    """Return editorial posts for `channel`, newest first, within `days`."""
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    rows = await fetch_all(
+        select(
+            editorial_posts.c.id,
+            editorial_posts.c.channel,
+            editorial_posts.c.created_at,
+            editorial_posts.c.category,
+            editorial_posts.c.entity_id,
+            editorial_posts.c.topic_slug,
+            editorial_posts.c.text,
+            editorial_posts.c.views,
+            editorial_posts.c.forwards,
+            editorial_posts.c.reactions,
+            editorial_posts.c.reactions_detail,
+            editorial_posts.c.telegram_message_id,
+        )
+        .where(editorial_posts.c.channel == channel)
+        .where(editorial_posts.c.created_at >= cutoff)
+        .order_by(desc(editorial_posts.c.created_at))
+    )
+    return [
+        EditorialRow(
+            id=r["id"],
+            channel=r["channel"],
+            created_at=r["created_at"],
+            category=r["category"],
+            entity_id=r["entity_id"],
+            topic_slug=r["topic_slug"],
+            text=r["text"],
+            views=r["views"] or 0,
+            forwards=r["forwards"] or 0,
+            reactions=r["reactions"] or 0,
+            reactions_detail=r["reactions_detail"],
+            telegram_message_id=r["telegram_message_id"],
+        )
+        for r in (rows or [])
+    ]
+
+
+def _first_line(text: str, limit: int = 120) -> str:
+    first = text.strip().split("\n", 1)[0]
+    # Strip simple HTML tags for preview (readability only).
+    cleaned = []
+    in_tag = False
+    for ch in first:
+        if ch == "<":
+            in_tag = True
+        elif ch == ">":
+            in_tag = False
+        elif not in_tag:
+            cleaned.append(ch)
+    out = "".join(cleaned).strip()
+    return out[:limit] + ("…" if len(out) > limit else "")
+
+
+def _median(values: list[int]) -> int:
+    if not values:
+        return 0
+    sorted_vals = sorted(values)
+    mid = len(sorted_vals) // 2
+    if len(sorted_vals) % 2:
+        return sorted_vals[mid]
+    return (sorted_vals[mid - 1] + sorted_vals[mid]) // 2
+
+
+def format_channel_stats_report(
+    rows: list[EditorialRow],
+    channel: str,
+    days: int,
+    as_of: datetime,
+) -> str:
+    if not rows:
+        return (
+            f"# Channel stats — @{channel} — {as_of.date().isoformat()}\n\n"
+            f"No editorial posts in the last {days} days.\n"
+        )
+
+    views = [r.views for r in rows]
+    median_views = _median(views)
+    top_views = sorted(rows, key=lambda r: r.views, reverse=True)[:5]
+    # Only include posts that had at least 24h to accumulate views.
+    cutoff_24h = as_of - timedelta(hours=24)
+    mature = [r for r in rows if r.created_at <= cutoff_24h]
+    bottom_views = sorted(mature, key=lambda r: r.views)[:3]
+
+    # Reaction emoji summary (top 5 across all posts).
+    reaction_counter: Counter[str] = Counter()
+    for r in rows:
+        for emoji, count in (r.reactions_detail or {}).items():
+            reaction_counter[emoji] += count
+
+    # Category / entity frequency for rotation awareness.
+    categories = Counter(r.category or "?" for r in rows)
+    entities = Counter(r.entity_id or "?" for r in rows)
+    recent_keys = [(r.category, r.entity_id) for r in rows[:7]]
+
+    lines = [
+        f"# Channel stats — @{channel} — {as_of.date().isoformat()}",
+        "",
+        f"Window: last {days} days. Posts: {len(rows)}. Median views: {median_views}.",
+        "",
+        "## Top 5 by views",
+        "",
+    ]
+    for r in top_views:
+        lines.append(
+            f"- **{r.views}** views, {r.reactions} react, {r.forwards} fwd — "
+            f"`{r.category or '?'}/{r.entity_id or '?'}` — {_first_line(r.text)}"
+        )
+
+    if bottom_views:
+        lines += ["", "## Weakest 3 (≥24h old)", ""]
+        for r in bottom_views:
+            lines.append(
+                f"- **{r.views}** views, {r.reactions} react — "
+                f"`{r.category or '?'}/{r.entity_id or '?'}` — {_first_line(r.text)}"
+            )
+
+    lines += ["", "## Reaction mix (top 5)", ""]
+    for emoji, count in reaction_counter.most_common(5):
+        lines.append(f"- {emoji} × {count}")
+
+    lines += ["", "## Category frequency", ""]
+    for cat, count in categories.most_common():
+        lines.append(f"- {cat}: {count}")
+
+    lines += ["", "## Last 7 (category / entity — don't repeat these)", ""]
+    for cat, ent in recent_keys:
+        lines.append(f"- `{cat or '?'}` / `{ent or '?'}`")
+
+    lines += [
+        "",
+        "## Top 5 entity_ids by frequency",
+        "",
+    ]
+    for ent, count in entities.most_common(5):
+        lines.append(f"- {ent}: {count}")
+
+    lines += [
+        "",
+        "_Generated by `src/comms/performance.py`. Regenerates daily at 06:55 UTC._",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+@flow(
+    retries=1,
+    retry_delay_seconds=30,
+    timeout_seconds=60,
+    on_failure=[notify_telegram_on_failure],
+)
+async def write_channel_stats_report(
+    channel: str = "ru",
+    days: int = 30,
+    output_dir: str | None = None,
+) -> str:
+    """Write the daily channel stats markdown snapshot. Returns the file path."""
+    log = get_run_logger()
+    rows = await get_recent_editorial_performance(channel=channel, days=days)
+    as_of = datetime.utcnow()
+    report = format_channel_stats_report(rows, channel=channel, days=days, as_of=as_of)
+
+    out_dir = Path(output_dir) if output_dir else REPORTS_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"channel-stats-{as_of.date().isoformat()}.md"
+    path.write_text(report, encoding="utf-8")
+    log.info(f"Wrote {path} with {len(rows)} posts")
+    return str(path)
+
+
+__all__ = [
+    "EditorialRow",
+    "REPORTS_DIR",
+    "format_channel_stats_report",
+    "get_recent_editorial_performance",
+    "write_channel_stats_report",
+]

--- a/src/comms/performance.py
+++ b/src/comms/performance.py
@@ -68,6 +68,7 @@ async def get_recent_editorial_performance(
         )
         .where(editorial_posts.c.channel == channel)
         .where(editorial_posts.c.created_at >= cutoff)
+        .where(editorial_posts.c.telegram_message_id.isnot(None))
         .order_by(desc(editorial_posts.c.created_at))
     )
     return [

--- a/src/comms/publishing.py
+++ b/src/comms/publishing.py
@@ -14,7 +14,11 @@ Invariants enforced here (not in prompt):
 - `<blockquote>` is always rewritten to `<blockquote expandable>`.
 - Substring/pattern ban (describe_memes, circuit breakers, A/B iteration updates).
 - Category+entity rotation check against the last 14 editorial posts.
-- Idempotency via SHA256 `draft_hash` (same draft, same channel → no double-post).
+- Idempotency via SHA256 `draft_hash`. The hash row is INSERTED before the
+  Telegram send (telegram_message_id NULL), then UPDATED with the real id
+  after send returns. A retry that races with a previous in-flight call
+  loses the ON CONFLICT and refuses to double-post; a retry after the
+  previous call succeeded short-circuits via the existing-row fast path.
 """
 
 from __future__ import annotations
@@ -24,7 +28,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Iterable
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert
 
 from src.database import editorial_posts, execute, fetch_all, fetch_one
@@ -41,6 +45,10 @@ ALLOWED_HTML_TAGS = {"b", "strong", "i", "em", "code", "a", "blockquote"}
 
 _TAG_RE = re.compile(r"<(/?)([a-zA-Z][a-zA-Z0-9\-]*)([^>]*)>")
 _BLOCKQUOTE_OPEN_RE = re.compile(r"<blockquote(\s[^>]*)?>", re.IGNORECASE)
+# Match a real `href=` attribute, not a substring of e.g. `xhref=`. Requires a
+# non-letter (or start-of-attrs) before `href` so `xhref=` is rejected.
+_HREF_ATTR_RE = re.compile(r"(?:^|[^a-z])href\s*=", re.IGNORECASE)
+_HREF_VALUE_RE = re.compile(r"href\s*=\s*['\"]([^'\"]*)['\"]", re.IGNORECASE)
 
 BANNED_SUBSTRINGS: tuple[str, ...] = (
     "describe_memes",
@@ -176,8 +184,15 @@ def _validate_html(text: str) -> list[str]:
             else:
                 stack.pop()
             continue
-        if tag == "a" and "href=" not in attrs.lower():
-            errors.append("<a> tag missing href attribute")
+        if tag == "a":
+            if not _HREF_ATTR_RE.search(attrs):
+                errors.append("<a> tag missing href attribute")
+            else:
+                href_match = _HREF_VALUE_RE.search(attrs)
+                if href_match:
+                    scheme = href_match.group(1).strip().lower()
+                    if scheme.startswith(("javascript:", "data:", "vbscript:", "file:")):
+                        errors.append(f"<a> href uses unsafe scheme: {scheme.split(':', 1)[0]}:")
         if tag == "blockquote" and stack and "blockquote" in stack:
             errors.append("Nested <blockquote> is not supported by Telegram")
         stack.append(tag)
@@ -263,8 +278,20 @@ def compute_draft_hash(
     photo_key: str | None,
     category: str,
     entity_id: str,
+    button_text: str | None = None,
+    button_url: str | None = None,
 ) -> str:
-    blob = f"{channel}|{category}|{entity_id}|{photo_key or ''}|{text}"
+    blob = "|".join(
+        [
+            channel,
+            category,
+            entity_id,
+            photo_key or "",
+            button_text or "",
+            button_url or "",
+            text,
+        ]
+    )
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:32]
 
 
@@ -309,15 +336,18 @@ async def publish_editorial_post(
         photo_key=photo_key,
         category=category,
         entity_id=entity_id,
+        button_text=button_text,
+        button_url=button_url,
     )
 
+    # Fast-path: identical draft already posted (telegram_message_id set).
     existing = await fetch_one(
         select(
             editorial_posts.c.id,
             editorial_posts.c.telegram_message_id,
         ).where(editorial_posts.c.draft_hash == draft_hash)
     )
-    if existing:
+    if existing and existing["telegram_message_id"] is not None:
         return EditorialPostResult(
             message_id=existing["telegram_message_id"],
             editorial_post_id=existing["id"],
@@ -336,6 +366,38 @@ async def publish_editorial_post(
     if not result.ok:
         raise EditorialValidationError(result.errors)
 
+    # Claim the draft_hash slot BEFORE posting so a crash between TG send and
+    # DB write cannot result in a re-post on retry. INSERT ON CONFLICT DO
+    # NOTHING; if a row already exists with telegram_message_id IS NULL,
+    # another worker is mid-send — refuse to double-post.
+    claim_stmt = (
+        insert(editorial_posts)
+        .values(
+            channel=channel,
+            telegram_message_id=None,
+            draft_hash=draft_hash,
+            category=category,
+            entity_id=entity_id,
+            topic_slug=topic_slug,
+            text=normalized_text,
+            has_media=has_media,
+            validation_version=VALIDATION_VERSION,
+        )
+        .on_conflict_do_nothing(index_elements=["draft_hash"])
+        .returning(editorial_posts.c.id)
+    )
+    claim_row = await fetch_one(claim_stmt)
+    if claim_row is None:
+        # Lost the race — another caller already claimed this draft_hash.
+        raise EditorialValidationError(
+            [
+                "Draft is already being published by another worker "
+                "(draft_hash claim row exists with no telegram_message_id). "
+                "Retry after the other call completes or fails."
+            ]
+        )
+    editorial_post_id = claim_row["id"]
+
     # Import lazily — avoids pulling python-telegram-bot into the Comms agent
     # runtime for dry-run / validation-only calls in tests.
     from src.flows.crossposting.editorial import post_editorial_to_channel
@@ -349,39 +411,34 @@ async def publish_editorial_post(
         button_url=button_url,
     )
 
-    row = await fetch_one(
-        insert(editorial_posts)
-        .values(
-            channel=channel,
-            telegram_message_id=message_id,
-            draft_hash=draft_hash,
-            category=category,
-            entity_id=entity_id,
-            topic_slug=topic_slug,
-            text=normalized_text,
-            has_media=has_media,
-            validation_version=VALIDATION_VERSION,
-        )
-        .returning(editorial_posts.c.id)
+    await execute(
+        update(editorial_posts)
+        .where(editorial_posts.c.id == editorial_post_id)
+        .values(telegram_message_id=message_id)
     )
-    if row is None:
-        raise RuntimeError(f"editorial_posts insert returned no row for message_id={message_id}")
 
     return EditorialPostResult(
         message_id=message_id,
-        editorial_post_id=row["id"],
+        editorial_post_id=editorial_post_id,
         already_posted=False,
         normalized_text=normalized_text,
     )
 
 
 async def mark_tracked_message_ids(channel: str) -> dict[int, int]:
-    """Return {telegram_message_id: editorial_posts.id} for stats collector."""
+    """Return {telegram_message_id: editorial_posts.id} for stats collector.
+
+    Skips claim rows with telegram_message_id IS NULL (drafts mid-publish or
+    orphaned by a crash between claim and Telegram send).
+    """
     rows = await fetch_all(
         select(
             editorial_posts.c.id,
             editorial_posts.c.telegram_message_id,
-        ).where(editorial_posts.c.channel == channel)
+        ).where(
+            editorial_posts.c.channel == channel,
+            editorial_posts.c.telegram_message_id.isnot(None),
+        )
     )
     return {r["telegram_message_id"]: r["id"] for r in (rows or [])}
 

--- a/src/comms/publishing.py
+++ b/src/comms/publishing.py
@@ -56,6 +56,10 @@ BANNED_SUBSTRINGS: tuple[str, ...] = (
     "fixed bug",
     "ab test",
     "a/b test",
+    # Russian forms — agent writes in Russian for @ffmemes.
+    "а/б тест",
+    "аб-тест",
+    "сплит-тест",
 )
 
 # Regex patterns for banned content structures.
@@ -65,7 +69,52 @@ BANNED_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bday\s+\d+\s*/\s*\d+", re.IGNORECASE),
     # "итерация эксперимента" — experiments-in-progress framing.
     re.compile(r"итерация\s+эксперимента", re.IGNORECASE),
+    # "A/B тест", "А/B test", "а/b тест" — every mixed-script combination of
+    # Cyrillic/Latin a-b around a slash followed by test/тест. This is the
+    # bypass that the prompt-level HARD BAN couldn't catch.
+    re.compile(r"[аa]\s*/\s*[бbв]\s*[-–\s]?\s*(?:test|тест)", re.IGNORECASE),
 )
+
+# Cyrillic → Latin lookalike map. Used by _normalize_lookalikes() before the
+# substring/pattern ban check so that mixed-script evasion (e.g. Cyrillic А
+# in "А/B тест") cannot route around the ban list.
+_CYRILLIC_TO_LATIN = str.maketrans(
+    {
+        "а": "a",
+        "А": "a",
+        "е": "e",
+        "Е": "e",
+        "о": "o",
+        "О": "o",
+        "р": "p",
+        "Р": "p",
+        "с": "c",
+        "С": "c",
+        "у": "y",
+        "У": "y",
+        "х": "x",
+        "Х": "x",
+        "к": "k",
+        "К": "k",
+        "в": "b",
+        "В": "b",
+        "м": "m",
+        "М": "m",
+        "т": "t",
+        "Т": "t",
+        "н": "h",
+        "Н": "h",
+    }
+)
+
+
+def _normalize_lookalikes(text: str) -> str:
+    """Fold Cyrillic homoglyphs to Latin for ban-list matching only.
+
+    Applied before substring/pattern checks; never to the posted text.
+    """
+    return text.translate(_CYRILLIC_TO_LATIN)
+
 
 ALLOWED_CHANNELS = frozenset({"ru", "en"})
 
@@ -139,12 +188,17 @@ def _validate_html(text: str) -> list[str]:
 
 def _check_banned(text: str) -> list[str]:
     errors: list[str] = []
+    # Fold Cyrillic homoglyphs to Latin so mixed-script bypass (e.g. Cyrillic А
+    # in "А/B тест") still trips the ban list. Patterns are checked against
+    # both forms because the Cyrillic-only patterns (день, итерация) need the
+    # original characters.
     lower = text.lower()
+    folded = _normalize_lookalikes(lower)
     for needle in BANNED_SUBSTRINGS:
-        if needle in lower:
+        if needle in lower or needle in folded:
             errors.append(f"Banned substring: '{needle}' — topic violates HARD BAN")
     for pattern in BANNED_PATTERNS:
-        m = pattern.search(text)
+        m = pattern.search(text) or pattern.search(folded)
         if m:
             errors.append(
                 f"Banned pattern: '{m.group(0)}' — A/B iteration updates are banned, "

--- a/src/comms/publishing.py
+++ b/src/comms/publishing.py
@@ -1,0 +1,351 @@
+"""
+Single entry point for publishing editorial posts to @ffmemes channels.
+
+The Comms Agent calls `publish_editorial_post(...)` — that function validates
+the draft, posts it as ONE Telegram message via `post_editorial_to_channel`,
+and persists metadata to `editorial_posts` so the stats collector can track
+it. Raw `curl`/Bot API calls are banned; this module is the only sanctioned
+path.
+
+Invariants enforced here (not in prompt):
+- One-message publishing (sendPhoto with caption, single call).
+- Caption length ≤ 1024 chars when media is attached (Telegram hard limit).
+- HTML tag whitelist (b, strong, i, em, code, a, blockquote).
+- `<blockquote>` is always rewritten to `<blockquote expandable>`.
+- Substring/pattern ban (describe_memes, circuit breakers, A/B iteration updates).
+- Category+entity rotation check against the last 14 editorial posts.
+- Idempotency via SHA256 `draft_hash` (same draft, same channel → no double-post).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+
+from src.database import editorial_posts, execute, fetch_all, fetch_one
+
+VALIDATION_VERSION = 1
+
+# Telegram Bot API caption limit for sendPhoto (chars, not bytes).
+TELEGRAM_CAPTION_MAX = 1024
+# Telegram Bot API text limit for sendMessage.
+TELEGRAM_MESSAGE_MAX = 4096
+
+# HTML tag whitelist. Agent-facing tone: casual, concise — these 5 cover it.
+ALLOWED_HTML_TAGS = {"b", "strong", "i", "em", "code", "a", "blockquote"}
+
+_TAG_RE = re.compile(r"<(/?)([a-zA-Z][a-zA-Z0-9\-]*)([^>]*)>")
+_BLOCKQUOTE_OPEN_RE = re.compile(r"<blockquote(\s[^>]*)?>", re.IGNORECASE)
+
+BANNED_SUBSTRINGS: tuple[str, ...] = (
+    "describe_memes",
+    "describe memes",
+    "circuit breaker",
+    "openrouter",
+    "free tier",
+    "rate limit",
+    "402 error",
+    "deploy rollback",
+    "rollback",
+    "crashed",
+    "fixed bug",
+    "ab test",
+    "a/b test",
+)
+
+# Regex patterns for banned content structures.
+BANNED_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # "день 11/14", "day 12/14" — in-progress experiment iteration updates.
+    re.compile(r"день\s+\d+\s*/\s*\d+", re.IGNORECASE),
+    re.compile(r"\bday\s+\d+\s*/\s*\d+", re.IGNORECASE),
+    # "итерация эксперимента" — experiments-in-progress framing.
+    re.compile(r"итерация\s+эксперимента", re.IGNORECASE),
+)
+
+ALLOWED_CHANNELS = frozenset({"ru", "en"})
+
+
+class EditorialValidationError(Exception):
+    """Raised when a draft fails validation. The agent must fix and retry."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("Draft rejected: " + "; ".join(errors))
+
+
+@dataclass
+class ValidationResult:
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class EditorialPostResult:
+    message_id: int
+    editorial_post_id: int
+    already_posted: bool
+    normalized_text: str
+
+
+def normalize_blockquote(text: str) -> str:
+    """Rewrite every <blockquote> to <blockquote expandable>.
+
+    User preference: expandable by default. If the agent already wrote
+    `<blockquote expandable>`, leave it alone.
+    """
+
+    def repl(match: re.Match[str]) -> str:
+        attrs = (match.group(1) or "").strip()
+        if "expandable" in attrs.lower():
+            return match.group(0)
+        return "<blockquote expandable>"
+
+    return _BLOCKQUOTE_OPEN_RE.sub(repl, text)
+
+
+def _validate_html(text: str) -> list[str]:
+    errors: list[str] = []
+    stack: list[str] = []
+    for match in _TAG_RE.finditer(text):
+        closing = match.group(1) == "/"
+        tag = match.group(2).lower()
+        attrs = match.group(3) or ""
+        if tag not in ALLOWED_HTML_TAGS:
+            errors.append(
+                f"Disallowed HTML tag <{tag}>. Allowed: " + ", ".join(sorted(ALLOWED_HTML_TAGS))
+            )
+            continue
+        if closing:
+            if not stack or stack[-1] != tag:
+                errors.append(f"Mismatched closing tag </{tag}>")
+            else:
+                stack.pop()
+            continue
+        if tag == "a" and "href=" not in attrs.lower():
+            errors.append("<a> tag missing href attribute")
+        if tag == "blockquote" and stack and "blockquote" in stack:
+            errors.append("Nested <blockquote> is not supported by Telegram")
+        stack.append(tag)
+    if stack:
+        errors.append(f"Unclosed HTML tags: {', '.join(stack)}")
+    return errors
+
+
+def _check_banned(text: str) -> list[str]:
+    errors: list[str] = []
+    lower = text.lower()
+    for needle in BANNED_SUBSTRINGS:
+        if needle in lower:
+            errors.append(f"Banned substring: '{needle}' — topic violates HARD BAN")
+    for pattern in BANNED_PATTERNS:
+        m = pattern.search(text)
+        if m:
+            errors.append(
+                f"Banned pattern: '{m.group(0)}' — A/B iteration updates are banned, "
+                "post the conclusive learning instead"
+            )
+    return errors
+
+
+def _check_length(text: str, has_media: bool) -> list[str]:
+    limit = TELEGRAM_CAPTION_MAX if has_media else TELEGRAM_MESSAGE_MAX
+    # Length check is on the final text Telegram will see. HTML tags DO count
+    # toward the caption limit in the Bot API. We keep the agent safely under.
+    if len(text) > limit:
+        kind = "caption" if has_media else "text"
+        return [
+            f"Too long: {len(text)} chars > {limit} {kind} limit. "
+            "Splitting into two messages is banned — shorten or move details "
+            "into <blockquote expandable>."
+        ]
+    return []
+
+
+def _check_rotation(
+    category: str,
+    entity_id: str,
+    recent: Iterable[tuple[str | None, str | None]],
+) -> list[str]:
+    for rc, re_ in recent:
+        if rc == category and re_ == entity_id:
+            return [
+                f"Rotation violation: category={category!r} entity={entity_id!r} "
+                "was published in the last 14 editorial posts. Pick a different anomaly."
+            ]
+    return []
+
+
+def validate_post_draft(
+    text: str,
+    has_media: bool,
+    category: str,
+    entity_id: str,
+    recent: Iterable[tuple[str | None, str | None]] = (),
+) -> ValidationResult:
+    """Validate a post draft. Returns ValidationResult — does not raise."""
+    errors: list[str] = []
+    if not text.strip():
+        errors.append("Empty post text")
+    if not category:
+        errors.append("Missing category (A-F)")
+    if not entity_id:
+        errors.append("Missing entity_id (specific source/metric/feature)")
+    errors.extend(_validate_html(text))
+    errors.extend(_check_banned(text))
+    errors.extend(_check_length(text, has_media))
+    errors.extend(_check_rotation(category, entity_id, recent))
+    return ValidationResult(ok=not errors, errors=errors)
+
+
+def compute_draft_hash(
+    channel: str,
+    text: str,
+    photo_key: str | None,
+    category: str,
+    entity_id: str,
+) -> str:
+    blob = f"{channel}|{category}|{entity_id}|{photo_key or ''}|{text}"
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:32]
+
+
+async def _recent_rotation_keys(
+    channel: str, limit: int = 14
+) -> list[tuple[str | None, str | None]]:
+    rows = await fetch_all(
+        select(editorial_posts.c.category, editorial_posts.c.entity_id)
+        .where(editorial_posts.c.channel == channel)
+        .order_by(editorial_posts.c.created_at.desc())
+        .limit(limit)
+    )
+    return [(r["category"], r["entity_id"]) for r in (rows or [])]
+
+
+async def publish_editorial_post(
+    text: str,
+    channel: str,
+    category: str,
+    entity_id: str,
+    photo_file_id: str | None = None,
+    photo_url: str | None = None,
+    button_text: str | None = None,
+    button_url: str | None = None,
+    topic_slug: str | None = None,
+) -> EditorialPostResult:
+    """Publish an editorial post. Single sanctioned posting path for the agent.
+
+    Raises EditorialValidationError on validation failure — the agent must
+    read the error list, fix the draft, and call again.
+    """
+    if channel not in ALLOWED_CHANNELS:
+        raise EditorialValidationError([f"Invalid channel {channel!r}; use 'ru' or 'en'"])
+
+    normalized_text = normalize_blockquote(text)
+    photo_key = photo_file_id or photo_url
+    has_media = bool(photo_key)
+
+    draft_hash = compute_draft_hash(
+        channel=channel,
+        text=normalized_text,
+        photo_key=photo_key,
+        category=category,
+        entity_id=entity_id,
+    )
+
+    existing = await fetch_one(
+        select(
+            editorial_posts.c.id,
+            editorial_posts.c.telegram_message_id,
+        ).where(editorial_posts.c.draft_hash == draft_hash)
+    )
+    if existing:
+        return EditorialPostResult(
+            message_id=existing["telegram_message_id"],
+            editorial_post_id=existing["id"],
+            already_posted=True,
+            normalized_text=normalized_text,
+        )
+
+    recent = await _recent_rotation_keys(channel)
+    result = validate_post_draft(
+        text=normalized_text,
+        has_media=has_media,
+        category=category,
+        entity_id=entity_id,
+        recent=recent,
+    )
+    if not result.ok:
+        raise EditorialValidationError(result.errors)
+
+    # Import lazily — avoids pulling python-telegram-bot into the Comms agent
+    # runtime for dry-run / validation-only calls in tests.
+    from src.flows.crossposting.editorial import post_editorial_to_channel
+
+    message_id = await post_editorial_to_channel(
+        text=normalized_text,
+        channel=channel,
+        photo_file_id=photo_file_id,
+        photo_url=photo_url,
+        button_text=button_text,
+        button_url=button_url,
+    )
+
+    row = await fetch_one(
+        insert(editorial_posts)
+        .values(
+            channel=channel,
+            telegram_message_id=message_id,
+            draft_hash=draft_hash,
+            category=category,
+            entity_id=entity_id,
+            topic_slug=topic_slug,
+            text=normalized_text,
+            has_media=has_media,
+            validation_version=VALIDATION_VERSION,
+        )
+        .returning(editorial_posts.c.id)
+    )
+    if row is None:
+        raise RuntimeError(f"editorial_posts insert returned no row for message_id={message_id}")
+
+    return EditorialPostResult(
+        message_id=message_id,
+        editorial_post_id=row["id"],
+        already_posted=False,
+        normalized_text=normalized_text,
+    )
+
+
+async def mark_tracked_message_ids(channel: str) -> dict[int, int]:
+    """Return {telegram_message_id: editorial_posts.id} for stats collector."""
+    rows = await fetch_all(
+        select(
+            editorial_posts.c.id,
+            editorial_posts.c.telegram_message_id,
+        ).where(editorial_posts.c.channel == channel)
+    )
+    return {r["telegram_message_id"]: r["id"] for r in (rows or [])}
+
+
+# `execute` is re-exported so tests can patch a single location if needed.
+__all__ = [
+    "ALLOWED_HTML_TAGS",
+    "BANNED_PATTERNS",
+    "BANNED_SUBSTRINGS",
+    "EditorialPostResult",
+    "EditorialValidationError",
+    "TELEGRAM_CAPTION_MAX",
+    "TELEGRAM_MESSAGE_MAX",
+    "ValidationResult",
+    "compute_draft_hash",
+    "execute",
+    "mark_tracked_message_ids",
+    "normalize_blockquote",
+    "publish_editorial_post",
+    "validate_post_draft",
+]

--- a/src/database.py
+++ b/src/database.py
@@ -485,7 +485,7 @@ editorial_posts = Table(
     metadata,
     Column("id", Integer, Identity(), primary_key=True),
     Column("channel", String, nullable=False),
-    Column("telegram_message_id", BigInteger, nullable=False),
+    Column("telegram_message_id", BigInteger, nullable=True),
     Column("draft_hash", String, nullable=False),
     Column("category", String),
     Column("entity_id", String),

--- a/src/database.py
+++ b/src/database.py
@@ -480,6 +480,49 @@ channel_daily_stats = Table(
     UniqueConstraint("channel", "date"),
 )
 
+editorial_posts = Table(
+    "editorial_posts",
+    metadata,
+    Column("id", Integer, Identity(), primary_key=True),
+    Column("channel", String, nullable=False),
+    Column("telegram_message_id", BigInteger, nullable=False),
+    Column("draft_hash", String, nullable=False),
+    Column("category", String),
+    Column("entity_id", String),
+    Column("topic_slug", String),
+    Column("text", String, nullable=False),
+    Column("has_media", Boolean, nullable=False, server_default="false"),
+    Column("validation_version", Integer, nullable=False, server_default="1"),
+    Column("created_at", DateTime, server_default=func.now(), nullable=False),
+    Column("views", Integer),
+    Column("forwards", Integer),
+    Column("reactions", Integer),
+    Column("comments", Integer),
+    Column("reactions_detail", JSONB),  # {"😁": 6, "❤": 4, ...}
+    Column("stats_updated_at", DateTime),
+    UniqueConstraint("draft_hash", name="uq_editorial_posts_draft_hash"),
+    UniqueConstraint("channel", "telegram_message_id", name="uq_editorial_posts_channel_msg"),
+)
+
+editorial_post_snapshots = Table(
+    "editorial_post_snapshots",
+    metadata,
+    Column("id", Integer, Identity(), primary_key=True),
+    Column("channel", String, nullable=False),
+    Column(
+        "editorial_post_id",
+        ForeignKey("editorial_posts.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("telegram_message_id", BigInteger, nullable=False),
+    Column("views", Integer),
+    Column("forwards", Integer),
+    Column("reactions", Integer),
+    Column("comments", Integer),
+    Column("reactions_detail", JSONB),
+    Column("snapshot_at", DateTime, server_default=func.now(), nullable=False),
+)
+
 user_popup_logs = Table(
     "user_popup_logs",
     metadata,

--- a/src/flows/crossposting/stats_collector.py
+++ b/src/flows/crossposting/stats_collector.py
@@ -31,6 +31,8 @@ from src.database import (
     channel_daily_stats,
     crossposting,
     crossposting_snapshots,
+    editorial_post_snapshots,
+    editorial_posts,
     execute,
     fetch_all,
 )
@@ -61,8 +63,30 @@ def _get_telethon_client() -> TelegramClient | None:
     )
 
 
+def _extract_metrics(msg) -> tuple[int, int, int, dict[str, int], int]:
+    """Return (views, forwards, reactions_total, reactions_detail, comments)."""
+    views = getattr(msg, "views", None) or 0
+    forwards = getattr(msg, "forwards", None) or 0
+    reaction_count = 0
+    reactions_detail: dict[str, int] = {}
+    if msg.reactions and hasattr(msg.reactions, "results"):
+        for r in msg.reactions.results:
+            reaction_count += r.count
+            emoji = getattr(r.reaction, "emoticon", str(r.reaction))
+            reactions_detail[emoji] = r.count
+    comments = 0
+    if msg.replies:
+        comments = getattr(msg.replies, "replies", 0) or 0
+    return views, forwards, reaction_count, reactions_detail, comments
+
+
 async def _collect_post_stats(client: TelegramClient, channel_key: str, channel_username: str):
-    """Collect views/forwards/reactions for recent posts in a channel."""
+    """Collect views/forwards/reactions for recent posts in a channel.
+
+    Posts may be tracked in two places: `crossposting` (meme cross-posts, high
+    volume) or `editorial_posts` (agent-written updates, ~1/day). A single
+    Telegram message cannot be both, so we dispatch by source.
+    """
     log = get_run_logger()
 
     try:
@@ -71,89 +95,116 @@ async def _collect_post_stats(client: TelegramClient, channel_key: str, channel_
         log.error(f"Cannot access @{channel_username} — private or no access")
         return
 
-    # Get recent posts (last 48h worth, limit 50)
-    messages = await client.get_messages(entity, limit=50)
+    # Fetch a wider window: editorial posts are low-volume (~1/day) so we want
+    # to keep refreshing them for ~30 days. Meme crossposts get most of their
+    # views in the first 48h, but re-updating is cheap.
+    messages = await client.get_messages(entity, limit=200)
 
-    cutoff = datetime.utcnow() - timedelta(hours=48)
+    cutoff = datetime.utcnow() - timedelta(days=30)
     recent_messages = [m for m in messages if m.date and m.date.replace(tzinfo=None) > cutoff]
 
-    log.info(f"@{channel_username}: {len(recent_messages)} posts in last 48h")
+    log.info(f"@{channel_username}: {len(recent_messages)} posts in last 30d")
 
-    # Get crossposting rows that have telegram_message_id for matching
     if not recent_messages:
         return
 
-    # Fetch all crossposting rows for this channel that have telegram_message_id set.
-    # We filter in Python rather than using ANY() which isn't used elsewhere in the codebase.
-    rows = await fetch_all(
+    # Build two lookup maps so a single message update is routed correctly.
+    crosspost_rows = await fetch_all(
         text(
             "SELECT meme_id, telegram_message_id FROM crossposting "
             "WHERE channel = :channel AND telegram_message_id IS NOT NULL"
         ),
         {"channel": channel_key},
     )
-    known_msg_ids = {r["telegram_message_id"]: r["meme_id"] for r in rows} if rows else {}
+    known_crosspost = (
+        {r["telegram_message_id"]: r["meme_id"] for r in crosspost_rows} if crosspost_rows else {}
+    )
 
-    snapshots_inserted = 0
+    editorial_rows = await fetch_all(
+        text("SELECT id, telegram_message_id FROM editorial_posts " "WHERE channel = :channel"),
+        {"channel": channel_key},
+    )
+    known_editorial = (
+        {r["telegram_message_id"]: r["id"] for r in editorial_rows} if editorial_rows else {}
+    )
+
+    crosspost_snapshots = 0
+    editorial_snapshots = 0
     for msg in recent_messages:
-        views = getattr(msg, "views", None) or 0
-        forwards = getattr(msg, "forwards", None) or 0
+        views, forwards, reaction_count, reactions_detail, comments = _extract_metrics(msg)
 
-        # Reactions: total count + per-emoji breakdown
-        reaction_count = 0
-        reactions_detail = {}
-        if msg.reactions and hasattr(msg.reactions, "results"):
-            for r in msg.reactions.results:
-                reaction_count += r.count
-                emoji = getattr(r.reaction, "emoticon", str(r.reaction))
-                reactions_detail[emoji] = r.count
+        meme_id = known_crosspost.get(msg.id)
+        editorial_id = known_editorial.get(msg.id)
 
-        # Comments count
-        comments = 0
-        if msg.replies:
-            comments = getattr(msg.replies, "replies", 0) or 0
-
-        meme_id = known_msg_ids.get(msg.id)
-        if meme_id is None:
-            # Post not tracked in crossposting table (pre-T2 or manual)
-            continue
-
-        # Insert time-series snapshot
-        await execute(
-            insert(crossposting_snapshots).values(
-                channel=channel_key,
-                meme_id=meme_id,
-                telegram_message_id=msg.id,
-                views=views,
-                forwards=forwards,
-                reactions=reaction_count,
-                comments=comments,
-                reactions_detail=reactions_detail or None,
-                message_text=(msg.text or "")[:500],
+        if meme_id is not None:
+            await execute(
+                insert(crossposting_snapshots).values(
+                    channel=channel_key,
+                    meme_id=meme_id,
+                    telegram_message_id=msg.id,
+                    views=views,
+                    forwards=forwards,
+                    reactions=reaction_count,
+                    comments=comments,
+                    reactions_detail=reactions_detail or None,
+                    message_text=(msg.text or "")[:500],
+                )
             )
-        )
-        snapshots_inserted += 1
+            crosspost_snapshots += 1
+            await execute(
+                text(
+                    "UPDATE crossposting SET views = :views, forwards = :fwd, "
+                    "reactions = :react, comments = :comments, "
+                    "reactions_detail = :rdetail, stats_updated_at = NOW() "
+                    "WHERE channel = :ch AND telegram_message_id = :msg_id"
+                ),
+                {
+                    "views": views,
+                    "fwd": forwards,
+                    "react": reaction_count,
+                    "comments": comments,
+                    "rdetail": json.dumps(reactions_detail) if reactions_detail else None,
+                    "ch": channel_key,
+                    "msg_id": msg.id,
+                },
+            )
 
-        # Update latest values on crossposting table
-        await execute(
-            text(
-                "UPDATE crossposting SET views = :views, forwards = :fwd, "
-                "reactions = :react, comments = :comments, "
-                "reactions_detail = :rdetail, stats_updated_at = NOW() "
-                "WHERE channel = :ch AND telegram_message_id = :msg_id"
-            ),
-            {
-                "views": views,
-                "fwd": forwards,
-                "react": reaction_count,
-                "comments": comments,
-                "rdetail": json.dumps(reactions_detail) if reactions_detail else None,
-                "ch": channel_key,
-                "msg_id": msg.id,
-            },
-        )
+        if editorial_id is not None:
+            await execute(
+                insert(editorial_post_snapshots).values(
+                    channel=channel_key,
+                    editorial_post_id=editorial_id,
+                    telegram_message_id=msg.id,
+                    views=views,
+                    forwards=forwards,
+                    reactions=reaction_count,
+                    comments=comments,
+                    reactions_detail=reactions_detail or None,
+                )
+            )
+            editorial_snapshots += 1
+            await execute(
+                text(
+                    "UPDATE editorial_posts SET views = :views, forwards = :fwd, "
+                    "reactions = :react, comments = :comments, "
+                    "reactions_detail = :rdetail, stats_updated_at = NOW() "
+                    "WHERE channel = :ch AND telegram_message_id = :msg_id"
+                ),
+                {
+                    "views": views,
+                    "fwd": forwards,
+                    "react": reaction_count,
+                    "comments": comments,
+                    "rdetail": json.dumps(reactions_detail) if reactions_detail else None,
+                    "ch": channel_key,
+                    "msg_id": msg.id,
+                },
+            )
 
-    log.info(f"@{channel_username}: {snapshots_inserted} snapshots inserted")
+    log.info(
+        f"@{channel_username}: {crosspost_snapshots} crosspost snapshots, "
+        f"{editorial_snapshots} editorial snapshots"
+    )
 
 
 async def _collect_subscriber_count(

--- a/src/flows/crossposting/stats_collector.py
+++ b/src/flows/crossposting/stats_collector.py
@@ -121,7 +121,10 @@ async def _collect_post_stats(client: TelegramClient, channel_key: str, channel_
     )
 
     editorial_rows = await fetch_all(
-        text("SELECT id, telegram_message_id FROM editorial_posts " "WHERE channel = :channel"),
+        text(
+            "SELECT id, telegram_message_id FROM editorial_posts "
+            "WHERE channel = :channel AND telegram_message_id IS NOT NULL"
+        ),
         {"channel": channel_key},
     )
     known_editorial = (

--- a/tests/comms/test_performance.py
+++ b/tests/comms/test_performance.py
@@ -1,0 +1,111 @@
+"""Unit tests for the performance report formatter.
+
+The DB-backed helpers are covered by integration; these tests cover the
+deterministic formatting layer.
+"""
+
+from datetime import datetime, timedelta
+
+from src.comms.performance import (
+    EditorialRow,
+    format_channel_stats_report,
+)
+
+
+def _row(
+    rid: int,
+    days_ago: int,
+    views: int,
+    category: str = "C",
+    entity: str | None = None,
+    reactions: int = 0,
+    reactions_detail: dict[str, int] | None = None,
+    forwards: int = 0,
+    text: str = "sample",
+) -> EditorialRow:
+    now = datetime(2026, 4, 24, 6, 0, 0)
+    return EditorialRow(
+        id=rid,
+        channel="ru",
+        created_at=now - timedelta(days=days_ago),
+        category=category,
+        entity_id=entity or f"ent_{rid}",
+        topic_slug=f"slug-{rid}",
+        text=text,
+        views=views,
+        forwards=forwards,
+        reactions=reactions,
+        reactions_detail=reactions_detail,
+        telegram_message_id=1000 + rid,
+    )
+
+
+def test_format_empty_rows():
+    out = format_channel_stats_report([], channel="ru", days=30, as_of=datetime(2026, 4, 24))
+    assert "No editorial posts" in out
+    assert "2026-04-24" in out
+
+
+def test_format_reports_median_and_counts():
+    rows = [_row(i, days_ago=i, views=100 + i * 10) for i in range(5)]
+    out = format_channel_stats_report(rows, channel="ru", days=30, as_of=datetime(2026, 4, 24, 10))
+    assert "Posts: 5" in out
+    assert "Median views: 120" in out
+
+
+def test_format_top_views_sorted_desc():
+    rows = [_row(1, 1, 50), _row(2, 2, 500), _row(3, 3, 200)]
+    out = format_channel_stats_report(rows, channel="ru", days=30, as_of=datetime(2026, 4, 24, 10))
+    top_section = out.split("## Top 5 by views")[1].split("##")[0]
+    lines = [line for line in top_section.splitlines() if line.startswith("-")]
+    # First bullet should be the 500-view row.
+    assert "500" in lines[0]
+    assert "200" in lines[1]
+    assert "50" in lines[2]
+
+
+def test_format_weakest_excludes_fresh():
+    # Fresh (<24h old) post with 0 views should NOT show in weakest — we can't
+    # judge yet.
+    fresh = _row(1, days_ago=0, views=0, text="fresh post")
+    mature_low = _row(2, days_ago=5, views=20, text="mature low")
+    mature_high = _row(3, days_ago=4, views=500, text="mature high")
+    out = format_channel_stats_report(
+        [fresh, mature_low, mature_high],
+        channel="ru",
+        days=30,
+        as_of=datetime(2026, 4, 24, 10),
+    )
+    weakest = out.split("## Weakest 3")[1].split("##")[0]
+    assert "mature low" in weakest
+    assert "fresh post" not in weakest
+
+
+def test_format_reaction_mix_top5():
+    rows = [
+        _row(1, 1, 100, reactions_detail={"🔥": 10, "❤": 5}),
+        _row(2, 2, 100, reactions_detail={"🔥": 4, "👍": 3, "😁": 2}),
+        _row(3, 3, 100, reactions_detail={"💩": 1}),
+    ]
+    out = format_channel_stats_report(rows, channel="ru", days=30, as_of=datetime(2026, 4, 24, 10))
+    section = out.split("## Reaction mix")[1].split("##")[0]
+    assert "🔥 × 14" in section
+    assert "❤ × 5" in section
+
+
+def test_format_rotation_keys_last_7():
+    rows = [_row(i, days_ago=i, views=50, category="C", entity=f"e{i}") for i in range(10)]
+    out = format_channel_stats_report(rows, channel="ru", days=30, as_of=datetime(2026, 4, 24, 10))
+    section = out.split("## Last 7")[1].split("##")[0]
+    # First 7 entities should appear.
+    for i in range(7):
+        assert f"e{i}" in section
+    # 8th should not.
+    assert "e8" not in section
+
+
+def test_format_strips_html_from_preview():
+    rows = [_row(1, 1, 100, text="<b>жир</b> и <i>курсив</i>")]
+    out = format_channel_stats_report(rows, channel="ru", days=30, as_of=datetime(2026, 4, 24, 10))
+    assert "<b>" not in out
+    assert "жир и курсив" in out

--- a/tests/comms/test_publishing.py
+++ b/tests/comms/test_publishing.py
@@ -1,0 +1,243 @@
+"""Unit tests for validation and normalization helpers in src.comms.publishing.
+
+These tests do NOT touch the DB or Telegram — they verify the pure pieces
+that would block a bad draft before any async work runs.
+"""
+
+import pytest
+
+from src.comms.publishing import (
+    ALLOWED_HTML_TAGS,
+    TELEGRAM_CAPTION_MAX,
+    compute_draft_hash,
+    normalize_blockquote,
+    validate_post_draft,
+)
+
+# ── normalize_blockquote ──────────────────────────────────────────────────
+
+
+def test_normalize_blockquote_rewrites_plain_to_expandable():
+    out = normalize_blockquote("before <blockquote>hi</blockquote> after")
+    assert out == "before <blockquote expandable>hi</blockquote> after"
+
+
+def test_normalize_blockquote_leaves_expandable_alone():
+    src = "x <blockquote expandable>y</blockquote>"
+    assert normalize_blockquote(src) == src
+
+
+def test_normalize_blockquote_is_case_insensitive():
+    out = normalize_blockquote("<BLOCKQUOTE>x</BLOCKQUOTE>")
+    assert "<blockquote expandable>" in out
+
+
+def test_normalize_blockquote_handles_multiple():
+    out = normalize_blockquote("<blockquote>a</blockquote> <blockquote>b</blockquote>")
+    assert out.count("<blockquote expandable>") == 2
+
+
+# ── validate_post_draft: happy path ───────────────────────────────────────
+
+
+def test_validate_happy_path_caption():
+    result = validate_post_draft(
+        text="<b>Интересное:</b> сессия выросла на 18%.",
+        has_media=True,
+        category="C",
+        entity_id="session_length_2026_04_24",
+        recent=[("C", "dau_delta_2026_04_23"), ("A", "popup_at_meme_5")],
+    )
+    assert result.ok, result.errors
+    assert result.errors == []
+
+
+# ── HTML whitelist ────────────────────────────────────────────────────────
+
+
+def test_validate_rejects_disallowed_tag():
+    result = validate_post_draft(
+        text="<div>broken</div>",
+        has_media=True,
+        category="C",
+        entity_id="e",
+    )
+    assert not result.ok
+    assert any("div" in e for e in result.errors)
+
+
+def test_validate_rejects_anchor_without_href():
+    result = validate_post_draft(
+        text="<a>click</a>",
+        has_media=True,
+        category="C",
+        entity_id="e",
+    )
+    assert not result.ok
+    assert any("href" in e.lower() for e in result.errors)
+
+
+def test_validate_rejects_unclosed_tag():
+    result = validate_post_draft(
+        text="<b>unclosed",
+        has_media=True,
+        category="C",
+        entity_id="e",
+    )
+    assert not result.ok
+    assert any("Unclosed" in e for e in result.errors)
+
+
+def test_validate_rejects_nested_blockquote():
+    result = validate_post_draft(
+        text="<blockquote>outer <blockquote>inner</blockquote></blockquote>",
+        has_media=True,
+        category="C",
+        entity_id="e",
+    )
+    assert not result.ok
+    assert any("Nested" in e for e in result.errors)
+
+
+def test_validate_accepts_all_whitelisted_tags():
+    body = (
+        "<b>b</b> <strong>s</strong> <i>i</i> <em>e</em> <code>c</code> "
+        '<a href="https://t.me/ffmemesbot">l</a> '
+        "<blockquote>q</blockquote>"
+    )
+    result = validate_post_draft(text=body, has_media=True, category="A", entity_id="feat_x")
+    assert result.ok, result.errors
+
+
+def test_whitelist_contains_expected_set():
+    # Guard against accidental addition of risky tags.
+    assert ALLOWED_HTML_TAGS == {"b", "strong", "i", "em", "code", "a", "blockquote"}
+
+
+# ── Banned substrings / patterns ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_text",
+    [
+        "мы пофиксили describe_memes",
+        "Circuit breaker сработал на параметрах",
+        "OpenRouter упал, всё пропало",
+        "А/B тест показал что",
+        "день 11/14 GOAT-фильтра идёт",
+        "Day 5/7 of the feature rollout",
+        "итерация эксперимента номер три",
+    ],
+)
+def test_validate_rejects_banned(bad_text):
+    result = validate_post_draft(text=bad_text, has_media=True, category="C", entity_id="e")
+    assert not result.ok, f"expected ban on: {bad_text!r}"
+
+
+def test_validate_banned_patterns_message_useful():
+    result = validate_post_draft(
+        text="день 12/14 эксперимента",
+        has_media=True,
+        category="C",
+        entity_id="e",
+    )
+    assert not result.ok
+    joined = " ".join(result.errors)
+    # Error should mention iteration updates are banned.
+    assert "iteration" in joined.lower() or "N/M" in joined or "12/14" in joined
+
+
+# ── Length cap ────────────────────────────────────────────────────────────
+
+
+def test_validate_rejects_caption_over_1024():
+    result = validate_post_draft(
+        text="A" * (TELEGRAM_CAPTION_MAX + 1),
+        has_media=True,
+        category="C",
+        entity_id="e",
+    )
+    assert not result.ok
+    assert any("Too long" in e for e in result.errors)
+
+
+def test_validate_accepts_caption_at_limit():
+    result = validate_post_draft(
+        text="A" * TELEGRAM_CAPTION_MAX,
+        has_media=True,
+        category="C",
+        entity_id="e",
+    )
+    assert result.ok
+
+
+def test_validate_allows_longer_text_when_no_media():
+    result = validate_post_draft(
+        text="A" * (TELEGRAM_CAPTION_MAX + 100),
+        has_media=False,
+        category="C",
+        entity_id="e",
+    )
+    assert result.ok
+
+
+# ── Rotation ──────────────────────────────────────────────────────────────
+
+
+def test_validate_rejects_rotation_clash():
+    result = validate_post_draft(
+        text="<b>hi</b>",
+        has_media=True,
+        category="C",
+        entity_id="dau_delta_2026_04_24",
+        recent=[("C", "dau_delta_2026_04_24")],
+    )
+    assert not result.ok
+    assert any("Rotation" in e for e in result.errors)
+
+
+def test_validate_passes_rotation_with_distinct_entity():
+    result = validate_post_draft(
+        text="<b>hi</b>",
+        has_media=True,
+        category="C",
+        entity_id="source_climber_2026_04_24",
+        recent=[("C", "dau_delta_2026_04_24")],
+    )
+    assert result.ok
+
+
+# ── Metadata ──────────────────────────────────────────────────────────────
+
+
+def test_validate_requires_category_and_entity():
+    result = validate_post_draft(text="<b>hi</b>", has_media=True, category="", entity_id="")
+    assert not result.ok
+    joined = " ".join(result.errors)
+    assert "category" in joined.lower()
+    assert "entity_id" in joined.lower()
+
+
+def test_validate_requires_nonempty_text():
+    result = validate_post_draft(text="   ", has_media=True, category="C", entity_id="e")
+    assert not result.ok
+    assert any("Empty" in e for e in result.errors)
+
+
+# ── Draft hash ────────────────────────────────────────────────────────────
+
+
+def test_compute_draft_hash_is_stable():
+    a = compute_draft_hash("ru", "hello", "file_id_1", "C", "e1")
+    b = compute_draft_hash("ru", "hello", "file_id_1", "C", "e1")
+    assert a == b
+    assert len(a) == 32
+
+
+def test_compute_draft_hash_differs_on_any_field():
+    base = compute_draft_hash("ru", "hello", "f1", "C", "e1")
+    assert base != compute_draft_hash("en", "hello", "f1", "C", "e1")
+    assert base != compute_draft_hash("ru", "hi", "f1", "C", "e1")
+    assert base != compute_draft_hash("ru", "hello", "f2", "C", "e1")
+    assert base != compute_draft_hash("ru", "hello", "f1", "A", "e1")
+    assert base != compute_draft_hash("ru", "hello", "f1", "C", "e2")

--- a/tests/comms/test_publishing.py
+++ b/tests/comms/test_publishing.py
@@ -77,6 +77,34 @@ def test_validate_rejects_anchor_without_href():
     assert any("href" in e.lower() for e in result.errors)
 
 
+def test_validate_rejects_xhref_bypass():
+    # 'href=' as a substring inside another attribute name (xhref) must NOT
+    # satisfy the href-required check. Substring match was a real bug.
+    result = validate_post_draft(
+        text='<a xhref="https://evil">click</a>',
+        has_media=True,
+        category="C",
+        entity_id="e",
+    )
+    assert not result.ok
+    assert any("href" in e.lower() for e in result.errors)
+
+
+@pytest.mark.parametrize(
+    "bad_href",
+    [
+        '<a href="javascript:alert(1)">x</a>',
+        '<a href="data:text/plain,hi">x</a>',
+        '<a href="vbscript:msgbox(1)">x</a>',
+        '<a href="file:///etc/passwd">x</a>',
+    ],
+)
+def test_validate_rejects_unsafe_href_schemes(bad_href):
+    result = validate_post_draft(text=bad_href, has_media=True, category="C", entity_id="e")
+    assert not result.ok
+    assert any("unsafe scheme" in e.lower() for e in result.errors)
+
+
 def test_validate_rejects_unclosed_tag():
     result = validate_post_draft(
         text="<b>unclosed",
@@ -241,3 +269,19 @@ def test_compute_draft_hash_differs_on_any_field():
     assert base != compute_draft_hash("ru", "hello", "f2", "C", "e1")
     assert base != compute_draft_hash("ru", "hello", "f1", "A", "e1")
     assert base != compute_draft_hash("ru", "hello", "f1", "C", "e2")
+
+
+def test_compute_draft_hash_includes_button():
+    base = compute_draft_hash("ru", "hello", "f1", "C", "e1")
+    with_button = compute_draft_hash(
+        "ru", "hello", "f1", "C", "e1", button_text="Открыть", button_url="https://t.me/x"
+    )
+    assert base != with_button
+    # Different URL → different hash even if text identical.
+    assert with_button != compute_draft_hash(
+        "ru", "hello", "f1", "C", "e1", button_text="Открыть", button_url="https://t.me/y"
+    )
+    # Different text → different hash even if URL identical.
+    assert with_button != compute_draft_hash(
+        "ru", "hello", "f1", "C", "e1", button_text="Поехали", button_url="https://t.me/x"
+    )


### PR DESCRIPTION
## Summary

Posts 224+225 and 226+227 on @ffmemes were shipped as two messages (photo without caption, prose as a separate sendMessage), and the prose itself was A/B iteration updates the Comms Agent is supposed to ban. Both failures have the same root cause: the agent was given raw `curl sendPhoto` examples in `AGENTS.md` and the HARD BAN was soft text. Moving invariants into code closes both gaps without narrowing the agent's creative scope.

**Architecture:** keep taste/ideation in prompt, move invariants into code.

- **`src/comms/publishing.py`** (new) — `publish_editorial_post(...)` is the only sanctioned posting path. It enforces:
  - **One message** — wraps the existing `post_editorial_to_channel` (sendPhoto with caption). Splitting into two messages is physically impossible through this API.
  - **1024-char caption cap** — Telegram hard limit; over it → `EditorialValidationError`.
  - **HTML whitelist** — `<b>`, `<strong>`, `<i>`, `<em>`, `<code>`, `<a href>`, `<blockquote>`. Plain `<blockquote>` is rewritten to `<blockquote expandable>` (user preference — collapsed by default). Nested blockquotes rejected.
  - **Substring + regex ban** — `describe_memes`, `circuit breaker`, `openrouter`, `free tier`, `rate limit`, `rollback`, `crashed`, `a/b test`, plus new `день N/M` / `day N/M` / `итерация эксперимента` patterns that catch the iteration-update failures we just saw.
  - **Rotation** — `(category, entity_id)` must not match any of the last 14 editorial posts.
  - **Idempotency** — SHA256 `draft_hash` on `(channel, text, photo, category, entity_id)`; retries return the same message_id.
- **`editorial_posts` + `editorial_post_snapshots` tables** — structured metadata + time-series. Separate from `crossposting` (which is meme-shaped with `FK meme.id`) to avoid leaking editorial hacks into meme code.
- **`stats_collector.py`** — now dispatches Telethon snapshots to the matching table (crossposting vs editorial) by `telegram_message_id`. Window widened to 30d / 200 msgs so editorial posts keep refreshing.
- **`src/comms/performance.py`** (new) — Prefect flow at 06:55 UTC materializes `experiments/reports/channel-stats-YYYY-MM-DD.md`: top/bottom posts by views, reaction emoji mix, category frequency, last-7 rotation hint. Comms Agent reads this in its new Step 0.
- **`agents/comms/AGENTS.md`** — stripped all raw `curl` examples; added Post Formatting (HTML) section; added Step 0 to read the performance digest; noted that HARD BAN substring/pattern matching now happens in `publish_editorial_post` — the agent can't route around it with synonyms.

## Architectural consultation

Codex reviewed the approach before implementation (consult session via `mcp__codex__codex`). Key advice landed verbatim: one canonical publish API that embeds validation internally; `editorial_posts` as a separate table; Python helper over DB (not Telethon) for the feedback loop; materialized markdown digest for LLM-friendly reasoning; direct Python call, not Prefect deployment-run, to avoid retry-doubles.

## Test plan

- [x] `ruff check --fix` clean on all touched files
- [x] `ruff format` applied
- [x] Smoke tests for `normalize_blockquote`, `validate_post_draft` (HTML whitelist, substring ban, pattern ban — день 11/14, caption length, rotation, metadata), `compute_draft_hash` — all pass
- [x] `format_channel_stats_report` smoke tested (empty, median, top-N sort, weakest excludes <24h fresh posts, emoji mix aggregation, last-7 rotation keys, HTML strip in preview)
- [x] `alembic upgrade 5a9d22dbecb6:a1b4c7d0e3f6 --sql` compiles to clean SQL
- [ ] After merge: run `docker compose exec app alembic upgrade head` on prod
- [ ] After merge: verify `editorial_posts` table exists and `collect_channel_stats` runs without error on next cron fire
- [ ] After merge: next Comms Agent post on @ffmemes should be one message with photo+caption, optionally with `<blockquote expandable>` for extended context
- [ ] After merge: first `channel-stats-YYYY-MM-DD.md` will be empty (no tracked editorial posts yet) — expected; fills up as agent posts

## Deploy checklist

1. Merge PR → auto-deploys via Coolify
2. `ssh root@t.ffmemes.com "cd /path/to/app && docker compose exec app alembic upgrade head"` — applies `a1b4c7d0e3f6` adding `editorial_posts` + `editorial_post_snapshots`
3. Restart `prefect_worker` so the new `Write Channel Stats Report` deployment registers (or wait for next serve_flows reload)
4. Monitor next `collect_channel_stats` run — should log `@fastfoodmemes: N crosspost snapshots, 0 editorial snapshots` until agent posts its first editorial via the new path