### PR TITLE
fix(mod-chat): show direct post URLs and live reaction counts

### DIFF
--- a/src/tgbot/handlers/chat/mod_chat_stat.py
+++ b/src/tgbot/handlers/chat/mod_chat_stat.py
@@ -60,21 +60,38 @@ _STATS_QUERY = text(
     r"""
     SELECT
         m.id,
-        COALESCE(ms.nmemes_sent, 0)  AS views,
-        COALESCE(ms.nlikes, 0)       AS nlikes,
-        COALESCE(ms.ndislikes, 0)    AS ndislikes,
+        COALESCE(rc.views, 0)        AS views,
+        COALESCE(rc.nlikes, 0)       AS nlikes,
+        COALESCE(rc.ndislikes, 0)    AS ndislikes,
         COALESCE(ms.sec_to_react, 0) AS sec_to_react,
-        COALESCE(mrt.url, msrc.url)  AS source_url,
+        CASE
+            WHEN msrc.type = 'telegram' AND mrt.post_id IS NOT NULL
+                THEN msrc.url || '/' || mrt.post_id
+            WHEN msrc.type = 'vk' AND mrv.url IS NOT NULL
+                THEN mrv.url
+            ELSE msrc.url
+        END AS source_url,
         (
             SELECT count(*) FROM user_deep_link_log
             WHERE deep_link LIKE :mid_pattern
         ) AS clicks
     FROM meme m
+    LEFT JOIN (
+        SELECT
+            meme_id,
+            COUNT(*)                              AS views,
+            COUNT(*) FILTER (WHERE reaction_id=1) AS nlikes,
+            COUNT(*) FILTER (WHERE reaction_id=2) AS ndislikes
+        FROM user_meme_reaction
+        WHERE meme_id = :mid
+        GROUP BY meme_id
+    ) rc ON rc.meme_id = m.id
     LEFT JOIN meme_stats ms       ON ms.meme_id = m.id
     LEFT JOIN meme_source msrc    ON msrc.id = m.meme_source_id
     LEFT JOIN meme_raw_telegram mrt
-        ON mrt.meme_source_id = m.meme_source_id
-       AND mrt.post_id = m.raw_meme_id
+        ON msrc.type = 'telegram' AND mrt.id = m.raw_meme_id
+    LEFT JOIN meme_raw_vk mrv
+        ON msrc.type = 'vk' AND mrv.id = m.raw_meme_id
     WHERE m.id = :mid
     """
 )


### PR DESCRIPTION
## Why

Moderator forwarded meme #10133049 to the mod chat. The bot replied:

```
👁 0 · 👍 0 · 👎 0
src: https://t.me/matroskina_meme
```

Both halves were wrong:

1. **Source link was channel-only, not the post.** The current query did
   `LEFT JOIN meme_raw_telegram ON mrt.post_id = m.raw_meme_id`, but
   `meme.raw_meme_id` is the `meme_raw_telegram.id` (autoincrement PK),
   not the Telegram `post_id`. The join silently failed, so we fell
   back to `meme_source.url` (the channel root).

2. **Counts read from `meme_stats`, which is on a 15-min cron.** Memes
   served right before the forward have no row yet → `COALESCE(..., 0)`
   reports 0 views / 0 likes / 0 dislikes even though the user clearly
   received the meme.

## What changed

`src/tgbot/handlers/chat/mod_chat_stat.py`:

- Fix the join: `mrt.id = m.raw_meme_id` (gated by `msrc.type='telegram'`).
- Add a `meme_raw_vk` join so VK memes get their direct post URL too.
- Build the TG post URL from `msrc.url || '/' || mrt.post_id`. The stored
  `mrt.url` has the `/s/` preview prefix (`https://t.me/s/channel/12345`),
  which is the embedded-channel-view variant — not what you want when
  clicking through to "this exact post".
- Aggregate views/likes/dislikes live from `user_meme_reaction` so the
  reply reflects reality immediately, no cron lag.

`sec_to_react` still comes from `meme_stats` (median over a window —
not worth recomputing inline).

## Test plan

- [ ] After deploy, forward a recently-served meme to the mod chat and
      confirm the reply shows non-zero views and a `https://t.me/<channel>/<post_id>`
      link that opens the exact post.
- [ ] Forward an older popular meme and confirm counts match what
      `meme_stats` would have reported (within rounding).
- [ ] Forward a VK-sourced meme (if any are still active) and confirm
      `src:` is the `?w=wall...` post link, not the community root.