### PR TITLE
fix(mod-chat): split SQL bind to fix integer=text collision

### DIFF
--- a/src/tgbot/handlers/chat/mod_chat_stat.py
+++ b/src/tgbot/handlers/chat/mod_chat_stat.py
@@ -67,7 +67,7 @@ _STATS_QUERY = text(
         COALESCE(mrt.url, msrc.url)  AS source_url,
         (
             SELECT count(*) FROM user_deep_link_log
-            WHERE deep_link LIKE 's\_%\_' || :mid
+            WHERE deep_link LIKE :mid_pattern
         ) AS clicks
     FROM meme m
     LEFT JOIN meme_stats ms       ON ms.meme_id = m.id
@@ -81,7 +81,10 @@ _STATS_QUERY = text(
 
 
 async def _build_stat_reply(meme_id: int) -> str | None:
-    row = await fetch_one(_STATS_QUERY, {"mid": meme_id})
+    row = await fetch_one(
+        _STATS_QUERY,
+        {"mid": meme_id, "mid_pattern": rf"s\_%\_{meme_id}"},
+    )
     if not row:
         return None
 


### PR DESCRIPTION
## Summary

Mod-chat stat replies (added in #188) never sent. Every forward into the moderator chat silently failed with a Postgres type error.

**Root cause**

`_STATS_QUERY` bound `:mid` once but used it in two incompatible contexts:

- `WHERE m.id = :mid` (needs integer)
- `'s\_%\_' || :mid` (LIKE concat — Postgres infers text)

SQLAlchemy compiled both to a single `$1` placeholder. Postgres can only assign one type per parameter, picked text from the concat context, then `m.id (integer) = $1 (text)` raised `UndefinedFunctionError: operator does not exist: integer = text`.

The error was swallowed by the broad `try/except` in `src/tgbot/handlers/chat/chat.py:64-65` which logs at `WARNING` — that's why nothing showed up in Sentry.

**Fix**

Split into two named binds: `:mid` (int, used in equality) and `:mid_pattern` (text, pre-built `s\_%\_{meme_id}`). `:mid` stays unambiguously int.

## Verification

Reproduced and verified against the live prod DB (no test DB needed, the bug is purely a SQL parameter-typing issue):

- **Pre-fix:** `ProgrammingError: operator does not exist: integer = text` with `parameters: (10130524,)`
- **Post-fix:** query returns `{'id': 10130524, 'views': 10, 'nlikes': 1, 'ndislikes': 7, 'sec_to_react': 4.85, 'source_url': 'https://t.me/...', 'clicks': 0}`

Production log line confirming the original failure: `2026-04-24 20:52:01.426 WARNING src.tgbot.handlers.chat.chat - mod-chat stat reply error`.

## Test plan

- [x] `ruff check` and `ruff format --check` clean
- [x] Verified query against prod DB with a real `meme_id`
- [ ] Post-deploy: forward a meme into the mod chat, expect the stats reply