### PR TITLE
chore(deps): fastapi 0.115 → 0.136, uvicorn 0.32 → 0.46 (Batch 3)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,8 @@ httpx==0.28.*
 pydantic[email]==2.13.*
 pydantic-settings==2.14.*
 asyncpg==0.31.*
-fastapi==0.115.*
-uvicorn[standard]==0.32.*
+fastapi==0.136.*
+uvicorn[standard]==0.46.*
 
 sentry-sdk==2.58.*
 


### PR DESCRIPTION
## Summary

Batch 3 of the dependency-modernization effort. Notable minor bumps with small review surface.

| Lib | Old | New |
|---|---|---|
| `fastapi` | 0.115.* | 0.136.* |
| `uvicorn[standard]` | 0.32.* | 0.46.* |

## Why low risk

- **FastAPI 0.115 → 0.136**: pydantic v2 hardening, lifespan/Depends tweaks. `src/main.py` already uses the modern `lifespan` async-context-manager pattern (no deprecated `@app.on_event` hooks anywhere in the codebase). No source changes needed.
- **Uvicorn 0.32 → 0.46**: h11 + lifespan fixes, no API churn relevant to our usage.

## Verification

- `docker compose build app` clean
- App boots, `/healthcheck` returns 200, Telegram `getMe` succeeds
- `pytest -q` — **190 passed, 2 skipped** on Python 3.14

## Out of scope (Batch 4)

- `redis-py` 5 → 7 (major) — needs pubsub/queue test
- `Pillow` 11 → 12 (major) — needs `src/storage/watermark.py` audit

## Test plan

- [ ] CI green
- [ ] Coolify deploy succeeds
- [ ] `/tgbot/webhook` keeps accepting Telegram updates post-deploy