### PR TITLE
feat(mod-chat): reply with meme stats on moderator forwards

### DIFF
--- a/alembic/versions/2026-04-24_message_tg_forward_media.py
+++ b/alembic/versions/2026-04-24_message_tg_forward_media.py
@@ -1,0 +1,56 @@
+"""Extend message_tg with forward source and media metadata
+
+Adds columns needed to detect moderator-chat meme forwards (forward_from_*),
+capture media context for the chat agent (media_type, file_id, media_group_id),
+and indexes for fast lookup.
+
+Revision ID: a7b8c9d0e1f2
+Revises: 5a9d22dbecb6
+Create Date: 2026-04-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a7b8c9d0e1f2"
+down_revision = "5a9d22dbecb6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("message_tg", sa.Column("media_type", sa.String(), nullable=True))
+    op.add_column("message_tg", sa.Column("file_id", sa.String(), nullable=True))
+    op.add_column("message_tg", sa.Column("media_group_id", sa.String(), nullable=True))
+    op.add_column("message_tg", sa.Column("forward_from_chat_id", sa.BigInteger(), nullable=True))
+    op.add_column(
+        "message_tg", sa.Column("forward_from_message_id", sa.BigInteger(), nullable=True)
+    )
+    op.add_column("message_tg", sa.Column("forward_from_user_id", sa.BigInteger(), nullable=True))
+
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+    op.execute("COMMIT")
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_message_tg_chat_id_date "
+        "ON message_tg (chat_id, date DESC)"
+    )
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_message_tg_forward_source "
+        "ON message_tg (forward_from_chat_id, forward_from_message_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_message_tg_forward_source")
+    op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_message_tg_chat_id_date")
+
+    op.drop_column("message_tg", "forward_from_user_id")
+    op.drop_column("message_tg", "forward_from_message_id")
+    op.drop_column("message_tg", "forward_from_chat_id")
+    op.drop_column("message_tg", "media_group_id")
+    op.drop_column("message_tg", "file_id")
+    op.drop_column("message_tg", "media_type")

--- a/src/database.py
+++ b/src/database.py
@@ -552,9 +552,15 @@ message_tg = Table(
     Column("date", DateTime),
     Column("chat_id", BigInteger, nullable=False),
     Column("user_id", BigInteger, nullable=False),
-    Column("text", String),
+    Column("text", String),  # also stores caption when the message is media
     Column("reply_to_message_id", BigInteger),
     Column("sender_chat_id", BigInteger),  # Channel ID when posted as channel (777000 case)
+    Column("media_type", String),  # photo|video|animation|document|sticker|voice|video_note
+    Column("file_id", String),  # best-quality Telegram file_id for the attached media
+    Column("media_group_id", String),  # album grouping id
+    Column("forward_from_chat_id", BigInteger),
+    Column("forward_from_message_id", BigInteger),
+    Column("forward_from_user_id", BigInteger),
     UniqueConstraint("chat_id", "message_id", name="uq_message_tg"),
 )
 

--- a/src/tgbot/handlers/chat/chat.py
+++ b/src/tgbot/handlers/chat/chat.py
@@ -8,6 +8,7 @@ from telegram.ext import ContextTypes
 from src.config import settings
 from src.stats.service import get_user_stats
 from src.tgbot.constants import TELEGRAM_CHAT_RU_CHAT_ID
+from src.tgbot.handlers.chat.mod_chat_stat import handle_mod_chat_meme_forward
 from src.tgbot.handlers.chat.reaction import give_random_reaction
 from src.tgbot.handlers.chat.service import (
     get_latest_chat_messages,
@@ -55,6 +56,13 @@ async def handle_group_message(update: Update, context: ContextTypes.DEFAULT_TYP
         await save_telegram_message(msg)
     except Exception as e:
         logger.warning("Failed to save message: %s", e)
+
+    # Moderator chat: reply with short stats when a meme is forwarded here.
+    try:
+        if await handle_mod_chat_meme_forward(msg):
+            return
+    except Exception as e:
+        logger.warning("mod-chat stat reply error: %s", e)
 
     # Skip bot messages, channel forwards (777000), and service messages
     if not msg.from_user or msg.from_user.is_bot or msg.from_user.id == 777000:

--- a/src/tgbot/handlers/chat/mod_chat_stat.py
+++ b/src/tgbot/handlers/chat/mod_chat_stat.py
@@ -1,0 +1,110 @@
+"""Reply with short meme stats when a moderator forwards a bot meme to the mod chat."""
+
+import logging
+import re
+
+from sqlalchemy import text
+from telegram import Message
+from telegram.constants import MessageEntityType
+
+from src.database import fetch_one
+from src.tgbot.constants import TELEGRAM_MODERATOR_CHAT_ID
+
+logger = logging.getLogger(__name__)
+
+# Bot meme deep link embedded in the caption HTML:
+# https://t.me/ffmemesbot?start=s_<user_id>_<meme_id>
+_MEME_DEEP_LINK_RE = re.compile(r"t\.me/ffmemesbot\?start=s_\d+_(\d+)", re.IGNORECASE)
+
+
+async def handle_mod_chat_meme_forward(msg: Message) -> bool:
+    """If this is a meme forward in the moderator chat, reply with short stats.
+
+    Returns True when a reply was sent (caller should skip further handling).
+    """
+    if msg.chat.id != TELEGRAM_MODERATOR_CHAT_ID:
+        return False
+    if msg.forward_origin is None:
+        return False
+
+    meme_id = _extract_meme_id(msg)
+    if meme_id is None:
+        return False
+
+    reply = await _build_stat_reply(meme_id)
+    if not reply:
+        return False
+
+    try:
+        await msg.reply_text(reply, disable_web_page_preview=True)
+    except Exception as e:
+        logger.warning("mod-chat stat reply failed for meme %s: %s", meme_id, e)
+    return True
+
+
+def _extract_meme_id(msg: Message) -> int | None:
+    # Bot-sent memes embed the deep link inside a TEXT_LINK entity, so the URL
+    # is not present in the plain caption text; iterate entities first.
+    for ent in msg.caption_entities or msg.entities or []:
+        if ent.type == MessageEntityType.TEXT_LINK and ent.url:
+            m = _MEME_DEEP_LINK_RE.search(ent.url)
+            if m:
+                return int(m.group(1))
+    # Fallback: literal URL in text/caption.
+    body = msg.text or msg.caption or ""
+    m = _MEME_DEEP_LINK_RE.search(body)
+    return int(m.group(1)) if m else None
+
+
+_STATS_QUERY = text(
+    r"""
+    SELECT
+        m.id,
+        COALESCE(ms.nmemes_sent, 0)  AS views,
+        COALESCE(ms.nlikes, 0)       AS nlikes,
+        COALESCE(ms.ndislikes, 0)    AS ndislikes,
+        COALESCE(ms.sec_to_react, 0) AS sec_to_react,
+        COALESCE(mrt.url, msrc.url)  AS source_url,
+        (
+            SELECT count(*) FROM user_deep_link_log
+            WHERE deep_link LIKE 's\_%\_' || :mid
+        ) AS clicks
+    FROM meme m
+    LEFT JOIN meme_stats ms       ON ms.meme_id = m.id
+    LEFT JOIN meme_source msrc    ON msrc.id = m.meme_source_id
+    LEFT JOIN meme_raw_telegram mrt
+        ON mrt.meme_source_id = m.meme_source_id
+       AND mrt.post_id = m.raw_meme_id
+    WHERE m.id = :mid
+    """
+)
+
+
+async def _build_stat_reply(meme_id: int) -> str | None:
+    row = await fetch_one(_STATS_QUERY, {"mid": meme_id})
+    if not row:
+        return None
+
+    views = row["views"] or 0
+    nlikes = row["nlikes"] or 0
+    ndislikes = row["ndislikes"] or 0
+    sec = row["sec_to_react"] or 0
+    clicks = row["clicks"] or 0
+    source_url = row["source_url"]
+
+    parts = [f"👁 {_fmt_k(views)}", f"👍 {nlikes}", f"👎 {ndislikes}"]
+    # sec_to_react has a 99999 sentinel for "no data".
+    if 0 < sec < 99999:
+        parts.append(f"⏱ {sec:.1f}s")
+    lines = [" · ".join(parts)]
+    if clicks:
+        lines.append(f"🔗 {clicks} click{'s' if clicks != 1 else ''}")
+    if source_url:
+        lines.append(f"src: {source_url}")
+    return "\n".join(lines)
+
+
+def _fmt_k(n: int) -> str:
+    if n >= 10000:
+        return f"{n / 1000:.1f}k"
+    return str(n)

--- a/src/tgbot/handlers/chat/service.py
+++ b/src/tgbot/handlers/chat/service.py
@@ -2,7 +2,12 @@ import logging
 
 from sqlalchemy import func, text
 from sqlalchemy.dialects.postgresql import insert
-from telegram import Message
+from telegram import (
+    Message,
+    MessageOriginChannel,
+    MessageOriginChat,
+    MessageOriginUser,
+)
 
 from src.database import (
     execute,
@@ -81,6 +86,40 @@ async def update_telegram_chat_bot_left(chat_id: int) -> None:
     await execute(query)
 
 
+def _extract_media(msg: Message) -> tuple[str | None, str | None]:
+    """Return (media_type, best-quality file_id) or (None, None) for text-only messages."""
+    if msg.photo:
+        return "photo", msg.photo[-1].file_id
+    if msg.video:
+        return "video", msg.video.file_id
+    if msg.animation:
+        return "animation", msg.animation.file_id
+    if msg.document:
+        return "document", msg.document.file_id
+    if msg.sticker:
+        return "sticker", msg.sticker.file_id
+    if msg.voice:
+        return "voice", msg.voice.file_id
+    if msg.video_note:
+        return "video_note", msg.video_note.file_id
+    return None, None
+
+
+def _extract_forward(msg: Message) -> tuple[int | None, int | None, int | None]:
+    """Return (forward_from_chat_id, forward_from_message_id, forward_from_user_id)."""
+    origin = getattr(msg, "forward_origin", None)
+    if origin is None:
+        return None, None, None
+    if isinstance(origin, MessageOriginUser):
+        return None, None, origin.sender_user.id
+    if isinstance(origin, MessageOriginChat):
+        return origin.sender_chat.id, None, None
+    if isinstance(origin, MessageOriginChannel):
+        return origin.chat.id, origin.message_id, None
+    # MessageOriginHiddenUser: no usable id.
+    return None, None, None
+
+
 async def save_telegram_message(msg: Message) -> None:
     # Prefer sender_chat when present (anonymous channel posts)
     sender_chat_id = None
@@ -104,6 +143,9 @@ async def save_telegram_message(msg: Message) -> None:
     except Exception as e:
         logger.warning("Failed to upsert chat: %s", e)
 
+    media_type, file_id = _extract_media(msg)
+    fwd_chat_id, fwd_msg_id, fwd_user_id = _extract_forward(msg)
+
     query = (
         insert(message_tg)
         .values(
@@ -114,6 +156,12 @@ async def save_telegram_message(msg: Message) -> None:
             sender_chat_id=sender_chat_id,
             text=msg.text or msg.caption,
             reply_to_message_id=msg.reply_to_message.message_id if msg.reply_to_message else None,
+            media_type=media_type,
+            file_id=file_id,
+            media_group_id=msg.media_group_id,
+            forward_from_chat_id=fwd_chat_id,
+            forward_from_message_id=fwd_msg_id,
+            forward_from_user_id=fwd_user_id,
         )
         .on_conflict_do_nothing()
     )


### PR DESCRIPTION
## Summary

- When a moderator forwards a meme from the bot into `-1001305866294`, the bot replies with a short stat line (views, likes, dislikes, median reaction time, deep-link clicks, source URL). Helps answer "это я тупой, или людям этот мем реально зашел".
- `message_tg` extended to capture what was missing for this and other chat-analytics use cases: `media_type`, `file_id` (best quality), `media_group_id`, `forward_from_{chat,message,user}_id`. Caption now lands in the existing `text` column (previously dropped for media messages).
- Indexes added: `(chat_id, date DESC)` for chat-agent context windows, `(forward_from_chat_id, forward_from_message_id)` for forward lookup. Both created `CONCURRENTLY`.

## Implementation notes

- Meme-ID matching uses the `t.me/ffmemesbot?start=s_<user>_<meme>` deep link embedded in the caption's `TEXT_LINK` entity (preserved through Telegram forwards). No `file_id` / `file_unique_id` matching — cleaner and works even if Telegram re-encodes media.
- Stat reply hooks into the existing `handle_group_message` right after persist, before any chat-agent logic. Returns early when a stat reply was sent so the 5% random reaction doesn't fire on top.
- Forward origin parsed via PTB's `forward_origin` (Bot API 7.0+), covering user / chat / channel origins. `HiddenUser` is intentionally a no-op.
- No new tables, no catch-all `raw_json` column (kept the schema disciplined).

## Test plan

- [ ] After merge & migrate, moderator forwards a meme into the mod chat → bot replies within ~1s with the stat line.
- [ ] Caption-less forward (e.g. forwarded from a TG channel auto-post that stripped the deep link) → bot stays silent, no spam.
- [ ] Forward of a non-meme message → no reply.
- [ ] Existing chat-agent behaviour in RU/EN chats unchanged (same handler path, stat reply short-circuits only in the mod chat).
- [ ] `message_tg` inserts succeed for photo/video/animation/document/sticker/voice/video_note; `caption` now visible in `text` column.

## Out of scope

- Emoji-reaction labels (`MESSAGE_REACTION` updates) — separate spec, requires `allowed_updates` change and a lebels table.
- Auto-flagging low-quality memes into the mod chat from a Prefect job.
- Weekly digest of forwarded memes.