### PR TITLE
fix(agents): dedupe canary skill in release-engineer (caught by Staff Eng autonomous review)

### DIFF
--- a/agents/release-engineer/AGENTS.md
+++ b/agents/release-engineer/AGENTS.md
@@ -6,7 +6,6 @@ skills:
   - canary
   - document-release
   - setup-deploy
-  - canary
   - benchmark
 ---
 


### PR DESCRIPTION
## Summary

Staff Engineer's autonomous review of PR #186 caught this — `canary` was listed twice in `agents/release-engineer/AGENTS.md` `skills:`, a rebase artifact from combining ohld's role-merge edit with my Stage 1 `+canary,+benchmark` addition.

Quoting the agent's review (FFM-674 close comment):
> `agents/release-engineer/AGENTS.md:6` — `canary` listed twice in `skills:` YAML. `_sync_config.py` dedupes via `set()` so prod won't break, but it masks source-of-truth mistakes. Drop the duplicate.

Non-blocking (the dedupe in `_sync_config.py` keeps prod consistent), but the YAML should be the source of truth — not relying on downstream defensive coding.

## Why a separate PR

Validates the autonomous cycle on a third PR. PR #186 + PR #189 both self-merged via the new pipeline; this one tests the cycle on a tiny single-line change with NO `[pr:NNN-followup]` task chain (the agent flagged the bug but didn't create a fix-it task — that's the next gap to close, separate PR).