### PR TITLE
fix(crossposting): exclude videos from RU channel selection

### DIFF
--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -30,18 +30,16 @@ async def log_meme_sent(
 
 
 async def get_next_meme_for_tgchannelru():
+    # Videos excluded: 1.8x boost flipped RU channel to ~89% videos in last 14 days
+    # (84 video / 10 image as of 2026-04-26). Users complained about video-only feed.
+    # Same root cause as EN fix on 2026-04-22 — fwd/1k boost was an artifact of fewer
+    # views, not better content. RU was left untouched then; reality showed the 50/50
+    # mix collapsed within days. Hard-filter to images, mirroring EN.
     query = """
         SELECT
             M.id
             , M.type, M.telegram_file_id, M.caption
 
-        ----------- DEBUG
-        --	, MS.nlikes
-        --	, MS.ndislikes
-        --	, MS.nmemes_sent
-        --	, MS.raw_impr_rank
-        --	, MS.age_days
-        --	, M.meme_source_id
         FROM meme M
         INNER JOIN meme_stats MS
             ON MS.meme_id = M.id
@@ -53,6 +51,7 @@ async def get_next_meme_for_tgchannelru():
             AND CP.meme_id IS NULL
             AND M.status = 'ok'
             AND M.language_code = 'ru'
+            AND M.type = 'image'
             AND MS.nlikes >= 5
 
         ORDER BY -1
@@ -60,8 +59,6 @@ async def get_next_meme_for_tgchannelru():
             * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.8 END
             * CASE WHEN MS.age_days < 7 THEN 1 ELSE 0.8 END
             * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
-            -- Videos get 1.8x more forwards than photos (11K post analysis)
-            * CASE WHEN M.type = 'video' THEN 1.8 ELSE 1 END
             * CASE
                 WHEN MS.nmemes_sent <= 1 THEN 1
                 ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent


### PR DESCRIPTION
## Summary

- Hard-filter to `M.type = 'image'` on `get_next_meme_for_tgchannelru()` and drop the `1.8x` video boost.
- Mirrors the EN fix (#0ef74db, 2026-04-22).

## Why

User reported videos still showing on https://t.me/fastfoodmemes (RU channel).

Verified on prod DB this afternoon (2026-04-26):

```
RU channel last 14 days:
  video: 84
  image: 10
```

The April 22 fix only patched EN — the commit message explicitly left RU alone, assuming a "healthy ~50/50 mix". That assumption no longer held; RU had collapsed to ~89% videos under the same 1.8x boost from `219eee8`.

Root cause is identical to EN: the "1.8x more forwards" signal was an artifact of fewer views (RU users load videos poorly), not better content.

## Test plan

- [ ] Merge to `production` → Coolify auto-deploys
- [ ] Confirm next ~5 RU posts at `t.me/fastfoodmemes` are images, not videos
- [ ] Watch RU channel views/reactions over the next 7 days for the same recovery EN saw