### PR TITLE
feat(upload): full localization (RU/EN/UK) + inline OCR dedup

### DIFF
--- a/src/tgbot/handlers/upload/moderation.py
+++ b/src/tgbot/handlers/upload/moderation.py
@@ -9,7 +9,9 @@ from telegram.constants import ParseMode
 from telegram.error import BadRequest, Forbidden
 from telegram.ext import ContextTypes
 
+from src import localizer
 from src.config import settings
+from src.flows.storage.describe_memes import describe_single_meme
 from src.flows.storage.memes import (
     add_watermark_to_meme_content,
     upload_meme_content_to_tg,
@@ -18,7 +20,7 @@ from src.recommendations.service import create_user_meme_reaction
 from src.stats.meme import calculate_meme_reactions_and_engagement
 from src.stats.meme_source import calculate_meme_source_stats
 from src.storage.constants import MemeStatus, MemeType
-from src.storage.service import update_meme
+from src.storage.service import find_meme_duplicate, update_meme
 from src.storage.upload import download_meme_content_from_tg
 from src.tgbot.constants import UserType
 from src.tgbot.handlers.treasury.constants import TrxType
@@ -39,65 +41,98 @@ LEADERBOARD_URL = (
 )
 
 
+async def _notify_uploader(
+    bot: Bot,
+    meme_upload: dict[str, Any],
+    text: str,
+    parse_mode: str | None = ParseMode.HTML,
+) -> None:
+    """Send text to uploader, falling back to non-reply if original message was deleted."""
+    try:
+        await bot.send_message(
+            chat_id=meme_upload["user_id"],
+            reply_to_message_id=meme_upload["message_id"],
+            text=text,
+            parse_mode=parse_mode,
+        )
+    except Forbidden:
+        logging.warning(f"Can't notify uploader #{meme_upload['user_id']}: blocked bot")
+    except BadRequest:
+        try:
+            await bot.send_message(
+                chat_id=meme_upload["user_id"],
+                text=text,
+                parse_mode=parse_mode,
+            )
+        except Forbidden:
+            logging.warning(f"Can't notify uploader #{meme_upload['user_id']}: blocked bot")
+
+
+async def _get_uploader_lang(user_id: int) -> str | None:
+    user = await get_user_info(user_id)
+    return user["interface_lang"] if user else None
+
+
+async def _check_duplicate_via_ocr(meme: dict[str, Any]) -> tuple[dict[str, Any], int | None]:
+    """Describe the meme inline via OpenRouter vision and check for OCR-text duplicates.
+
+    Why: describe_memes cron runs hourly; for uploads we can't wait — run it synchronously
+    so the uploader gets immediate feedback and the moderator queue stays clean of dupes.
+    Non-images skip describe (OCR is image-only).
+    Failures (rate limit, model errors, short text) fall through silently — manual review kicks in.
+
+    Returns: (refreshed_meme, duplicate_of_id or None).
+    """
+    if meme["type"] != MemeType.IMAGE:
+        return meme, None
+
+    describe_log = logging.getLogger(__name__)
+    try:
+        status = await describe_single_meme(meme, describe_log)
+    except Exception as e:
+        logging.warning(f"Inline describe failed for meme {meme['id']}: {e}")
+        return meme, None
+
+    if isinstance(status, tuple):
+        status = status[0]
+    if status != "ok":
+        return meme, None
+
+    from src.tgbot.service import get_meme_by_id
+
+    refreshed = await get_meme_by_id(meme["id"])
+    if not refreshed:
+        return meme, None
+
+    ocr_text = (refreshed.get("ocr_result") or {}).get("text") or ""
+    if len(ocr_text) < 12:
+        return refreshed, None
+
+    dup_id = await find_meme_duplicate(refreshed["id"], ocr_text)
+    return refreshed, dup_id
+
+
 async def uploaded_meme_auto_review(
     meme: dict[str, Any], meme_upload: dict[str, Any], bot: Bot
 ) -> None:
+    uploader_lang = await _get_uploader_lang(meme_upload["user_id"])
+
     logging.info(f"Downloading meme {meme['id']} content")
     image_bytes = await download_meme_content_from_tg(meme["telegram_file_id"])
 
     logging.info(f"Adding watermark to meme {meme['id']} content")
     watermarked_meme_content = await add_watermark_to_meme_content(image_bytes, meme["type"])
     if watermarked_meme_content is None:
-        return await bot.send_message(
-            chat_id=meme_upload["user_id"],
-            reply_to_message_id=meme_upload["message_id"],
-            text="""
-❌ MEME REJECTED:
-Something went wrong when we tried to add watermark to your meme. Just try again.
-            """,
+        return await _notify_uploader(
+            bot, meme_upload, localizer.t("upload.watermark_failed", uploader_lang)
         )
 
     logging.info(f"Uploading watermarked meme {meme['id']} content to Telegram")
     meme = await upload_meme_content_to_tg(meme, watermarked_meme_content)
     if meme is None:
-        return await bot.send_message(
-            chat_id=meme_upload["user_id"],
-            reply_to_message_id=meme_upload["message_id"],
-            text="""
-❌ MEME REJECTED:
-Something went wrong when we tried to upload your meme to Telegram. Just try again.
-            """,
+        return await _notify_uploader(
+            bot, meme_upload, localizer.t("upload.tg_upload_failed", uploader_lang)
         )
-
-    #     logging.info(f"Finding duplicates of meme {meme['id']}")
-    #     duplicate_meme_id = await find_meme_duplicate(
-    #         meme["id"],
-    #         meme["ocr_result"]["text"],
-    #     )
-    #     if duplicate_meme_id:
-    #         await update_meme(
-    #             meme["id"],
-    #             status=MemeStatus.DUPLICATE,
-    #             duplicate_of=duplicate_meme_id,
-    #         )
-
-    #         # set like for the uploaded meme
-    #         await create_user_meme_reaction(
-    #             meme_upload["user_id"],
-    #             duplicate_meme_id,
-    #             "uploaded_meme",
-    #             reaction_id=1,
-    #             reacted_at=datetime.utcnow(),
-    #         )
-
-    #         return await bot.send_message(
-    #             chat_id=meme_upload["user_id"],
-    #             reply_to_message_id=meme_upload["message_id"],
-    #             text="""
-    # ❌ MEME REJECTED:
-    # Somebody already submitted this meme, sorry... Try another one.
-    #             """,
-    #         )
 
     logging.info(f"Updating meme {meme['id']} status to WAITING_REVIEW")
     meme = await update_meme(
@@ -105,7 +140,27 @@ Something went wrong when we tried to upload your meme to Telegram. Just try aga
         status=MemeStatus.WAITING_REVIEW,
     )
 
-    # send meme to a manual review
+    # Inline OCR + trigram dedup. Auto-reject on duplicate, else fall through to manual review.
+    meme, duplicate_of = await _check_duplicate_via_ocr(meme)
+    if duplicate_of is not None:
+        logging.info(f"Meme {meme['id']} is a duplicate of {duplicate_of}, auto-rejecting")
+        await update_meme(
+            meme["id"],
+            status=MemeStatus.DUPLICATE,
+            duplicate_of=duplicate_of,
+        )
+        # Credit the uploader with a like on the original, so it counts as engagement
+        await create_user_meme_reaction(
+            meme_upload["user_id"],
+            duplicate_of,
+            "uploaded_meme",
+            reaction_id=1,
+            reacted_at=datetime.utcnow(),
+        )
+        return await _notify_uploader(
+            bot, meme_upload, localizer.t("upload.rejected_duplicate", uploader_lang)
+        )
+
     return await send_uploaded_meme_to_manual_review(meme, meme_upload, bot)
 
 
@@ -258,34 +313,10 @@ async def handle_uploaded_meme_review_button(
             external_id=str(meme["id"]),
         )
 
-        text = """
-🎉🎉🎉
-
-Your <b>meme has been approved</b> and soon bot will send it to other users!
-
-See realtime stats of your uploaded memes: /uploads
-        """
-
-        try:
-            await context.bot.send_message(
-                chat_id=meme_upload["user_id"],
-                reply_to_message_id=meme_upload["message_id"],
-                text=text,
-                parse_mode=ParseMode.HTML,
-            )
-        except Forbidden:
-            logging.warning(f"Can't notify uploader #{meme_upload['user_id']}: blocked bot")
-        except BadRequest:
-            # messsage was deleted ??
-            # trying again withount reply_message_id
-            try:
-                await context.bot.send_message(
-                    chat_id=meme_upload["user_id"],
-                    text=text,
-                    parse_mode=ParseMode.HTML,
-                )
-            except Forbidden:
-                logging.warning(f"Can't notify uploader #{meme_upload['user_id']}: blocked bot")
+        uploader_lang = await _get_uploader_lang(meme_upload["user_id"])
+        await _notify_uploader(
+            context.bot, meme_upload, localizer.t("upload.approved", uploader_lang)
+        )
 
     else:
         await update_meme_by_upload_id(upload_id, status=MemeStatus.REJECTED)
@@ -302,29 +333,8 @@ See realtime stats of your uploaded memes: /uploads
             except BadRequest as exc:
                 if "Message is not modified" not in str(exc):
                     raise
-        try:
-            await context.bot.send_message(
-                chat_id=meme_upload["user_id"],
-                reply_to_message_id=meme_upload["message_id"],
-                text="""
-😢😢😢
 
-Your meme was rejected by our moderators. Send us something else!
-            """,
-            )
-        except Forbidden:
-            logging.warning(f"Can't notify uploader #{meme_upload['user_id']}: blocked bot")
-        except BadRequest:
-            # messsage was deleted ??
-            # trying again withount reply_message_id
-            try:
-                await context.bot.send_message(
-                    chat_id=meme_upload["user_id"],
-                    text="""
-😢😢😢
-
-Your meme was rejected by our moderators. Send us something else!
-            """,
-                )
-            except Forbidden:
-                logging.warning(f"Can't notify uploader #{meme_upload['user_id']}: blocked bot")
+        uploader_lang = await _get_uploader_lang(meme_upload["user_id"])
+        await _notify_uploader(
+            context.bot, meme_upload, localizer.t("upload.rejected", uploader_lang)
+        )

--- a/src/tgbot/handlers/upload/stats.py
+++ b/src/tgbot/handlers/upload/stats.py
@@ -13,27 +13,24 @@ from telegram import (
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 
+from src import localizer
 from src.storage.constants import MemeType
 from src.tgbot.handlers.upload.service import (
     get_fans_of_user_id,
     get_uploaded_memes_of_user_id,
 )
+from src.tgbot.user_info import get_user_info
 
 
 async def handle_uploaded_memes_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Shows stats for uploaded memes"""
-    # user_info = await get_user_info(update.effective_user.id)
+    user_info = await get_user_info(update.effective_user.id)
+    lang = user_info["interface_lang"] if user_info else None
 
     uploaded_memes = await get_uploaded_memes_of_user_id(update.effective_user.id)
     if len(uploaded_memes) == 0:
         await update.message.reply_text(
-            """
-📭 <b>You haven't uploaded any memes yet!</b>
-
-Just forward a meme to our bot to upload it. Only pics are supported yet.
-
-<i>read more:</i> /kitchen
-            """,
+            localizer.t("upload.no_uploads_yet", lang),
             parse_mode=ParseMode.HTML,
         )
         return
@@ -48,17 +45,13 @@ Just forward a meme to our bot to upload it. Only pics are supported yet.
     else:
         total_like_prc = round(total_likes * 100.0 / (total_likes + total_dislikes))
 
-    STATS_TEXT = f"""
-<b>YOUR UPLOADED MEMES</b>
-
-📥 You uploaded <b>{len(uploaded_memes)}</b> memes
-👁️ Views: <b>{total_views}</b>
-👍 Likes: <b>{total_likes}</b>
-♥️ Like %: <b>{total_like_prc}%</b>
-🙋 Fans: <b>{total_fans}</b>
-
-<b>Latest uploads</b>
-views - likes - like %"""
+    stats_text = localizer.t("upload.stats_header", lang).format(
+        n_memes=len(uploaded_memes),
+        total_views=total_views,
+        total_likes=total_likes,
+        total_like_prc=total_like_prc,
+        total_fans=total_fans,
+    )
 
     # show stats for last 5 uploads:
     media = []
@@ -73,13 +66,12 @@ views - likes - like %"""
         else:
             media.append(InputMediaVideo(media=uploaded_meme["telegram_file_id"]))
 
-        STATS_TEXT += f"\n▪ {views} - {likes} - {like_prc}%"
+        stats_text += f"\n▪ {views} - {likes} - {like_prc}%"
 
-    STATS_TEXT += "\n\n<b>Upload more memes and win lots of 🍔</b> /kitchen"
-    STATS_TEXT += "\n/leaderboard /stats /balance"
+    stats_text += "\n\n" + localizer.t("upload.stats_footer", lang)
 
     await update.message.reply_media_group(
         media=media,
-        caption=STATS_TEXT,
+        caption=stats_text,
         parse_mode=ParseMode.HTML,
     )

--- a/src/tgbot/handlers/upload/upload_meme.py
+++ b/src/tgbot/handlers/upload/upload_meme.py
@@ -195,11 +195,7 @@ async def handle_message_with_meme(update: Update, context: ContextTypes.DEFAULT
         uploaded_today = await count_24h_uploaded_not_approved_memes(update.effective_user.id)
         if uploaded_today >= 5:
             return await message.reply_text(
-                """
-You already uploaded lots of memes today. Try again tomorrow.
-Think about quality, not quantity: your goal is to get as many likes as possible.
-Analyse your /uploads
-                """
+                localizer.t("upload.rate_limit_exceeded", user["interface_lang"]),
             )
 
     meme_upload = await create_meme_raw_upload(message)
@@ -208,11 +204,9 @@ Analyse your /uploads
         context.bot, update.effective_user.id, user["interface_lang"]
     ):
         return await message.reply_text(
-            f"""
-You need to follow our channel to upload memes and try again:
-
-{get_related_channel_link(user["interface_lang"])}
-            """
+            localizer.t("upload.follow_channel_required", user["interface_lang"]).format(
+                link=get_related_channel_link(user["interface_lang"]),
+            ),
         )
 
     reply_markup = InlineKeyboardMarkup(

--- a/static/localization/upload.yml
+++ b/static/localization/upload.yml
@@ -1,23 +1,36 @@
 upload.rules:
   en: |-
-    Do you want to share this meme with our community?
+    Do you want to share this meme with users of @ffmemesbot?
 
-    <b>~ OUR RULES ~</b>
-    1️⃣ No bullshit content, you know what I mean.
-    2️⃣ We can reject any post at our discretion.
-    3️⃣ Meme will be rejected if we already have that meme in collection.
-    4️⃣ For now, your meme should have only 1 picture.
-    5️⃣ Providing false info about the meme will lead to a rejection and penalty.
-  
+    <blockquote expandable><b>~ OUR RULES ~</b>
+    1️⃣ Shitposts, tweet screenshots, fandom-specific memes aren't welcome — a meme should primarily be a <b>picture</b>.
+    2️⃣ Advertising, even indirect, is banned.
+    3️⃣ NSFW and harsh political/ideological attacks are banned.
+    4️⃣ If the meme feels stale or just not funny — expect a rejection.
+    5️⃣ If the same meme is already in our collection — we'll reject it.
+    6️⃣ Wrong language / false info about the meme — rejection.</blockquote>
+
   ru: |-
     Хочешь показать этот мем юзерам @ffmemesbot?
 
-    <b>~ НАШИ ПРАВИЛА ~</b>
-    1️⃣ Никакого бреда. Ты понимаешь, о чем я.
-    2️⃣ Мы можем отклонить любой пост по своему усмотрению.
-    3️⃣ Мем будет отклонен, если у нас уже есть такой мем в коллекции.
-    4️⃣ Пока что, ваш мем может быть только картинкой.
-    5️⃣ Предоставление ложной информации о меме приведет к отклонению и штрафу.
+    <blockquote expandable><b>~ НАШИ ПРАВИЛА ~</b>
+    1️⃣ Щитпосты, скрины твитов, мемы из узких фандомов не приветствуются — мем прежде всего <b>картинка</b>.
+    2️⃣ Реклама, даже косвенная, запрещена.
+    3️⃣ NSFW, резкие политические/идеологические выпады запрещены.
+    4️⃣ Если мем покажется баяном или просто несмешным — ждите отказ.
+    5️⃣ Если такой мем уже есть в нашей коллекции — отклоним.
+    6️⃣ Не тот язык / ложная инфа о меме — отказ.</blockquote>
+
+  uk: |-
+    Хочеш показати цей мем юзерам @ffmemesbot?
+
+    <blockquote expandable><b>~ НАШІ ПРАВИЛА ~</b>
+    1️⃣ Щитпости, скріни твітів, меми з вузьких фандомів не вітаються — мем передусім <b>картинка</b>.
+    2️⃣ Реклама, навіть непряма, заборонена.
+    3️⃣ NSFW та різкі політичні/ідеологічні випади заборонені.
+    4️⃣ Якщо мем здасться баяном або просто несмішним — чекайте відмову.
+    5️⃣ Якщо такий мем вже є в нашій колекції — відхилимо.
+    6️⃣ Не та мова / неправдива інфа про мем — відмова.</blockquote>
 
 
 upload.rules_accept_button:
@@ -406,3 +419,184 @@ upload.submitted:
     1. हमारी टीम से मंजूरी या अस्वीकृति का इंतजार करें।
     2. अन्य जोक्स देखते रहें - अन्य अपलोड की रेटिंग करें! 🕒
 
+
+upload.rate_limit_exceeded:
+  en: |-
+    You've already uploaded a lot of memes today. Try again tomorrow.
+    Think about quality, not quantity: your goal is to get as many likes as possible.
+    Analyse your /uploads
+
+  ru: |-
+    Сегодня ты уже загрузил много мемов. Попробуй завтра.
+    Думай о качестве, а не о количестве: твоя цель — получить как можно больше лайков.
+    Анализируй свои /uploads
+
+  uk: |-
+    Сьогодні ти вже завантажив багато мемів. Спробуй завтра.
+    Думай про якість, а не про кількість: твоя мета — отримати якнайбільше лайків.
+    Аналізуй свої /uploads
+
+
+upload.follow_channel_required:
+  en: |-
+    You need to follow our channel to upload memes:
+
+    {link}
+
+  ru: |-
+    Чтобы загружать мемы, подпишись на наш канал:
+
+    {link}
+
+  uk: |-
+    Щоб завантажувати меми, підпишись на наш канал:
+
+    {link}
+
+
+upload.approved:
+  en: |-
+    🎉🎉🎉
+
+    Your <b>meme has been approved</b> and the bot will soon send it to other users!
+
+    See realtime stats of your uploaded memes: /uploads
+
+  ru: |-
+    🎉🎉🎉
+
+    Твой <b>мем одобрен</b> — скоро бот начнёт показывать его другим юзерам!
+
+    Статистика твоих загрузок в реалтайме: /uploads
+
+  uk: |-
+    🎉🎉🎉
+
+    Твій <b>мем схвалено</b> — скоро бот почне показувати його іншим юзерам!
+
+    Статистика твоїх завантажень у реалтаймі: /uploads
+
+
+upload.rejected:
+  en: |-
+    😢😢😢
+
+    Your meme was rejected by our moderators. Send us something else!
+
+  ru: |-
+    😢😢😢
+
+    Модераторы отклонили твой мем. Присылай что-нибудь другое!
+
+  uk: |-
+    😢😢😢
+
+    Модератори відхилили твій мем. Надішли щось інше!
+
+
+upload.rejected_duplicate:
+  en: |-
+    😬 This meme is already in our collection, so we can't accept it again. Send us something else!
+
+  ru: |-
+    😬 Такой мем уже есть в нашей коллекции, поэтому повторно принять не можем. Пришли что-нибудь другое!
+
+  uk: |-
+    😬 Такий мем вже є в нашій колекції, тому повторно прийняти не можемо. Надішли щось інше!
+
+
+upload.watermark_failed:
+  en: |-
+    ❌ Something went wrong while adding a watermark to your meme. Just try again.
+
+  ru: |-
+    ❌ Что-то пошло не так при наложении водяного знака. Просто попробуй ещё раз.
+
+  uk: |-
+    ❌ Щось пішло не так при накладанні водяного знаку. Просто спробуй ще раз.
+
+
+upload.tg_upload_failed:
+  en: |-
+    ❌ Something went wrong while uploading your meme to Telegram. Just try again.
+
+  ru: |-
+    ❌ Что-то пошло не так при загрузке мема в Telegram. Просто попробуй ещё раз.
+
+  uk: |-
+    ❌ Щось пішло не так при завантаженні мема в Telegram. Просто спробуй ще раз.
+
+
+upload.no_uploads_yet:
+  en: |-
+    📭 <b>You haven't uploaded any memes yet!</b>
+
+    Just forward a meme to our bot to upload it.
+
+    <i>read more:</i> /kitchen
+
+  ru: |-
+    📭 <b>Ты ещё не загрузил ни одного мема!</b>
+
+    Просто перешли мем нашему боту, чтобы загрузить его.
+
+    <i>подробнее:</i> /kitchen
+
+  uk: |-
+    📭 <b>Ти ще не завантажив жодного мема!</b>
+
+    Просто переслати мем нашому боту, щоб завантажити його.
+
+    <i>детальніше:</i> /kitchen
+
+
+upload.stats_header:
+  en: |-
+    <b>YOUR UPLOADED MEMES</b>
+
+    📥 You uploaded <b>{n_memes}</b> memes
+    👁️ Views: <b>{total_views}</b>
+    👍 Likes: <b>{total_likes}</b>
+    ♥️ Like %: <b>{total_like_prc}%</b>
+    🙋 Fans: <b>{total_fans}</b>
+
+    <b>Latest uploads</b>
+    views - likes - like %
+
+  ru: |-
+    <b>ТВОИ ЗАГРУЖЕННЫЕ МЕМЫ</b>
+
+    📥 Загружено мемов: <b>{n_memes}</b>
+    👁️ Просмотры: <b>{total_views}</b>
+    👍 Лайки: <b>{total_likes}</b>
+    ♥️ Like %: <b>{total_like_prc}%</b>
+    🙋 Фанаты: <b>{total_fans}</b>
+
+    <b>Последние загрузки</b>
+    просмотры - лайки - like %
+
+  uk: |-
+    <b>ТВОЇ ЗАВАНТАЖЕНІ МЕМИ</b>
+
+    📥 Завантажено мемів: <b>{n_memes}</b>
+    👁️ Перегляди: <b>{total_views}</b>
+    👍 Лайки: <b>{total_likes}</b>
+    ♥️ Like %: <b>{total_like_prc}%</b>
+    🙋 Фанати: <b>{total_fans}</b>
+
+    <b>Останні завантаження</b>
+    перегляди - лайки - like %
+
+
+upload.stats_footer:
+  en: |-
+    <b>Upload more memes and win lots of 🍔</b> /kitchen
+    /leaderboard /stats /balance
+
+  ru: |-
+    <b>Загружай больше мемов и зарабатывай 🍔</b> /kitchen
+    /leaderboard /stats /balance
+
+  uk: |-
+    <b>Завантажуй більше мемів і заробляй 🍔</b> /kitchen
+    /leaderboard /stats /balance


### PR DESCRIPTION
## Summary

- Rewrite upload rules with expandable `<blockquote>` (EN/RU/UK), drop stale "picture-only" line since video/animation were already supported in code
- Localize all remaining hardcoded upload texts: rate limit, follow-channel, approved, rejected, watermark/upload errors, `/uploads` stats
- **Auto-dedup at upload time**: after watermark+TG upload, run `describe_single_meme` inline to fill `ocr_result.text`, then `find_meme_duplicate` (pg_trgm, GIN-indexed). If a duplicate is found → auto-reject with `upload.rejected_duplicate` message and credit the uploader with a like on the original. Falls through silently to manual review on OCR failure / short text / non-image.
- Extract `_notify_uploader` helper to DRY up the repeated Forbidden/BadRequest fallback pattern

## Why UK as third language

Top non-RU/EN by 7d reactions: uk=19k, es=2.6k — uk is a clear 3rd. Other languages fall back to en (or ru for CIS-listed langs) via existing `localizer.t()` rules.

## Test plan

- [ ] Upload a new meme — "Submitted for review" message appears in the uploader's interface language
- [ ] Approve via moderator chat — approval notification arrives in uploader's language
- [ ] Reject via moderator chat — rejection notification arrives in uploader's language
- [ ] Upload a meme whose OCR text matches an existing meme in the DB — should be auto-rejected with `upload.rejected_duplicate` and never reach moderator queue; moderator chat shows no new entry
- [ ] Upload a meme with short/no OCR text — should pass dedup silently and land in moderator queue as before
- [ ] `/uploads` renders localized header/footer with correct stats