### PR TITLE
fix(block-tracking): coerce tz-aware Telegram dates to naive UTC for blocked_bot_at

### DIFF
--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Sequence
 
 from sqlalchemy import bindparam, exists, select, text
@@ -319,7 +319,15 @@ async def mark_user_blocked(
     if current is None:
         return None
 
-    ts = when or datetime.utcnow()
+    # blocked_bot_at is TIMESTAMP WITHOUT TIME ZONE; asyncpg on Py 3.14 rejects
+    # tz-aware values. Telegram's update.my_chat_member.date is tz-aware UTC,
+    # so strip tzinfo (preserving the wall-clock UTC moment).
+    if when is None:
+        ts = datetime.now(timezone.utc).replace(tzinfo=None)
+    elif when.tzinfo is not None:
+        ts = when.astimezone(timezone.utc).replace(tzinfo=None)
+    else:
+        ts = when
     current_type = UserType(current["type"]) if current["type"] else None
 
     if current_type and current_type.is_moderator:


### PR DESCRIPTION
## Summary

- Sentry crash: `asyncpg.exceptions.DataError: invalid input for query argument $2: datetime.datetime(2026, 4, 27, 20, 0, 27, tzinfo=...) (can't subtract offset-naive and offset-aware datetimes)` on `UPDATE \"user\" SET ... blocked_bot_at=$2::TIMESTAMP WITHOUT TIME ZONE`.
- `user.blocked_bot_at` is `TIMESTAMP WITHOUT TIME ZONE`. asyncpg under Py 3.14 won't encode a tz-aware value there. `handle_user_blocked_bot` passes `update.my_chat_member.date` (tz-aware UTC) straight through `mark_user_blocked` → bang.

## What I changed

`src/tgbot/service.py::mark_user_blocked` now normalizes `when` before the UPDATE:
- `None` → `datetime.now(timezone.utc).replace(tzinfo=None)` (drops deprecated `utcnow()`)
- tz-aware → `astimezone(UTC).replace(tzinfo=None)` (preserves the wall-clock instant)
- tz-naive → unchanged

## Why not fix at the call site (PR #196 approach)

PR #196 was closed under the rationale that the refactor had already moved this off `datetime.utcnow()`, "passing Telegram's tz-aware datetime instead". That rationale missed that the column itself can't hold tz-aware values; the bug walked back in the second any caller passed Telegram's date through. Fixing in the helper handles all five call sites (`my_chat_member`, `forbidden_send_meme`, `forbidden_broadcast`, `forbidden_global_error`, `forbidden_forward_channel`, `forbidden_waitlist_invite`) and any future ones.

## Out of scope

5 other `datetime.utcnow()` sites in `src/tgbot/service.py` (`save_tg_user`, `update_user_lang`, etc.). They target the same naive columns so they encode fine — just deprecated. Sweep when Py removes `utcnow()`, not under a hot incident fix.

## Test plan

- [ ] Merge → Coolify auto-deploys
- [ ] Trigger user-blocks-bot in DM → expect no asyncpg DataError in Sentry, `user.blocked_bot_at` populated with UTC wall-clock
- [ ] Verify passive-block paths still record (any new row with `blocked_bot_at` from `forbidden_*` source labels)