### PR TITLE
fix(prefect): bump prefect-server to 3.6.28 to match runner

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       - "9898:9000"
 
   prefect-server:
-    image: prefecthq/prefect:3.4.17-python3.12
+    image: prefecthq/prefect:3.6.28-python3.14
     container_name: prefect_server
     command: prefect server start --host 0.0.0.0
     environment:


### PR DESCRIPTION
## Summary

Hotfix for the post-deploy regression introduced by #193.

#193 bumped the **runner**'s Prefect Python lib to 3.6.\* (forced by Python 3.14 — 3.4.17 hard-caps `requires-python <3.14`), but `docker-compose.prod.yml` (the file Coolify uses) still pinned the **prefect-server container** to `3.4.17-python3.12`. Result: runner can't authenticate to the 3.4 server's event stream and crash-loops with:

```
Exception: Unable to authenticate to the event stream. Please ensure the
provided auth_token you are using is valid for this environment.
RuntimeError: Runner failed to start: event_emitter — ...
```

This PR aligns the server image to `3.6.28-python3.14` to match.

## Why this wasn't caught in #193

I bumped `docker-compose.yml` (local dev) but missed `docker-compose.prod.yml` (Coolify-managed). Local `prefect-server` was already failing for an unrelated pre-existing reason (`database "prefect" does not exist`) which masked the version-mismatch issue end-to-end.

## Verification

- App container is healthy on prod (Up 4+ min after #193 merge)
- Only prefect-runner is crash-looping; this PR fixes it

## Test plan

- [ ] CI green
- [ ] After deploy: `prefect-runner` stays Up (no restart loop)
- [ ] Scheduled flows resume (parsers, stats, crossposting)