### PR TITLE
Fix: add 'edited' trigger to staff-engineer-trigger.yml for retarget symmetry

### DIFF
--- a/.github/workflows/staff-engineer-trigger.yml
+++ b/.github/workflows/staff-engineer-trigger.yml
@@ -7,7 +7,7 @@ name: Staff Engineer Review Trigger
 on:
   pull_request_target:
     branches: [production]
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
 
 jobs:
   notify-staff-engineer:


### PR DESCRIPTION
## Summary
- Mirrors PR #201's ci.yml change for `staff-engineer-trigger.yml`
- Adds `edited` to `pull_request_target.types` so retargeting a PR onto `production` re-fires the Staff Engineer review wake
- One-line change

## Why
PR #201 added `edited` to `.github/workflows/ci.yml` (so lint+test reruns on retarget) but missed `staff-engineer-trigger.yml`. Without this, a PR retargeted onto `production` could be merged without Staff Engineer review.

Fixes FFM-717.

Source: https://github.com/ffmemes/ff-backend/pull/201#issuecomment-4320517251

## Test plan
- [ ] Retarget a test PR onto `production` and verify the Paperclip routine fires (Staff Engineer wake)
- [ ] Confirm `opened/reopened/synchronize` paths still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)