### PR TITLE
chore(deps): runtime stack patch bumps (Batch 2)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,29 +1,29 @@
 redis==5.0.*
-alembic==1.13.*
+alembic==1.18.*
 psycopg2==2.9.*
 python-jose==3.3.*
-SQLAlchemy==2.0.43
+SQLAlchemy==2.0.49
 httpx==0.28.*
 
 pydantic[email]==2.13.*
-pydantic-settings==2.10.*
+pydantic-settings==2.14.*
 asyncpg==0.31.*
 fastapi==0.115.*
 uvicorn[standard]==0.32.*
 
-sentry-sdk==2.39.*
+sentry-sdk==2.58.*
 
 # prefect + worker
 prefect==3.6.*
-beautifulsoup4==4.13.*
-lxml==6.0.*
+beautifulsoup4==4.14.*
+lxml==6.1.*
 
-python-telegram-bot[rate-limiter]==22.3.*
+python-telegram-bot[rate-limiter]==22.7.*
 
 Pillow==11.3.*
 matplotlib==3.10.*
 
-openai==2.8.*
+openai==2.32.*
 openai-agents==0.4.*
 
-telethon==1.37.*
+telethon==1.43.*


### PR DESCRIPTION
## Summary

Batch 2 of the dependency-modernization effort (follows #193, #194, #195). All within-major bumps on the runtime stack, no breaking changes anticipated.

| Lib                  | Old      | New     |
|----------------------|----------|---------|
| `alembic`            | 1.13.*   | 1.18.*  |
| `SQLAlchemy`         | 2.0.43   | 2.0.49  |
| `pydantic-settings`  | 2.10.*   | 2.14.*  |
| `sentry-sdk`         | 2.39.*   | 2.58.*  |
| `beautifulsoup4`     | 4.13.*   | 4.14.*  |
| `lxml`               | 6.0.*    | 6.1.*   |
| `python-telegram-bot[rate-limiter]` | 22.3.* | 22.7.* |
| `openai`             | 2.8.*    | 2.32.*  |
| `telethon`           | 1.37.*   | 1.43.*  |

## Verification

- `docker compose build app` clean
- `pytest -q` — **190 passed, 2 skipped** (count went up from 149 → 190 vs Batch 1; Batch 1's pytest-asyncio loop-scope change apparently un-skipped some session-scoped async tests)
- App container boots, `/healthcheck` returns 200, Telegram `getMe` succeeds

## Out of scope (later batches)

- `redis-py` 5 → 7 (major) — Batch 4
- `Pillow` 11 → 12 (major) — Batch 4
- `fastapi` 0.115 → 0.136 (notable minor, lifespan review) — Batch 3
- `uvicorn` 0.32 → 0.46 — Batch 3
- `python-jose` → migrate to `pyjwt` — separate task
- `openai-agents` 0.4 → 0.14 (pre-1.0 churn) — hold

## Test plan

- [ ] CI green
- [ ] Coolify deploy succeeds
- [ ] Sentry remains quiet
- [ ] Bot reactions still work post-deploy