### PR TITLE
fix(observability): promote 4 silent except blocks to ERROR for Sentry

### DIFF
--- a/src/tgbot/handlers/chat/agent/runner.py
+++ b/src/tgbot/handlers/chat/agent/runner.py
@@ -175,6 +175,6 @@ def _log_usage(
                 },
             )
         except Exception as e:
-            logger.warning("Failed to log agent usage: %s", e)
+            logger.error("Failed to log agent usage: %s", e, exc_info=True)
 
     asyncio.create_task(_insert())

--- a/src/tgbot/handlers/chat/chat.py
+++ b/src/tgbot/handlers/chat/chat.py
@@ -55,14 +55,14 @@ async def handle_group_message(update: Update, context: ContextTypes.DEFAULT_TYP
     try:
         await save_telegram_message(msg)
     except Exception as e:
-        logger.warning("Failed to save message: %s", e)
+        logger.error("Failed to save message: %s", e, exc_info=True)
 
     # Moderator chat: reply with short stats when a meme is forwarded here.
     try:
         if await handle_mod_chat_meme_forward(msg):
             return
     except Exception as e:
-        logger.warning("mod-chat stat reply error: %s", e)
+        logger.error("mod-chat stat reply error: %s", e, exc_info=True)
 
     # Skip bot messages, channel forwards (777000), and service messages
     if not msg.from_user or msg.from_user.is_bot or msg.from_user.id == 777000:

--- a/src/tgbot/handlers/chat/mod_chat_stat.py
+++ b/src/tgbot/handlers/chat/mod_chat_stat.py
@@ -38,7 +38,7 @@ async def handle_mod_chat_meme_forward(msg: Message) -> bool:
     try:
         await msg.reply_text(reply, disable_web_page_preview=True)
     except Exception as e:
-        logger.warning("mod-chat stat reply failed for meme %s: %s", meme_id, e)
+        logger.error("mod-chat stat reply failed for meme %s: %s", meme_id, e, exc_info=True)
     return True
 
 


### PR DESCRIPTION
## Summary

Follow-up to #191. While fixing the mod-chat stat SQL bug, we noticed it never surfaced in Sentry despite firing on every forwarded meme for ~24h. Root cause: `sentry-sdk` 2.39's default `LoggingIntegration` auto-captures `logger.error` but not `logger.warning`, and the catch site logged at WARNING.

Audited the whole codebase for the same pattern — 32 silent `except Exception` blocks at WARNING level. Cross-checked with Codex. Promoting only the 4 that are real bug-class blind spots in the chat path:

| File:line | What was silent |
|---|---|
| `src/tgbot/handlers/chat/chat.py:58` | `save_telegram_message` failure — drops chat-agent context |
| `src/tgbot/handlers/chat/chat.py:65` | `handle_mod_chat_meme_forward` errors — exactly the #191 bug |
| `src/tgbot/handlers/chat/agent/runner.py:178` | `_log_usage` INSERT failure — paid LLM token-cost tracking |
| `src/tgbot/handlers/chat/mod_chat_stat.py:41` | `reply_text` failure — becomes new blind spot once chat.py:65 is at ERROR |

## What this changes

`logger.warning(...)` → `logger.error(..., exc_info=True)` at those 4 sites. Nothing else.

- No control-flow change. Handlers still don't crash, failures still log, the surrounding flow still continues.
- Only effect: future bugs at these sites become Sentry events (with full traceback via `exc_info=True`) instead of disappearing into prod logs.

## What was deliberately NOT promoted

Codex pushed back on 3 candidates I'd initially included. Agreed, kept them at WARNING:

- `src/tgbot/handlers/chat/service.py:133,143` — `upsert_telegram_chat` failure. Metadata only (no FK from `message_tg`); promoting would spam Sentry on any DB hiccup since every group message hits both calls.
- `src/tgbot/handlers/chat/chat.py:179` — already inside an outer `logger.error` at line 176, so we'd just lose the second-failure detail, not gain a new blind spot.

The remaining ~25 WARNING-level catches across `flows/`, `broadcasts/`, `redis.py`, `parsers/`, etc. are correctly silent (per-item retries in batches, fallback chains, type-migration cleanups). Most are bounded by an aggregate ERROR or a circuit breaker.

## Test plan

- [x] `python3 -m py_compile` clean on all 3 files
- [x] Diff is 4 single-line changes, no logic touched
- [ ] Post-deploy: trigger any of the 4 paths (e.g., forward a meme into mod chat) and confirm an error there now appears in Sentry