### PR TITLE
feat(crossposting): persist ranker decision log for retro analysis

### DIFF
--- a/alembic/versions/2026-04-28_add_crossposting_decision_log_table.py
+++ b/alembic/versions/2026-04-28_add_crossposting_decision_log_table.py
@@ -1,0 +1,61 @@
+"""add crossposting_decision_log table
+
+Revision ID: 78054f923898
+Revises: a1b4c7d0e3f6
+Create Date: 2026-04-28 19:54:51.333661
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "78054f923898"
+down_revision = "a1b4c7d0e3f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "crossposting_decision_log",
+        sa.Column("id", sa.Integer(), sa.Identity(always=False), nullable=False),
+        sa.Column(
+            "decided_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("channel", sa.String(), nullable=False),
+        sa.Column("picked_meme_id", sa.Integer(), nullable=True),
+        sa.Column("score_version", sa.Integer(), nullable=False),
+        sa.Column("median_signal", sa.Float(), nullable=True),
+        sa.Column("candidate_pool_size", sa.Integer(), nullable=True),
+        sa.Column(
+            "candidates",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["picked_meme_id"],
+            ["meme.id"],
+            name=op.f("crossposting_decision_log_picked_meme_id_fkey"),
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("crossposting_decision_log_pkey")),
+    )
+    op.create_index(
+        "ix_crossposting_decision_log_channel_time",
+        "crossposting_decision_log",
+        ["channel", "decided_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_crossposting_decision_log_channel_time",
+        table_name="crossposting_decision_log",
+    )
+    op.drop_table("crossposting_decision_log")

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -4,7 +4,12 @@ from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert
 
 from src.crossposting.constants import Channel
-from src.database import crossposting, execute, fetch_one
+from src.database import (
+    crossposting,
+    crossposting_decision_log,
+    execute,
+    fetch_all,
+)
 
 
 async def log_meme_sent(
@@ -34,130 +39,306 @@ async def log_meme_sent(
     await execute(insert_statement)
 
 
-async def get_next_meme_for_tgchannelru():
-    query = """
-        WITH src_quality AS (
-            SELECT
-                m.meme_source_id,
-                AVG(cp.forwards * SQRT(GREATEST(cp.views, 1) / 100.0)) AS signal,
-                COUNT(*) AS n_posts
-            FROM crossposting cp
-            JOIN meme m ON m.id = cp.meme_id
-            WHERE cp.channel = 'tgchannelru'
-              AND cp.created_at > NOW() - INTERVAL '30 days'
-              AND cp.created_at < NOW() - INTERVAL '48 hours'
-              AND cp.views IS NOT NULL
-              AND cp.views > 0
-              AND m.type = 'image'
-            GROUP BY m.meme_source_id
-            HAVING COUNT(*) >= 5
-        ),
-        src_median AS (
-            SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY signal) AS m_signal
-            FROM src_quality
-        ),
-        recent_src AS (
-            SELECT DISTINCT m2.meme_source_id
-            FROM crossposting cp2
-            JOIN meme m2 ON m2.id = cp2.meme_id
-            WHERE cp2.channel = 'tgchannelru'
-              AND cp2.created_at > NOW() - INTERVAL '24 hours'
-              AND cp2.telegram_message_id IS NOT NULL
-        )
-        SELECT M.id, M.type, M.telegram_file_id, M.caption
-        FROM meme M
-        INNER JOIN meme_stats MS ON MS.meme_id = M.id
-        LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelru'
-        LEFT JOIN src_quality SQ ON SQ.meme_source_id = M.meme_source_id
-        WHERE 1=1
-          AND CP.meme_id IS NULL
-          AND M.status = 'ok'
-          AND M.language_code = 'ru'
-          AND M.type = 'image'
-          AND MS.nlikes >= 5
-          AND M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
-        ORDER BY -1
-            * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
-            * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.8 END
-            * CASE WHEN MS.age_days < 7 THEN 1 ELSE 0.8 END
-            * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
-            * CASE
-                WHEN MS.nmemes_sent <= 1 THEN 1
-                ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
-              END
-            * COALESCE(
-                LEAST(2.0, GREATEST(0.5,
-                    SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
-                )),
-                1.0
-              )
-            * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
-        LIMIT 1
-    """
-    return await fetch_one(text(query))
+# Per-channel ranker constants (mirror the SQL ORDER BY).
+_CHANNEL_PARAMS: dict[str, dict[str, Any]] = {
+    "tgchannelru": {"impr_penalty": 0.8, "age_threshold": 7},
+    "tgchannelen": {"impr_penalty": 0.5, "age_threshold": 90},
+}
 
 
-async def get_next_meme_for_tgchannelen() -> dict[str, Any]:
-    query = """
-        WITH src_quality AS (
-            SELECT
-                m.meme_source_id,
-                AVG(cp.forwards * SQRT(GREATEST(cp.views, 1) / 100.0)) AS signal,
-                COUNT(*) AS n_posts
-            FROM crossposting cp
-            JOIN meme m ON m.id = cp.meme_id
-            WHERE cp.channel = 'tgchannelen'
-              AND cp.created_at > NOW() - INTERVAL '30 days'
-              AND cp.created_at < NOW() - INTERVAL '48 hours'
-              AND cp.views IS NOT NULL
-              AND cp.views > 0
-              AND m.type = 'image'
-            GROUP BY m.meme_source_id
-            HAVING COUNT(*) >= 5
-        ),
-        src_median AS (
-            SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY signal) AS m_signal
-            FROM src_quality
-        ),
-        recent_src AS (
-            SELECT DISTINCT m2.meme_source_id
-            FROM crossposting cp2
-            JOIN meme m2 ON m2.id = cp2.meme_id
-            WHERE cp2.channel = 'tgchannelen'
-              AND cp2.created_at > NOW() - INTERVAL '24 hours'
-              AND cp2.telegram_message_id IS NOT NULL
+def _compute_score_breakdown(row: dict[str, Any], channel: str) -> dict[str, Any]:
+    """Reproduce the SQL ORDER BY in Python so each candidate gets a logged score
+    breakdown. Must stay in sync with the ORDER BY in the SQL queries below."""
+    params = _CHANNEL_PARAMS[channel]
+    nlikes = row.get("nlikes") or 0
+    ndislikes = row.get("ndislikes") or 0
+    nmemes_sent = row.get("nmemes_sent") or 0
+    raw_impr_rank = row.get("raw_impr_rank")
+    age_days = row.get("age_days") or 0
+    invited_count = row.get("invited_count") or 0
+    src_signal = row.get("src_signal")
+    median_signal = row.get("median_signal")
+    caption_present = row.get("caption") is not None
+
+    denom = nlikes + ndislikes + 1
+    lr_factor = (nlikes + 1.0) / denom if denom else 0.5
+    impr_factor = (
+        1.0 if (raw_impr_rank is not None and raw_impr_rank <= 1) else params["impr_penalty"]
+    )
+    age_factor = 1.0 if age_days < params["age_threshold"] else 0.8
+    caption_factor = 0.8 if caption_present else 1.0
+    sent_factor = 1.0 if nmemes_sent <= 1 else (nlikes + ndislikes) / nmemes_sent
+
+    if src_signal is not None and median_signal:
+        # SQL returns NUMERIC as Decimal; cast both sides for safe arithmetic.
+        src_quality_mult = max(0.5, min(2.0, float(src_signal) / float(median_signal)))
+    else:
+        src_quality_mult = 1.0
+
+    invited_boost = 1.0 + min(invited_count, 10) * 0.1
+
+    final_score = (
+        lr_factor
+        * impr_factor
+        * age_factor
+        * caption_factor
+        * sent_factor
+        * src_quality_mult
+        * invited_boost
+    )
+
+    return {
+        "lr_factor": round(lr_factor, 4),
+        "impr_factor": round(impr_factor, 4),
+        "age_factor": round(age_factor, 4),
+        "caption_factor": round(caption_factor, 4),
+        "sent_factor": round(sent_factor, 4),
+        "src_quality_mult": round(src_quality_mult, 4),
+        "invited_boost": round(invited_boost, 4),
+        "final_score": round(final_score, 6),
+    }
+
+
+def _build_decision_log(
+    channel: str,
+    score_version: int,
+    candidates: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Build the kwargs dict for log_ranker_decision from a top-N candidate list.
+    Returns None if candidates is empty."""
+    if not candidates:
+        return None
+    picked = candidates[0]
+    log_candidates = []
+    for i, row in enumerate(candidates):
+        breakdown = _compute_score_breakdown(row, channel)
+        log_candidates.append(
+            {
+                "rank": i + 1,
+                "meme_id": row["id"],
+                "source_id": row.get("meme_source_id"),
+                "nlikes": row.get("nlikes"),
+                "ndislikes": row.get("ndislikes"),
+                "raw_impr_rank": row.get("raw_impr_rank"),
+                "age_days": row.get("age_days"),
+                "nmemes_sent": row.get("nmemes_sent"),
+                "invited_count": row.get("invited_count"),
+                "caption_present": row.get("caption") is not None,
+                "src_signal": (
+                    round(float(row["src_signal"]), 4)
+                    if row.get("src_signal") is not None
+                    else None
+                ),
+                **breakdown,
+            }
         )
-        SELECT M.id, M.type, M.telegram_file_id, M.caption
-        FROM meme M
-        INNER JOIN meme_stats MS ON MS.meme_id = M.id
-        LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelen'
-        LEFT JOIN src_quality SQ ON SQ.meme_source_id = M.meme_source_id
-        WHERE 1=1
-          AND CP.meme_id IS NULL
-          AND M.status = 'ok'
-          AND M.language_code = 'en'
-          AND M.type = 'image'
-          AND MS.nlikes >= 5
-          AND M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
-        ORDER BY -1
-            * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
-            * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.5 END
-            * CASE WHEN MS.age_days < 90 THEN 1 ELSE 0.8 END
-            * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
-            * CASE
-                WHEN MS.nmemes_sent <= 1 THEN 1
-                ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
-              END
-            * COALESCE(
-                LEAST(2.0, GREATEST(0.5,
-                    SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
-                )),
-                1.0
-              )
-            * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
-        LIMIT 1
+    return {
+        "channel": channel,
+        "picked_meme_id": picked["id"],
+        "score_version": score_version,
+        "median_signal": (
+            round(float(picked["median_signal"]), 4)
+            if picked.get("median_signal") is not None
+            else None
+        ),
+        "pool_size": picked.get("candidate_pool_size"),
+        "candidates": log_candidates,
+    }
+
+
+async def log_ranker_decision(
+    channel: str,
+    picked_meme_id: int | None,
+    score_version: int,
+    median_signal: float | None,
+    pool_size: int | None,
+    candidates: list[dict[str, Any]],
+) -> None:
+    """Insert one row into crossposting_decision_log. Failures must be wrapped
+    in try/except by the caller (logging miss << duplicate album publish).
     """
-    return await fetch_one(text(query))
+    insert_stmt = insert(crossposting_decision_log).values(
+        channel=channel,
+        picked_meme_id=picked_meme_id,
+        score_version=score_version,
+        median_signal=median_signal,
+        candidate_pool_size=pool_size,
+        candidates=candidates,
+    )
+    await execute(insert_stmt)
+
+
+# Columns exposed for MemeData construction. Keep narrow — adding fields here
+# would require matching changes in src/storage/schemas.py:MemeData.
+_PICKED_FIELDS = ("id", "type", "telegram_file_id", "caption")
+
+
+def _picked_meme_dict(candidate: dict[str, Any]) -> dict[str, Any]:
+    return {k: candidate[k] for k in _PICKED_FIELDS}
+
+
+_RU_QUERY = """
+    WITH src_quality AS (
+        SELECT
+            m.meme_source_id,
+            AVG(cp.forwards * SQRT(GREATEST(cp.views, 1) / 100.0)) AS signal,
+            COUNT(*) AS n_posts
+        FROM crossposting cp
+        JOIN meme m ON m.id = cp.meme_id
+        WHERE cp.channel = 'tgchannelru'
+          AND cp.created_at > NOW() - INTERVAL '30 days'
+          AND cp.created_at < NOW() - INTERVAL '48 hours'
+          AND cp.views IS NOT NULL
+          AND cp.views > 0
+          AND m.type = 'image'
+        GROUP BY m.meme_source_id
+        HAVING COUNT(*) >= 5
+    ),
+    src_median AS (
+        SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY signal) AS m_signal
+        FROM src_quality
+    ),
+    recent_src AS (
+        SELECT DISTINCT m2.meme_source_id
+        FROM crossposting cp2
+        JOIN meme m2 ON m2.id = cp2.meme_id
+        WHERE cp2.channel = 'tgchannelru'
+          AND cp2.created_at > NOW() - INTERVAL '24 hours'
+          AND cp2.telegram_message_id IS NOT NULL
+    )
+    SELECT
+        M.id, M.type, M.telegram_file_id, M.caption,
+        M.meme_source_id,
+        MS.nlikes, MS.ndislikes, MS.raw_impr_rank,
+        MS.age_days, MS.nmemes_sent, MS.invited_count,
+        SQ.signal AS src_signal,
+        (SELECT m_signal FROM src_median) AS median_signal,
+        COUNT(*) OVER () AS candidate_pool_size
+    FROM meme M
+    INNER JOIN meme_stats MS ON MS.meme_id = M.id
+    LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelru'
+    LEFT JOIN src_quality SQ ON SQ.meme_source_id = M.meme_source_id
+    WHERE 1=1
+      AND CP.meme_id IS NULL
+      AND M.status = 'ok'
+      AND M.language_code = 'ru'
+      AND M.type = 'image'
+      AND MS.nlikes >= 5
+      AND M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
+    ORDER BY -1
+        * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
+        * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.8 END
+        * CASE WHEN MS.age_days < 7 THEN 1 ELSE 0.8 END
+        * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
+        * CASE
+            WHEN MS.nmemes_sent <= 1 THEN 1
+            ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
+          END
+        * COALESCE(
+            LEAST(2.0, GREATEST(0.5,
+                SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
+            )),
+            1.0
+          )
+        * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
+    LIMIT :limit
+"""
+
+_EN_QUERY = """
+    WITH src_quality AS (
+        SELECT
+            m.meme_source_id,
+            AVG(cp.forwards * SQRT(GREATEST(cp.views, 1) / 100.0)) AS signal,
+            COUNT(*) AS n_posts
+        FROM crossposting cp
+        JOIN meme m ON m.id = cp.meme_id
+        WHERE cp.channel = 'tgchannelen'
+          AND cp.created_at > NOW() - INTERVAL '30 days'
+          AND cp.created_at < NOW() - INTERVAL '48 hours'
+          AND cp.views IS NOT NULL
+          AND cp.views > 0
+          AND m.type = 'image'
+        GROUP BY m.meme_source_id
+        HAVING COUNT(*) >= 5
+    ),
+    src_median AS (
+        SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY signal) AS m_signal
+        FROM src_quality
+    ),
+    recent_src AS (
+        SELECT DISTINCT m2.meme_source_id
+        FROM crossposting cp2
+        JOIN meme m2 ON m2.id = cp2.meme_id
+        WHERE cp2.channel = 'tgchannelen'
+          AND cp2.created_at > NOW() - INTERVAL '24 hours'
+          AND cp2.telegram_message_id IS NOT NULL
+    )
+    SELECT
+        M.id, M.type, M.telegram_file_id, M.caption,
+        M.meme_source_id,
+        MS.nlikes, MS.ndislikes, MS.raw_impr_rank,
+        MS.age_days, MS.nmemes_sent, MS.invited_count,
+        SQ.signal AS src_signal,
+        (SELECT m_signal FROM src_median) AS median_signal,
+        COUNT(*) OVER () AS candidate_pool_size
+    FROM meme M
+    INNER JOIN meme_stats MS ON MS.meme_id = M.id
+    LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelen'
+    LEFT JOIN src_quality SQ ON SQ.meme_source_id = M.meme_source_id
+    WHERE 1=1
+      AND CP.meme_id IS NULL
+      AND M.status = 'ok'
+      AND M.language_code = 'en'
+      AND M.type = 'image'
+      AND MS.nlikes >= 5
+      AND M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
+    ORDER BY -1
+        * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
+        * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.5 END
+        * CASE WHEN MS.age_days < 90 THEN 1 ELSE 0.8 END
+        * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
+        * CASE
+            WHEN MS.nmemes_sent <= 1 THEN 1
+            ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
+          END
+        * COALESCE(
+            LEAST(2.0, GREATEST(0.5,
+                SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
+            )),
+            1.0
+          )
+        * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
+    LIMIT :limit
+"""
+
+
+async def get_next_meme_for_tgchannelru(
+    log_top_n: int = 5,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Pick the top crosspost candidate for @fastfoodmemes (RU).
+
+    Returns ``(picked_meme, decision_log)``:
+
+    - ``picked_meme`` — narrow dict suitable for ``MemeData(**...)`` construction
+      (id, type, telegram_file_id, caption). ``None`` when no candidate passes
+      filters.
+    - ``decision_log`` — kwargs dict for ``log_ranker_decision``, with the top-N
+      candidates and per-candidate score breakdown. ``None`` when no candidates.
+    """
+    rows = await fetch_all(text(_RU_QUERY), {"limit": log_top_n})
+    if not rows:
+        return None, None
+    return _picked_meme_dict(rows[0]), _build_decision_log("tgchannelru", 2, rows)
+
+
+async def get_next_meme_for_tgchannelen(
+    log_top_n: int = 5,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Same as :func:`get_next_meme_for_tgchannelru` but for @fast_food_memes (EN)."""
+    rows = await fetch_all(text(_EN_QUERY), {"limit": log_top_n})
+    if not rows:
+        return None, None
+    return _picked_meme_dict(rows[0]), _build_decision_log("tgchannelen", 2, rows)
 
 
 async def get_next_meme_for_vkgroupru():

--- a/src/database.py
+++ b/src/database.py
@@ -466,6 +466,29 @@ crossposting_snapshots = Table(
     Column("snapshot_at", DateTime, server_default=func.now(), nullable=False),
 )
 
+crossposting_decision_log = Table(
+    "crossposting_decision_log",
+    metadata,
+    Column("id", Integer, Identity(), primary_key=True),
+    Column("decided_at", DateTime, server_default=func.now(), nullable=False),
+    Column("channel", String, nullable=False),
+    Column("picked_meme_id", ForeignKey("meme.id", ondelete="SET NULL")),
+    Column("score_version", Integer, nullable=False),
+    Column("median_signal", Float),
+    Column("candidate_pool_size", Integer),
+    # candidates JSONB: list of {meme_id, source_id, rank, nlikes, ndislikes,
+    # raw_impr_rank, age_days, nmemes_sent, invited_count, caption_present,
+    # src_signal, src_quality_mult, lr_factor, impr_factor, age_factor,
+    # caption_factor, sent_factor, invited_boost, final_score}
+    Column("candidates", JSONB, nullable=False),
+    Index(
+        "ix_crossposting_decision_log_channel_time",
+        "channel",
+        "decided_at",
+    ),
+)
+
+
 channel_daily_stats = Table(
     "channel_daily_stats",
     metadata,

--- a/src/flows/crossposting/meme.py
+++ b/src/flows/crossposting/meme.py
@@ -10,6 +10,7 @@ from src.crossposting.service import (
     get_next_meme_for_tgchannelen,
     get_next_meme_for_tgchannelru,
     log_meme_sent,
+    log_ranker_decision,
 )
 from src.crossposting.vk import post_photo_to_group
 from src.flows.hooks import notify_telegram_on_failure
@@ -191,12 +192,20 @@ def _get_en_caption_for_crossposting_meme(meme: MemeData, channel: Channel) -> s
 async def post_meme_to_tgchannelen():
     logger = get_run_logger()
 
-    meme_data = await get_next_meme_for_tgchannelen()
+    meme_data, decision = await get_next_meme_for_tgchannelen()
     if meme_data is None:
         logger.warning("No qualifying meme for TG Channel EN, skipping slot")
         return
     next_meme = MemeData(**meme_data)
     logger.info(f"Next meme for TG Channel EN: {next_meme.id}")
+
+    # Persist the ranker decision for retro analysis. Failure must NOT propagate
+    # — Prefect retry would republish the meme.
+    if decision:
+        try:
+            await log_ranker_decision(**decision)
+        except Exception as e:
+            logger.error(f"log_ranker_decision failed for {next_meme.id}: {e}")
 
     caption_text = _get_en_caption_for_crossposting_meme(next_meme, Channel.TG_CHANNEL_EN)
     next_meme.caption = caption_text
@@ -237,12 +246,20 @@ async def post_meme_to_tgchannelen():
 async def post_meme_to_tgchannelru():
     logger = get_run_logger()
 
-    meme_data = await get_next_meme_for_tgchannelru()
+    meme_data, decision = await get_next_meme_for_tgchannelru()
     if meme_data is None:
         logger.warning("No qualifying meme for TG Channel RU, skipping slot")
         return
     next_meme = MemeData(**meme_data)
     logger.info(f"Next meme for TG Channel RU: {next_meme.id}")
+
+    # Persist the ranker decision for retro analysis. Failure must NOT propagate
+    # — Prefect retry would republish the meme.
+    if decision:
+        try:
+            await log_ranker_decision(**decision)
+        except Exception as e:
+            logger.error(f"log_ranker_decision failed for {next_meme.id}: {e}")
 
     caption_text = _get_ru_caption_for_crossposting_meme(next_meme, Channel.TG_CHANNEL_RU)
     next_meme.caption = caption_text

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -2,8 +2,11 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import delete, text
 
-from src.crossposting.service import get_next_meme_for_tgchannelru
-from src.database import crossposting, engine
+from src.crossposting.service import (
+    get_next_meme_for_tgchannelru,
+    log_ranker_decision,
+)
+from src.database import crossposting, crossposting_decision_log, engine
 from src.flows.crossposting.meme import _clean_caption
 from tests.factories import (
     TEST_ID_START,
@@ -58,6 +61,11 @@ def test_whitespace_only():
 
 async def _wipe(conn):
     await conn.execute(delete(crossposting).where(crossposting.c.meme_id >= TEST_ID_START))
+    await conn.execute(
+        delete(crossposting_decision_log).where(
+            crossposting_decision_log.c.picked_meme_id >= TEST_ID_START
+        )
+    )
     await cleanup_test_data(conn)
     await conn.commit()
 
@@ -129,11 +137,14 @@ async def test_select_excludes_source_posted_within_24h(clean_xpost):
         await create_meme_stats(conn, meme_id=10004, nlikes=10, ndislikes=2)
         await conn.commit()
 
-    result = await get_next_meme_for_tgchannelru()
-    assert result is not None, "Source B candidate should remain selectable"
-    assert result["id"] == 10004, (
+    picked, decision = await get_next_meme_for_tgchannelru()
+    assert picked is not None, "Source B candidate should remain selectable"
+    assert picked["id"] == 10004, (
         "diversity cap must exclude source 10001 and prefer source 10003 candidate"
     )
+    assert decision is not None
+    assert decision["picked_meme_id"] == 10004
+    assert decision["candidates"][0]["meme_id"] == 10004
 
 
 @pytest.mark.asyncio
@@ -158,8 +169,9 @@ async def test_select_returns_none_when_all_filtered(clean_xpost):
         await _insert_crossposting(conn, "tgchannelru", 10013, hours_ago=72, views=100, forwards=5)
         await conn.commit()
 
-    result = await get_next_meme_for_tgchannelru()
-    assert result is None
+    picked, decision = await get_next_meme_for_tgchannelru()
+    assert picked is None
+    assert decision is None
 
 
 @pytest.mark.asyncio
@@ -209,10 +221,19 @@ async def test_source_quality_applied_when_n_above_threshold(clean_xpost):
         await create_meme_stats(conn, meme_id=10250, nlikes=10, ndislikes=2)
         await conn.commit()
 
-    result = await get_next_meme_for_tgchannelru()
-    assert result is not None
-    assert result["id"] == 10150, (
+    picked, decision = await get_next_meme_for_tgchannelru()
+    assert picked is not None
+    assert picked["id"] == 10150, (
         "good_source candidate should outrank bad_source via SQ multiplier"
+    )
+    # Decision log captures both candidates with their src_quality_mult
+    assert decision is not None
+    candidate_meme_ids = [c["meme_id"] for c in decision["candidates"]]
+    assert 10150 in candidate_meme_ids and 10250 in candidate_meme_ids
+    picked_breakdown = decision["candidates"][0]
+    other_breakdown = next(c for c in decision["candidates"] if c["meme_id"] == 10250)
+    assert picked_breakdown["src_quality_mult"] > other_breakdown["src_quality_mult"], (
+        "good_source mult must exceed bad_source mult"
     )
 
 
@@ -226,6 +247,105 @@ async def test_source_quality_neutral_when_no_snapshots(clean_xpost):
         await create_meme_stats(conn, meme_id=10301, nlikes=10, ndislikes=2)
         await conn.commit()
 
-    result = await get_next_meme_for_tgchannelru()
-    assert result is not None
-    assert result["id"] == 10301
+    picked, decision = await get_next_meme_for_tgchannelru()
+    assert picked is not None
+    assert picked["id"] == 10301
+    assert decision is not None
+    # Cold-start: src_signal None and src_quality_mult falls through to neutral 1.0
+    only_candidate = decision["candidates"][0]
+    assert only_candidate["src_signal"] is None
+    assert only_candidate["src_quality_mult"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_ranker_decision_log_records_top5(clean_xpost):
+    """Decision log persists top-N candidates with full score breakdown for retro analysis."""
+    async with engine.connect() as conn:
+        await create_meme_source(conn, id=10400, language_code="ru")
+        # Create 7 eligible candidates from the same source (so all pass filters
+        # and rank by score). LIMIT in get_next_meme_for_tgchannelru is 5 → top-5 logged.
+        for i in range(7):
+            mid = 10401 + i
+            await create_meme(
+                conn,
+                id=mid,
+                meme_source_id=10400,
+                language_code="ru",
+                type="image",
+                status="ok",
+            )
+            # Different nlikes so the ranker has a deterministic ordering
+            await create_meme_stats(conn, meme_id=mid, nlikes=20 - i, ndislikes=2)
+        await conn.commit()
+
+    picked, decision = await get_next_meme_for_tgchannelru()
+    assert picked is not None
+    assert decision is not None
+    # Persist via the actual logger (exercising the SQL path)
+    await log_ranker_decision(**decision)
+
+    async with engine.connect() as conn:
+        rows = (
+            (
+                await conn.execute(
+                    text(
+                        "SELECT channel, picked_meme_id, score_version, candidate_pool_size, "
+                        "candidates FROM crossposting_decision_log WHERE picked_meme_id >= :s "
+                        "ORDER BY decided_at DESC LIMIT 1"
+                    ),
+                    {"s": TEST_ID_START},
+                )
+            )
+            .mappings()
+            .all()
+        )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["channel"] == "tgchannelru"
+    assert row["picked_meme_id"] == picked["id"]
+    assert row["score_version"] == 2
+    assert row["candidate_pool_size"] == 7  # 7 eligible memes
+    assert len(row["candidates"]) == 5  # top-5 logged (LIMIT 5)
+    # Each entry has the documented score breakdown keys
+    required_keys = {
+        "rank",
+        "meme_id",
+        "source_id",
+        "nlikes",
+        "ndislikes",
+        "raw_impr_rank",
+        "age_days",
+        "nmemes_sent",
+        "invited_count",
+        "caption_present",
+        "src_signal",
+        "src_quality_mult",
+        "lr_factor",
+        "impr_factor",
+        "age_factor",
+        "caption_factor",
+        "sent_factor",
+        "invited_boost",
+        "final_score",
+    }
+    assert required_keys.issubset(row["candidates"][0].keys())
+    # Rank order matches list order
+    ranks = [c["rank"] for c in row["candidates"]]
+    assert ranks == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_ranker_decision_log_does_not_propagate_db_errors(clean_xpost):
+    """Caller wraps log_ranker_decision in try/except. Smoke-test that obviously
+    invalid args (missing required key) raise — caller is responsible for catching.
+    Ensures the logger doesn't silently swallow programmer errors."""
+    with pytest.raises(Exception):
+        # Missing channel — DB-level NOT NULL violation
+        await log_ranker_decision(
+            channel=None,  # type: ignore[arg-type]
+            picked_meme_id=99999,
+            score_version=2,
+            median_signal=1.0,
+            pool_size=1,
+            candidates=[{"rank": 1, "meme_id": 99999}],
+        )


### PR DESCRIPTION
## Summary

Adds `crossposting_decision_log` table that records, per ranker call, the top-5 candidates with full per-multiplier score breakdown. Closes the forensic gap left by Phase 2 (#210): once the source-quality CTE inputs roll out of the 30-day mature window, we still know *why* each meme was picked.

## What's logged per call

```
{
  decided_at, channel, picked_meme_id, score_version, median_signal,
  candidate_pool_size,                     -- # memes that passed all filters
  candidates: [                            -- top-5 by ORDER BY
    {
      rank, meme_id, source_id,
      nlikes, ndislikes, raw_impr_rank, age_days, nmemes_sent,
      invited_count, caption_present,
      src_signal, src_quality_mult,        -- per-source rolling metric + clamped multiplier
      lr_factor, impr_factor, age_factor,  -- existing multipliers (Python-mirrored)
      caption_factor, sent_factor, invited_boost,
      final_score
    },
    ...
  ]
}
```

## Why

Phase 2 ranker has 7 multiplier components. After 30+ days, the source-quality CTE inputs roll out and we can't retroactively reconstruct what the ranker saw. Without decision logging, the only retro we can do is "did v2 beat v1?" — not "which multiplier dominated?"

This unlocks queries like:
- *Distribution of clamp activations:* how often does `src_quality_mult` hit 0.5/2.0?
- *invited_count value:* did the boost change picks vs rank-2?
- *Pool size:* correlated with channel reach? With cron timing?

## Implementation

- `src/database.py`: new `crossposting_decision_log` table (id, decided_at, channel, picked_meme_id FK, score_version, median_signal, candidate_pool_size, candidates JSONB) + composite index on `(channel, decided_at)`.
- `alembic/versions/2026-04-28_add_crossposting_decision_log_table.py`: clean migration (single head verified).
- `src/crossposting/service.py`:
  - `get_next_meme_for_tgchannelru/en` refactored to return `(picked_meme, decision_log)` tuple. Both `None` if no candidates pass filters.
  - SQL extended to expose raw `meme_stats` fields + `src_signal` + `median_signal` + `COUNT(*) OVER ()` for pool size — ORDER BY identical to before so picking semantics are unchanged.
  - Top-5 returned via `LIMIT :limit` (default 5).
  - `_compute_score_breakdown(row, channel)` mirrors the SQL ORDER BY in Python — the table at the top of the function maps per-channel constants (`impr_penalty`, `age_threshold`).
  - `log_ranker_decision()` writes the JSONB row.
- `src/flows/crossposting/meme.py`: handlers unpack the tuple, call `log_ranker_decision` inside try/except (a log miss is acceptable; a Prefect retry republishing the album is not — same safety pattern as the recent #210 fix).

## Verification

- 15/15 tests pass (`docker compose exec app pytest tests/test_crossposting_meme.py`):
  - 9 existing `_clean_caption` tests
  - 4 ranker tests (existing, updated for tuple return + assert decision is populated)
  - 2 new tests:
    - `test_ranker_decision_log_records_top5` — full schema check, top-5 captured, pool size correct
    - `test_ranker_decision_log_does_not_propagate_db_errors` — invalid args raise (caller wraps in try/except)
- ruff check + format clean
- alembic single head verified locally

## Cost

~10 INSERTs/day (5 RU + 5 EN crons), ~2KB JSON each = 20KB/day = 7MB/year. One additional SQL roundtrip per crosspost (negligible).

## Read patterns (post-deploy retro queries)

```sql
-- How often does src_quality_mult hit the clamp ceiling/floor?
SELECT channel,
  COUNT(*) FILTER (WHERE (candidates->0->>'src_quality_mult')::float >= 1.99) AS at_ceiling,
  COUNT(*) FILTER (WHERE (candidates->0->>'src_quality_mult')::float <= 0.51) AS at_floor,
  COUNT(*) AS total
FROM crossposting_decision_log
WHERE decided_at > NOW() - INTERVAL '14 days'
GROUP BY channel;

-- Did invited_count boost change picks?
SELECT channel,
  AVG((candidates->0->>'invited_count')::int) AS picked_invites,
  AVG((candidates->1->>'invited_count')::int) AS rank2_invites
FROM crossposting_decision_log
WHERE decided_at > NOW() - INTERVAL '14 days'
GROUP BY channel;
```

## Test plan

- [x] All 15 unit + integration tests pass
- [x] alembic upgrade head succeeds; downgrade succeeds (cleanup test fixture)
- [x] Migration single head check
- [x] Ranker still picks the same meme as before (ORDER BY unchanged)
- [ ] **Post-merge:** verify first decision log row lands cleanly on next RU/EN cron
- [ ] **Post-merge:** Sentry + prod logs clean for 30min after first cron

## Predecessor

#210 — Phase 2 source-quality ranker (merged 2026-04-28)