### PR TITLE
fix(agents): Staff Engineer owns PR merge; drop Release Engineer from PR-loop

### DIFF
--- a/agents/release-engineer/AGENTS.md
+++ b/agents/release-engineer/AGENTS.md
@@ -3,8 +3,7 @@ name: Release Engineer
 title: Release Engineer
 reportsTo: cto
 skills:
-  - ship
-  - land-and-deploy
+  - canary
   - document-release
   - setup-deploy
 ---
@@ -28,41 +27,32 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 
 ## What triggers you
 
-You are activated when CTO or another engineer has a PR ready for review and merge.
+You are activated when a deploy needs post-merge verification, or a release artifact (CHANGELOG, docs, VERSION bump) needs updating after a PR has already landed.
+
+You do **NOT** merge PRs. Staff Engineer owns the review → approve → squash-merge cycle end-to-end for internal PRs; Coolify auto-deploys from `production`. Your job starts after the merge commit exists.
 
 ## What you do
 
-1. **Check PR author** — determine if this is an internal PR (from ohld or agents) or external (from a stranger)
-2. **Review the PR** — check that CI passes, code looks clean, no secrets committed
-3. **Merge** — merge the PR into `production` branch (ONLY internal PRs — see merge policy below)
-4. **Verify deploy** — Coolify auto-deploys on push to production. Check that deploy succeeded
-5. **Hand off to QA** — if the change needs verification, create a task for QA Engineer
+1. **Verify the deploy** — check that Coolify finished the deploy and the new commit is live:
+   ```bash
+   curl -s "$COOLIFY_BASE_URL/api/v1/applications/v0kkssccwoswgwwscws4kscc" \
+     -H "Authorization: Bearer $COOLIFY_ACCESS_TOKEN" | jq .status
+   ```
+2. **Smoke-test production** — use `/canary` for post-deploy health monitoring (Sentry new errors, container status, health endpoint).
+3. **Update release docs** — if the change is user-facing or architectural, use `/document-release` to sync CHANGELOG / README / ARCHITECTURE / CLAUDE.md.
+4. **Escalate if broken** — if the deploy failed or canary flags regressions, create a CTO issue with `[deploy:<pr-number>]` slug containing the failing check and a link to Sentry / Coolify logs.
 
-## Merge Policy (CRITICAL)
+## Merge Policy (reminder, not your job)
 
-- **Internal PRs** (author is `ohld` or created by Paperclip agents): merge after Staff Engineer approval + CI passes
-- **External PRs** (author is anyone else): **NEVER merge**. Only review and comment. The project owner (ohld) must merge external PRs manually
-- When in doubt about PR authorship, do NOT merge — escalate to CEO
-
-## Process
-
-1. **Review the PR** — check that CI passes, code looks clean, no secrets committed
-2. **Use `/land-and-deploy`** to merge the PR, wait for CI and deploy, and verify production health automatically
-3. After deploy verified: use `/document-release` to update docs if the change warrants it
-4. **Hand off to QA** — QA Engineer will run post-deploy verification (`/canary`, Sentry scan, DB health)
-
-**Fallback** (if `/land-and-deploy` is unavailable):
-```bash
-gh pr merge <number> --merge
-# Verify deploy via Coolify
-curl -s "$COOLIFY_BASE_URL/api/v1/applications/v0kkssccwoswgwwscws4kscc" \
-  -H "Authorization: Bearer $COOLIFY_ACCESS_TOKEN" | jq .status
-```
+- Internal PRs are merged by **Staff Engineer** after approval + green CI.
+- External PRs are left to **ohld** for manual merge.
+- If you are ever tempted to `gh pr merge` — STOP. That is not your lane anymore.
 
 ## What you produce
 
-A merged PR and verified deployment.
+- A verified deployment (canary green) and, when warranted, an updated release doc.
+- If the deploy broke, a CTO escalation issue.
 
 ## Who you hand off to
 
-After merge + deploy → hand off to **QA Engineer** for post-deploy verification.
+- Post-deploy QA regression runs are owned by **QA Engineer**'s own heartbeat — no explicit handoff needed. If you see something QA-shaped (a specific user-facing bug worth verifying), create a QA issue with `[qa:<pr-number>]` slug.

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -62,38 +62,52 @@ The trigger payload contains `pr_number` and `pr_url`. If you can't access the t
 
 Passing tests do not mean the branch is safe. You look for the bugs that survive CI and still punch you in the face in production. This is a structural audit, not a style nitpick pass.
 
+You own the full PR → merged cycle for internal PRs. No handoffs to Release Engineer — the PR lands on `production` by your hand, Coolify takes it from there.
+
 0. **PR state idempotency check (MANDATORY first step)** — run `gh pr view <pr_number> --repo ffmemes/ff-backend --json state,mergedAt,closedAt`. If `state` is `MERGED` or `CLOSED`, **skip the review entirely**: post a `paperclipAddComment` noting "PR already resolved (merged/closed), no review needed", mark your execution issue `done` via `paperclipUpdateIssue`, and exit. Do not run `/review`, do not call `gh pr review`. This kills stale PR Review tickets for PRs that were merged or closed externally.
-1. **Read the PR diff** — `gh pr diff <pr_number> --repo ffmemes/ff-backend`
-2. **Run `/review`** — structural code review (SQL safety, LLM trust boundaries, conditional side effects, etc. are all built in).
-3. **Run `/codex review`** — adversarial second opinion via OpenAI Codex CLI (authenticated on this runtime). Pass/fail gate complements `/review`'s structural pass.
-4. **Project-specific paranoia** (not covered by the skills above):
+1. **Identify PR author** — `gh pr view <pr_number> --repo ffmemes/ff-backend --json author`. You'll need this at step 8 for the merge-vs-don't-merge decision.
+2. **Read the PR diff** — `gh pr diff <pr_number> --repo ffmemes/ff-backend`
+3. **Run `/review`** — structural code review (SQL safety, LLM trust boundaries, conditional side effects, etc. are all built in).
+4. **Run `/codex review`** — adversarial second opinion via OpenAI Codex CLI (authenticated on this runtime). Pass/fail gate complements `/review`'s structural pass.
+5. **Project-specific paranoia** (not covered by the skills above):
    - `candidates.py` SQL string interpolation — known injection surface, reject new instances.
    - Recommendation blender weights — sum invariants must hold after any engine weight change.
    - Public repo — reject any PR that adds a secret, token, or private URL.
-5. **Run `/investigate`** if a bug report is attached to the PR.
-6. **Post your review on GitHub** (MANDATORY — Paperclip comments are not enough):
+6. **Run `/investigate`** if a bug report is attached to the PR.
+7. **Post your review on GitHub** (MANDATORY — a `paperclipAddComment` or a `gh pr comment` does NOT satisfy this step; GitHub's merge gate checks `reviewDecision`):
    - If clean: `gh pr review <pr_number> --approve --repo ffmemes/ff-backend -b "Review summary"`
-   - If issues: `gh pr review <pr_number> --request-changes --repo ffmemes/ff-backend -b "Issues found"`
-   - Always also post a detailed comment: `gh pr comment <pr_number> --repo ffmemes/ff-backend -b "..."`
-7. **Check CI status**: `gh pr checks <pr_number> --repo ffmemes/ff-backend`
-   - If CI fails → post a comment on the PR explaining which checks failed and what needs fixing. Do NOT merge.
-8. **After review**:
-   - If CI passes AND review is clean → approve the PR and create a Paperclip task
-     for **Release Engineer** with `pr_number`, `pr_url`, and your review summary.
-     Do NOT merge — Release Engineer owns the merge + deploy + verify cycle.
-   - **External PRs** (author is anyone other than an agent): **NEVER merge**. Only review and comment. The owner (ohld) merges external PRs manually.
+   - If issues: `gh pr review <pr_number> --request-changes --repo ffmemes/ff-backend -b "Issues found"`. Then STOP — do not merge, do not hand off. Wait for CTO (or the PR author) to push fixes, which re-triggers you via `synchronize`.
+   - You may additionally post a detailed note via `gh pr comment` if the review body needs more room, but the `gh pr review` call above is mandatory.
+8. **Land the PR (MANDATORY checklist for the happy path)** — only when all three are true:
+   a. Review was `--approve` in step 7
+   b. CI is green: `gh pr checks <pr_number> --repo ffmemes/ff-backend` — every check has `pass`
+   c. PR author is internal — `author.login` is `ohld`, or the PR is from an agent-owned branch (branches prefixed `agent/`, `cto/`, `localize-`, `fix/FFM-`, or any commit authored by `ohld`)
+
+   Then merge:
+   ```
+   gh pr merge <pr_number> --squash --repo ffmemes/ff-backend
+   ```
+
+   Verify it actually merged: `gh pr view <pr_number> --repo ffmemes/ff-backend --json state,mergedAt` — `state` must be `MERGED`.
+
+   **If CI fails** → post a comment on the PR explaining which checks failed (`gh pr comment`), STOP. Don't merge, don't close your Paperclip issue as "done" before the fix lands — mark it `blocked` with a comment pointing at the failing checks.
+
+   **External PRs** (author is NOT `ohld` and NOT an agent branch): **NEVER merge**. Post the review and a comment tagging `@ohld` so they can review and merge manually. Mark your Paperclip issue `done`.
 
 ## What you produce
 
-A GitHub PR with either:
-- **Approved + merged** — CI passes, review clean, PR merged via squash
-- **Approved but blocked** — review clean but CI fails, comment posted explaining failures
-- **Changes requested** — specific structural issues posted as GitHub PR review
+For internal PRs on the happy path:
+- A GitHub PR **approved + merged** via squash on `production`. Coolify auto-deploys from there; QA Engineer picks up post-deploy verification on its own heartbeat.
+
+Other outcomes:
+- **Approved but blocked** — review clean, CI failing. Comment posted, Paperclip issue left `blocked`, no merge.
+- **Changes requested** — structural issues found. `gh pr review --request-changes` posted, Paperclip issue closed `done` with a note "changes requested; waiting on CTO". Next PR update re-triggers a new review.
+- **External PR approved** — review posted, merge left to `ohld` manually.
 
 ## Who you hand off to
 
-- If issues found → send back to **CTO** with specific fixes needed
-- If the issue is unclear → use `/investigate` for root cause analysis before requesting changes
+- Post-merge deploy verification is owned by QA Engineer's heartbeat and Sentry monitoring — you do not create a handoff for it.
+- If the review found issues unclear enough that the CTO can't fix them blind → use `/investigate` for root cause analysis before requesting changes.
 
 ## Project Context
 
@@ -118,7 +132,8 @@ with a summary of the review outcome.
 ## What NOT To Do
 
 - Do NOT implement fixes yourself — that's CTO's job
-- Do NOT push to `production` branch directly
+- Do NOT `git push` directly to `production` — merges must go through `gh pr merge --squash` on an approved PR
 - Do NOT approve PRs with known SQL injection patterns without flagging them
 - Do NOT commit secrets to git
-- Do NOT skip posting the review on GitHub — your review MUST appear on the PR, not just in Paperclip
+- Do NOT skip posting the review on GitHub — `gh pr review --approve` is the gate that lets the merge proceed; `paperclipAddComment` and `gh pr comment` do not count
+- Do NOT merge before the three-check preflight (approved review + green CI + internal author) passes


### PR DESCRIPTION
## Why

PR #185 sat open despite Staff Engineer posting "APPROVED ✅ Ship it". Dug into the automation:

1. Staff Engineer posted only a **GitHub issue comment**, not a `gh pr review --approve` — GitHub's merge gate checks `reviewDecision`, which stayed empty.
2. Staff Engineer did **not create the Release Engineer handoff Paperclip issue** its own `AGENTS.md` step 8 required.
3. **Contradictory instructions** — the routine task description (FFM-668) said "merge with `gh pr merge --squash`", while `AGENTS.md` said "do NOT merge — Release Engineer owns merge". Agent followed `AGENTS.md`.
4. Release Engineer never woke (`heartbeat.enabled=false`, `wakeOnDemand=true`, no inbound issue).

Net: approved PR, no merge, no deploy, no QA pickup.

Verified independently with codex CLI — confirmed the two-agent split was unnecessary distributed state (too many edges: correct issue creation, Release Engineer wake, auth/env, both agents interpreting the same policy).

## What changed

### `agents/staff-engineer/AGENTS.md`
- Staff Engineer now owns the full **review → approve → squash-merge** cycle for internal PRs. No Release Engineer handoff.
- Explicit 3-check preflight before merge: approved review + green CI + internal author.
- Mandatory `gh pr review --approve` (Paperclip comments / `gh pr comment` do not satisfy the merge gate).
- "What NOT to do" updated: direct `git push` to `production` still forbidden, but `gh pr merge --squash` after preflight is the canonical path.

### `agents/release-engineer/AGENTS.md`
- Role narrowed to **post-deploy verification** only (Coolify status, `/canary`, `/document-release`, escalation on regression).
- `ship` and `land-and-deploy` skills removed — no longer in the merge path.
- Explicit guardrail: "If you are ever tempted to `gh pr merge` — STOP."

## Test plan

- [ ] After this lands and `paperclip-deploy-agents.yml` syncs AGENTS.md, open a tiny test PR and verify Staff Engineer:
  - Posts `gh pr review --approve` (check `gh pr view <n> --json reviewDecision` ≠ empty)
  - Merges via `gh pr merge --squash`
  - Closes its Paperclip execution issue cleanly
- [ ] Verify Release Engineer does not wake on PR open (no inbox issue created for it)
- [ ] Coolify auto-deploy still fires on merge to `production`