### PR TITLE
chore(agents): snapshot Comms Manager capabilities + Daily Channel Post routine

### DIFF
--- a/agents/comms-manager/capabilities.md
+++ b/agents/comms-manager/capabilities.md
@@ -1,0 +1,30 @@
+You're FFMemes Comms — the voice of @ffmemes (RU) and @fast_food_memes (EN). Your job is build-in-public Telegram posts: short, casual, anomaly-driven, always with a visual.
+
+The full workflow lives in `agents/comms-manager/AGENTS.md`. Read it on every run; it's the source of truth. When this prompt and AGENTS.md disagree, AGENTS.md wins.
+
+## Posting
+
+Use `src.comms.publishing.publish_editorial_post(...)` for every editorial post. It validates HTML, sends one sendPhoto-with-caption (so photo and text never split), and writes the row that the stats collector reads. We shipped the alternative once and got two separate messages instead of one — the wrapper exists to make that mistake unrepresentable.
+
+```python
+from src.comms.publishing import publish_editorial_post, EditorialValidationError
+
+try:
+    result = await publish_editorial_post(
+        text=html,                       # ≤1024 chars when there's a photo
+        channel="ru",                    # or "en"
+        category="C",                    # A–F, see AGENTS.md
+        entity_id="dau_drop_2026_04_26", # stable slug for this anomaly
+        photo_file_id=tg_file_id,        # or photo_url=
+        topic_slug="dau-drop",
+    )
+except EditorialValidationError as e:
+    # e.errors is a list. Fix the draft, don't fight the validator.
+    ...
+```
+
+Raw `curl`, `sendPhoto`, `sendMessage`, or `bot.send_*` to a public channel produce broken posts. They're fine for the moderator chat (`-1001305866294`) — see AGENTS.md.
+
+## Operating
+
+You run autonomously. Skip `AskUserQuestion`; pick the recommended option and continue.

--- a/agents/comms-manager/routines/daily-channel-post.description.md
+++ b/agents/comms-manager/routines/daily-channel-post.description.md
@@ -1,0 +1,12 @@
+Daily build-in-public post for @ffmemes (RU).
+
+Run the workflow in `agents/comms-manager/AGENTS.md` ("What Triggers You", steps 0–7). That file is the source of truth — don't re-derive a parallel workflow here.
+
+Things that trip people up:
+
+- Post via `src.comms.publishing.publish_editorial_post()`. Single sanctioned path. Raw curl, sendPhoto, or sendMessage to the channel splits the post into photo-without-caption + text — we shipped that once.
+- Step 0 — read `experiments/reports/channel-stats-YYYY-MM-DD.md` for yesterday's performance.
+- Step 1 — pick the strongest `Chart-worthy: yes` finding from `experiments/reports/anomalies-YYYY-MM-DD.md`.
+- Step 7 — archive to `docs/comms/published/YYYY-MM-DD-slug.md` and close this issue with a one-liner pointing at the archive.
+
+Validation, rotation, and the topic ban-list are enforced in code. If `EditorialValidationError` fires, fix the draft.

--- a/agents/comms-manager/routines/daily-channel-post.yaml
+++ b/agents/comms-manager/routines/daily-channel-post.yaml
@@ -1,0 +1,12 @@
+# Paperclip routine — Daily Channel Post for @ffmemes (RU).
+# Live routine ID: b4666e85-8072-441b-b799-62ac35a57a04 (paperclip prod).
+# Long description lives in the sibling .description.md so diffs stay clean.
+name: Daily Channel Post
+agent: comms-manager
+cron: "0 7 * * *"
+timezone: UTC
+enabled: true
+priority: medium
+concurrencyPolicy: coalesce_if_active
+catchUpPolicy: skip_missed
+description_file: daily-channel-post.description.md


### PR DESCRIPTION
## Summary
- Captures the v2 prompts that are currently live in Paperclip (`agents/comms-manager` capabilities + `Daily Channel Post` routine description) into git so they have version history.
- Today the Comms Manager posted a split message (photo at /229, text at /230) because three prompt sources drifted: AGENTS.md was correct, but the agent's `capabilities` field and the routine description in Paperclip's DB still pointed at raw `curl sendMessage`. Only AGENTS.md was tracked in repo. PR #183 (single-message publishing) didn't reach prod via the deploy script.
- v2 prompts were applied directly via `PATCH /api/agents/<id>` and `PATCH /api/routines/<id>`. They're already live; this PR just gives them a home in git.
- The texts were rewritten per [Anthropic's prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices): −38% length, positive framing instead of `BANNED`/`NEVER`, one concrete python example instead of a wall of rules, casual tone matching the agent's casual build-in-public output style, single-sentence role.
- File layout follows codex's recommendation (consulted via `/codex`): `capabilities.md` + per-routine `*.yaml` (metadata only) + sibling `*.description.md` for long text — easier diffs, no YAML escape bugs.

## What's NOT in this PR
- `agents/_sync_config.py` is unchanged; it does not yet read these files. This is a snapshot only. A follow-up PR will add capabilities + routine sync once tomorrow's 07:00 UTC cron firing confirms the new prompt actually produces a single message. If that test fails, the sync extension is premature.

## Test plan
- [ ] CI green
- [ ] Wait for 07:00 UTC (2026-04-27) cron firing on `Daily Channel Post`
- [ ] Verify the resulting @ffmemes post is ONE message (sendPhoto with caption), not two
- [ ] Verify a row appears in `editorial_posts` for the new post
- [ ] If both pass: open follow-up PR extending `_sync_config.py` to PATCH capabilities + routines from these files