### PR TITLE
chore(agents): add Paperclip routine outcome observability

### DIFF
--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -90,6 +90,24 @@ You do NOT code. You do NOT review PRs. You do NOT debug. You think, decide, and
 - **Experiment to start?** → Create experiment file, create task for CTO to implement
 - **Something to announce?** → Create task for Comms Manager
 
+## Comms Approval Handoff
+
+When you review a Comms draft issue with title `[post:YYYY-MM-DD-slug] ...`,
+your approval is only an intermediate state. The channel post is not done until
+Comms publishes it through `publish_editorial_post` and records the Telegram
+message id.
+
+For an approved post:
+1. Add a comment starting with `APPROVED_TO_PUBLISH`.
+2. Reassign the same issue to Comms Manager and set status back to `todo`.
+3. Do NOT mark the issue `done`. Only Comms Manager closes `[post:...]` issues
+   after publishing and archiving.
+
+For a rejected or stale post:
+1. Comment with `REJECTED` or `STALE_NEEDS_REFRESH` and the required change.
+2. Reassign the issue to Comms Manager with status `todo`.
+3. Do NOT leave the draft assigned to CEO unless you are actively reviewing it.
+
 ## Every Heartbeat (daily)
 
 ### 1. Review Analyst Reports

--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -160,8 +160,23 @@ Run steps 1-7 from "What Triggers You" above. No CEO approval needed.
 Run steps 1-6, then instead of posting directly:
 1. Create a Paperclip issue with full post text + visual PNG attached.
    Title format: `[post:YYYY-MM-DD-slug] Brief topic` (see Issue Hygiene).
-2. Wait for CEO approval — NEVER post without approval.
-3. On approval, post + archive (step 7).
+2. Assign the draft issue to CEO for approval, but make the terminal owner explicit:
+   CEO must either reject it back to Comms, or approve it back to Comms for
+   publishing. CEO approval is not a terminal outcome.
+3. You may close the short-lived routine execution issue after the draft issue is
+   created, so tomorrow's cron is not blocked. The closing comment MUST say
+   `outcome=draft_created`, link the draft issue, and note that publication is
+   still pending.
+4. When an approved `[post:...]` issue is assigned back to you, publish via
+   `publish_editorial_post`, archive, log, and close that draft issue with
+   `outcome=published`, `telegram_message_id`, and `editorial_post_id`.
+5. NEVER close an approved `[post:...]` issue as done before publishing. A CEO
+   approval comment without a Telegram message id means the post is still not
+   public.
+
+If a draft is still waiting for approval or publish after 24h, treat it as stale:
+comment with `outcome=stale_draft`, either refresh the data for today's post or
+ask CEO to explicitly skip, and do not publish outdated metrics silently.
 
 ## Tone of Voice
 

--- a/agents/comms-manager/routines/daily-channel-post.description.md
+++ b/agents/comms-manager/routines/daily-channel-post.description.md
@@ -11,6 +11,6 @@ Things that trip people up:
 - CEO approval is not publication. If approval is required, the routine may close
   its execution issue with `outcome=draft_created`, but the linked `[post:...]`
   issue must later be reassigned to Comms and closed only after
-  `publish_editorial_post()` returns `message_id` / `editorial_post_id`.
+  `publish_editorial_post()` returns `telegram_message_id` / `editorial_post_id`.
 
 Validation, rotation, and the topic ban-list are enforced in code. If `EditorialValidationError` fires, fix the draft.

--- a/agents/comms-manager/routines/daily-channel-post.description.md
+++ b/agents/comms-manager/routines/daily-channel-post.description.md
@@ -8,5 +8,9 @@ Things that trip people up:
 - Step 0 — read `experiments/reports/channel-stats-YYYY-MM-DD.md` for yesterday's performance.
 - Step 1 — pick the strongest `Chart-worthy: yes` finding from `experiments/reports/anomalies-YYYY-MM-DD.md`.
 - Step 7 — archive to `docs/comms/published/YYYY-MM-DD-slug.md` and close this issue with a one-liner pointing at the archive.
+- CEO approval is not publication. If approval is required, the routine may close
+  its execution issue with `outcome=draft_created`, but the linked `[post:...]`
+  issue must later be reassigned to Comms and closed only after
+  `publish_editorial_post()` returns `message_id` / `editorial_post_id`.
 
 Validation, rotation, and the topic ban-list are enforced in code. If `EditorialValidationError` fires, fix the draft.

--- a/agents/qa-engineer/AGENTS.md
+++ b/agents/qa-engineer/AGENTS.md
@@ -184,17 +184,26 @@ After deterministic smoke passes, run `/qa exhaustive` for an improvised bug hun
 
 When triggered by the daily watchdog routine, check that all other routines are running AND succeeding:
 
-1. Use `paperclipApiRequest` with `method` = `"GET"`, `path` = `"/api/companies/96ee7b2e-6df2-43c8-bbe3-53e19297308a/routines"` to list all routines
-2. For each routine, check BOTH **freshness** (did it run recently?) AND **health** (did it succeed?):
+1. Run the compact outcome audit first:
+```bash
+source ~/.zshrc 2>/dev/null || true
+python scripts/paperclip_routine_audit.py --focus all
+```
+If the script is unavailable in the runtime workspace, fall back to
+`paperclipApiRequest`, but preserve the same outcome checks manually.
+2. Use `paperclipApiRequest` with `method` = `"GET"`, `path` = `"/api/companies/96ee7b2e-6df2-43c8-bbe3-53e19297308a/routines"` only for freshness/status details not already shown by the script.
+3. For each routine, check BOTH **freshness** (did it run recently?) AND **health** (did it produce the expected outcome?):
    - **Daily Analyst Report** → ran in last 28h AND `lastRun.status` is not `failed`
    - **QA Log Scan** → ran in last 12h AND `lastRun.status` is not `failed`
    - **Weekly CEO Review** → ran in last 14 days AND `lastRun.status` is not `failed`
    - **Weekly Analyst Summary** → ran in last 14 days AND `lastRun.status` is not `failed`
-   - **gstack Update Check** → ran in last 48h AND `lastRun.status` is not `failed`
+   - **Daily Channel Post** → latest linked `[post:...]` issue has `outcome=published`, `telegram_message_id`, and `editorial_post_id`; draft/approval-only handoffs are YELLOW
+   - **gstack Update Check** → ran in last 48h, `lastRun.status` is not `failed`, and does NOT have `unknown_gstack_update_path` / degraded update flags
+   - **Paperclip Update Check** → ran in last 48h and includes version/changelog impact, not only SHA equality
    - **PR Review** → event-driven, skip unless no runs in 7 days
    - **Process Health Check** → skip (that's you)
-3. If any routine is STALE (hasn't run in time) or FAILED (`lastRun.status == "failed"`) → create **HIGH** priority task for CEO with: which routine, when it last ran, what the status was, and the `failureReason` if available
-4. If all routines are healthy → log "Process health: GREEN" in your QA report
+4. If any routine is STALE, FAILED, or has outcome flags from `paperclip_routine_audit.py`, create or update ONE `[maintenance:routine-outcome-health]` issue for CEO with: routine, issue id, flag, timestamp, and the exact expected outcome contract.
+5. If all routines are fresh and outcome-clean → log "Process health: GREEN" in your QA report.
 
 ## What NOT To Do
 - Do NOT fix bugs yourself (create tasks for **CTO**)

--- a/docs/agents/routine-observability.md
+++ b/docs/agents/routine-observability.md
@@ -1,0 +1,78 @@
+# Agent Routine Observability
+
+Use this before broad manual audits. The goal is to measure useful outcomes,
+not whether Paperclip emitted activity notifications.
+
+## First Command
+
+```bash
+source ~/.zshrc
+python scripts/paperclip_routine_audit.py --focus all
+```
+
+Use `--focus comms` for channel posting and `--focus updates` for Paperclip /
+gstack checks. Add `--json` when another agent needs compact structured input.
+
+## Outcome Contracts
+
+### Daily Channel Post
+
+Terminal success is `outcome=published` with both:
+
+- `telegram_message_id`
+- `editorial_post_id`
+
+`draft_created`, `approval_pending`, and `APPROVED_TO_PUBLISH` are intermediate
+states. CEO approval must reassign the `[post:...]` issue to Comms Manager with
+status `todo`; CEO must not close the issue. Comms Manager is the only terminal
+owner and closes it after publishing through `publish_editorial_post()`.
+
+If a `[post:...]` draft is older than 24 hours, refresh or skip it explicitly.
+Do not publish stale daily metrics silently.
+
+### gstack Update Check
+
+Terminal success must include:
+
+- `upstream_ref`
+- `checked_count`
+- `updated_count`
+- `failed_count`
+- `stale_count`
+- `removed_count`
+- `update_method`
+
+If there are persistent 404s, rate limits, removed upstream skills, or no known
+update path, the run is degraded. Keep one open
+`[maintenance:gstack-update-blocked]` issue instead of closing each daily run as
+green.
+
+### Paperclip Update Check
+
+This is not only a SHA poll. Every run should record:
+
+- deployed Paperclip version/ref
+- latest stable npm version
+- latest canary version, ignored unless explicitly requested
+- changelog delta since deployed version
+- impact on this agent system: simplifications, bug fixes, new skills/tools
+
+If upstream changed, create one triage issue with the impact summary. Do not
+bury the analysis in a completed routine comment.
+
+## Telegram Activity Feed
+
+`@ffnerdbot` is only a low-signal activity feed. It proves that agents started
+or stopped tasks; it does not prove that a useful product outcome happened.
+Routine health should come from the outcome contracts above and from Paperclip
+issues/comments, not from Telegram notifications.
+
+## Context Discipline For Agents
+
+- Spawn subagents only with bounded questions and required output fields.
+- Prefer `scripts/paperclip_routine_audit.py --json` over dumping full agent
+  configs, issue lists, or server logs into context.
+- Summarize upstream changelogs into a repo doc or Paperclip issue first, then
+  reason from that artifact.
+- Treat secrets in Paperclip agent config as toxic output. Never paste values
+  into comments, docs, or chat.

--- a/docs/agents/routine-observability.md
+++ b/docs/agents/routine-observability.md
@@ -60,6 +60,17 @@ This is not only a SHA poll. Every run should record:
 If upstream changed, create one triage issue with the impact summary. Do not
 bury the analysis in a completed routine comment.
 
+### PR Review
+
+Each PR webhook must create or resume the matching `[pr:<number>] Review` issue.
+If trigger payload `pr_number=215` links to `[pr:214] Review`, that is
+`coalesced_pr_review_mismatch`, not healthy queueing.
+
+An issue with status `in_progress`, a latest run status of `running`, and
+`activeRun=null` is `zombie_execution_run`. It blocks future PR reviews while
+doing no visible work. The watchdog should escalate it as a Paperclip runtime
+issue and re-trigger the affected PR after the stale execution is closed.
+
 ## Telegram Activity Feed
 
 `@ffnerdbot` is only a low-signal activity feed. It proves that agents started

--- a/docs/agents/update-routine-findings-2026-05-01.md
+++ b/docs/agents/update-routine-findings-2026-05-01.md
@@ -59,6 +59,11 @@ release note from scratch.
   before closing as useful.
 - `@ffnerdbot` is only an activity feed. It is useful to see work starting and
   stopping, but not to judge value delivered.
+- PR Review can currently misqueue work: PR #215 was coalesced into active
+  `FFM-860 [pr:214] Review`, then both `FFM-860` and the re-triggered
+  `FFM-862 [pr:215] Review` showed `in_progress` + running run +
+  `activeRun=null` with no review comments. Treat this as Paperclip runtime
+  zombie execution, not as a real review in progress.
 
 ## Repo Changes Made
 

--- a/docs/agents/update-routine-findings-2026-05-01.md
+++ b/docs/agents/update-routine-findings-2026-05-01.md
@@ -1,0 +1,81 @@
+# Paperclip / gstack Update Findings — 2026-05-01
+
+This is the compact handoff from the May 1 update routine audit. Use it as
+input for the next Paperclip/gstack update check instead of re-reading every
+release note from scratch.
+
+## Sources Checked
+
+- Paperclip stable npm line: `paperclipai` / `@paperclipai/mcp-server`
+  latest stable `2026.428.0`; canary line `2026.430.0-canary.*` is not a prod
+  target unless explicitly requested.
+- Paperclip releases:
+  - https://github.com/paperclipai/paperclip/releases/tag/v2026.427.0
+  - https://github.com/paperclipai/paperclip/releases/tag/v2026.428.0
+- gstack changelog: https://github.com/garrytan/gstack/blob/main/CHANGELOG.md
+- Telegram plugin npm line: `paperclip-plugin-telegram` latest `0.6.0`.
+
+## Paperclip Changes That Matter Here
+
+- Structured issue-thread interactions: suggested tasks, question forms, and
+  confirmation cards. Use these for approvals and one-way gates instead of
+  ad-hoc comments when prod support is verified.
+- First-class blockers and ordered sub-issues. Use `blockedByIssueIds` and
+  checklist/subtask structure instead of free-text "blocked" states.
+- Liveness/recovery improvements and active-run watchdog. After prod upgrade
+  verification, remove prompt-side race/recovery prose that duplicates runtime
+  behavior.
+- Productivity review service. This is the right surface for "agents are busy
+  but did anything useful happen?" It should open issues for no-comment streaks,
+  long-active runs, and high-churn loops.
+- Recovery fixes in `v2026.428.0`: stranded assigned todo issues, stale company
+  skill refreshes, `maxConcurrentRuns:1`, manual routine visibility, and issue
+  tree pause/resume.
+
+## gstack Changes That Matter Here
+
+- `1.20.0.0`: `/scrape` and `/skillify` browser-skill flow. Use `/scrape` for
+  read-only changelog/dashboard extraction. Do not allow unattended `/skillify`
+  in prod agents yet because it creates persistent browser skills after approval
+  gates.
+- `1.21.1.0`: stronger `/plan-ceo-review` smoke tests around Step 0. Good for
+  planning quality; do not bypass plan-review gates with blanket "always accept"
+  behavior except where the prompt explicitly says autonomous approval is safe.
+- `1.17.0.0`: gbrain memory source/sync flow. Useful later, but it is local-Mac
+  oriented and should not be wired into Paperclip cloud agents without an infra
+  decision.
+
+## Findings From Live Routine Outcomes
+
+- `Daily Channel Post` Apr 30 created `FFM-842`, got CEO approval, then closed
+  green without publishing. The actual public outcome requires
+  `telegram_message_id` and `editorial_post_id`; approval alone is intermediate.
+- `gstack Update Check` closed green while it had no canonical update path for
+  runtime-delivered skills. Future runs must report `upstream_ref`,
+  `checked_count`, `updated_count`, `failed_count`, `removed_count`, and
+  `update_method`.
+- `Paperclip Update Check` is currently SHA-only. It must include deployed
+  version/ref, latest stable, changelog delta, and "impact on this agent system"
+  before closing as useful.
+- `@ffnerdbot` is only an activity feed. It is useful to see work starting and
+  stopping, but not to judge value delivered.
+
+## Repo Changes Made
+
+- Added `scripts/paperclip_routine_audit.py` for compact routine outcome audits.
+- Added `docs/agents/routine-observability.md` with outcome contracts.
+- Updated CEO and Comms prompts so CEO approval returns `[post:...]` issues to
+  Comms instead of closing them as done.
+- Deployed updated agent instructions to live Paperclip on 2026-05-01.
+
+## Next Safe Improvements
+
+- Upgrade Paperclip to stable `2026.428.0` after confirming migrations and
+  backing up prod. Then verify blocker scheduling, structured interactions, and
+  productivity review on real issues before deleting prompt hotfixes.
+- Keep canary `2026.430.0-canary.*` out of prod unless there is a specific bug
+  fix that justifies canary risk.
+- Add `/scrape` to agents that need read-only web extraction only after gstack
+  skill import/update path is explicit and observable.
+- Update Telegram plugin only if we want better routing/threading/digests. It
+  will not solve value observability by itself.

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -174,6 +174,18 @@ Deploy after editing: `./agents/deploy.sh`
 
 ## Routines
 
+Start routine debugging with the compact audit helper instead of dumping raw
+Paperclip JSON:
+
+```bash
+source ~/.zshrc
+python scripts/paperclip_routine_audit.py --focus all
+```
+
+Outcome contracts live in `docs/agents/routine-observability.md`. In particular,
+`@ffnerdbot` is an activity feed only; it is not the source of truth for whether
+a routine produced a useful result.
+
 | Routine | Agent | Schedule (UTC) | Trigger Type | What it does |
 |---------|-------|----------------|-------------|--------------|
 | Daily Analyst Report | Analyst | `19 6 * * *` | schedule + API | Query metrics, detect anomalies, write report |
@@ -183,7 +195,7 @@ Deploy after editing: `./agents/deploy.sh`
 | Weekly Analyst Summary | Analyst | `23 9 * * 1` | schedule | Weekly summary for CEO review |
 | gstack Update Check | CEO | `17 3 * * *` | schedule | Update skills, review changelog |
 | Paperclip Update Check | CTO | `0 4 * * *` | schedule | Check for Paperclip updates |
-| Daily Channel Post | Comms | `0 7 * * *` | schedule | Daily @ffmemes TG channel post |
+| Daily Channel Post | Comms | `0 7 * * *` | schedule | Daily @ffmemes TG channel post; success means published, not only draft approved |
 | PR Review | Staff Engineer | on PR event | 2 webhooks + API | Review PRs via GitHub Actions trigger |
 
 ## Plugins

--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Compact read-only audit for Paperclip routine outcomes.
+
+This is intentionally narrow: it turns routine issues/comments into a small
+outcome report so agents do not spend context manually spelunking Paperclip JSON.
+
+Env:
+  PAPERCLIP_URL
+  PAPERCLIP_API_KEY
+  PAPERCLIP_COMPANY_ID (optional, defaults to FFmemes prod company)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+DEFAULT_COMPANY_ID = "96ee7b2e-6df2-43c8-bbe3-53e19297308a"
+POST_RE = re.compile(r"FFM-\d+")
+DEGRADED_PATTERNS = (
+    "rate-limited",
+    "transient failure",
+    "persistent 404",
+    "no local gstack install",
+    "0 updated",
+    "skills no longer in upstream",
+)
+PUBLISHED_PATTERNS = ("outcome=published", "editorial_post_id", "telegram_message_id")
+
+
+class Paperclip:
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+
+    def get(self, path: str, query: dict[str, str] | None = None) -> Any:
+        url = self.base_url + path
+        if query:
+            url += "?" + urllib.parse.urlencode(query)
+        req = urllib.request.Request(url)
+        req.add_header("Authorization", f"Bearer {self.api_key}")
+        req.add_header("User-Agent", "ffmemes-paperclip-routine-audit/1.0")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"HTTP {exc.code} for {path}: {body}") from exc
+
+
+def parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def minutes_between(start: str | None, end: str | None) -> float | None:
+    a = parse_ts(start)
+    b = parse_ts(end)
+    if not a or not b:
+        return None
+    return round((b - a).total_seconds() / 60, 1)
+
+
+def compact_body(body: str, limit: int = 240) -> str:
+    body = " ".join(body.split())
+    return body if len(body) <= limit else body[: limit - 1] + "…"
+
+
+def issue_comments(client: Paperclip, issue_id: str) -> list[dict[str, Any]]:
+    comments = client.get(f"/api/issues/{issue_id}/comments", {"limit": "100"})
+    if not isinstance(comments, list):
+        return []
+    return sorted(comments, key=lambda item: item.get("createdAt") or "")
+
+
+def get_issue(client: Paperclip, issue_id: str) -> dict[str, Any] | None:
+    try:
+        issue = client.get(f"/api/issues/{issue_id}")
+    except RuntimeError:
+        return None
+    return issue if isinstance(issue, dict) else None
+
+
+def list_issues(client: Paperclip, company_id: str, status: str, limit: int = 100) -> list[dict]:
+    issues = client.get(
+        f"/api/companies/{company_id}/issues",
+        {"status": status, "limit": str(limit)},
+    )
+    return issues if isinstance(issues, list) else []
+
+
+def routine_matches(name: str, focus: str) -> bool:
+    lower = name.lower()
+    if focus == "all":
+        return True
+    if focus == "comms":
+        return "channel post" in lower or "comms" in lower
+    if focus == "updates":
+        return "update check" in lower or "gstack" in lower or "paperclip" in lower
+    return focus.lower() in lower
+
+
+def classify_issue(issue: dict[str, Any], comments: list[dict[str, Any]]) -> tuple[list[str], str]:
+    text = "\n".join([issue.get("description") or ""] + [c.get("body") or "" for c in comments])
+    lower = text.lower()
+    flags: list[str] = []
+    if any(pattern in lower for pattern in DEGRADED_PATTERNS):
+        flags.append("degraded_green")
+    if "last deployed sha" in lower and "current master sha" in lower:
+        if "latest stable" not in lower and "changelog" not in lower:
+            flags.append("sha_only_update_check")
+    if "gstack-derived skills" in lower and "paperclip skills runtime" in lower:
+        flags.append("unknown_gstack_update_path")
+    if "draft issue exists" in lower or "awaiting ceo approval" in lower:
+        flags.append("draft_handoff")
+    if "approved" in lower and not any(pattern in lower for pattern in PUBLISHED_PATTERNS):
+        flags.append("approved_without_publish_marker")
+    if not comments and issue.get("status") == "done":
+        flags.append("no_comments")
+    latest = comments[-1].get("body", "") if comments else issue.get("description", "")
+    return flags, compact_body(latest or "")
+
+
+def referenced_post_issues(
+    client: Paperclip,
+    issue: dict[str, Any],
+    comments: list[dict],
+) -> list[dict]:
+    text = "\n".join([issue.get("description") or ""] + [c.get("body") or "" for c in comments])
+    found: list[dict] = []
+    for ident in sorted(set(POST_RE.findall(text))):
+        ref = get_issue(client, ident)
+        if ref and (ref.get("title") or "").startswith("[post:"):
+            ref_comments = issue_comments(client, ref["id"])
+            flags, latest = classify_issue(ref, ref_comments)
+            found.append(
+                {
+                    "identifier": ref.get("identifier"),
+                    "title": ref.get("title"),
+                    "status": ref.get("status"),
+                    "assigneeAgentId": ref.get("assigneeAgentId"),
+                    "updatedAt": ref.get("updatedAt"),
+                    "flags": flags,
+                    "latest": latest,
+                }
+            )
+    return found
+
+
+def audit_routines(client: Paperclip, company_id: str, focus: str) -> list[dict[str, Any]]:
+    routines = client.get(f"/api/companies/{company_id}/routines")
+    if not isinstance(routines, list):
+        raise RuntimeError("Unexpected routines response")
+
+    rows: list[dict[str, Any]] = []
+    for routine in routines:
+        if routine.get("status") != "active":
+            continue
+        name = routine.get("title") or routine.get("name") or ""
+        if not routine_matches(name, focus):
+            continue
+        run = routine.get("lastRun") or {}
+        linked = run.get("linkedIssue") or {}
+        issue_id = run.get("linkedIssueId")
+        issue = get_issue(client, issue_id) if issue_id else None
+        comments = issue_comments(client, issue_id) if issue_id else []
+        flags, latest = classify_issue(issue or {}, comments)
+        row = {
+            "routine": name,
+            "routineId": routine.get("id"),
+            "runStatus": run.get("status"),
+            "triggeredAt": run.get("triggeredAt"),
+            "completedAt": run.get("completedAt"),
+            "durationMin": minutes_between(run.get("triggeredAt"), run.get("completedAt")),
+            "issue": linked.get("identifier") or (issue or {}).get("identifier"),
+            "issueStatus": linked.get("status") or (issue or {}).get("status"),
+            "flags": flags,
+            "latest": latest,
+        }
+        refs = referenced_post_issues(client, issue or {}, comments)
+        if refs:
+            row["referencedPostIssues"] = refs
+        rows.append(row)
+    return rows
+
+
+def stale_post_drafts(client: Paperclip, company_id: str) -> list[dict[str, Any]]:
+    statuses = "todo,in_progress,in_review,blocked,done"
+    rows: list[dict[str, Any]] = []
+    for issue in list_issues(client, company_id, statuses):
+        title = issue.get("title") or ""
+        if not title.startswith("[post:"):
+            continue
+        comments = issue_comments(client, issue["id"])
+        flags, latest = classify_issue(issue, comments)
+        if flags or issue.get("status") != "done":
+            rows.append(
+                {
+                    "identifier": issue.get("identifier"),
+                    "title": title,
+                    "status": issue.get("status"),
+                    "updatedAt": issue.get("updatedAt"),
+                    "flags": flags,
+                    "latest": latest,
+                }
+            )
+    return rows
+
+
+def print_text(report: dict[str, Any]) -> None:
+    print(f"paperclip_routine_audit generated_at={report['generatedAt']}")
+    print()
+    for row in report["routines"]:
+        flags = ",".join(row["flags"]) if row["flags"] else "ok"
+        print(
+            f"{row['routine']}: run={row['runStatus']} issue={row['issue']} "
+            f"issue_status={row['issueStatus']} duration_min={row['durationMin']} flags={flags}"
+        )
+        if row["latest"]:
+            print(f"  latest: {row['latest']}")
+        for ref in row.get("referencedPostIssues", []):
+            ref_flags = ",".join(ref["flags"]) if ref["flags"] else "ok"
+            print(f"  ref {ref['identifier']} {ref['status']} flags={ref_flags}: {ref['title']}")
+            if ref["latest"]:
+                print(f"    latest: {ref['latest']}")
+    if report["postDrafts"]:
+        print()
+        print("post_drafts:")
+        for draft in report["postDrafts"]:
+            flags = ",".join(draft["flags"]) if draft["flags"] else "ok"
+            print(f"  {draft['identifier']} {draft['status']} flags={flags}: {draft['title']}")
+            if draft["latest"]:
+                print(f"    latest: {draft['latest']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--company-id",
+        default=os.getenv("PAPERCLIP_COMPANY_ID", DEFAULT_COMPANY_ID),
+    )
+    parser.add_argument("--focus", default="all", help="all, comms, updates, or name substring")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args()
+
+    base_url = os.getenv("PAPERCLIP_URL")
+    api_key = os.getenv("PAPERCLIP_API_KEY")
+    if not base_url or not api_key:
+        print("Set PAPERCLIP_URL and PAPERCLIP_API_KEY", file=sys.stderr)
+        return 2
+
+    client = Paperclip(base_url, api_key)
+    post_drafts = (
+        stale_post_drafts(client, args.company_id) if args.focus in {"all", "comms"} else []
+    )
+    report = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "companyId": args.company_id,
+        "focus": args.focus,
+        "routines": audit_routines(client, args.company_id, args.focus),
+        "postDrafts": post_drafts,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_text(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -34,6 +34,23 @@ DEGRADED_PATTERNS = (
     "skills no longer in upstream",
 )
 PUBLISHED_PATTERNS = ("outcome=published", "editorial_post_id", "telegram_message_id")
+SENSITIVE_PATTERNS = (
+    (
+        re.compile(r"(?i)\b(bearer\s+)[a-z0-9._~+/=-]{20,}"),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(r"(https?://)[^@\s/:]+:[^@\s@]+@"),
+        r"\1[REDACTED]@",
+    ),
+    (
+        re.compile(
+            r"(?i)\b([a-z0-9_]*(?:token|secret|api_key|auth)[a-z0-9_]*\s*[:=]\s*)"
+            r"([^\s,;]+)"
+        ),
+        r"\1[REDACTED]",
+    ),
+)
 
 
 class Paperclip:
@@ -72,6 +89,8 @@ def minutes_between(start: str | None, end: str | None) -> float | None:
 
 def compact_body(body: str, limit: int = 240) -> str:
     body = " ".join(body.split())
+    for pattern, replacement in SENSITIVE_PATTERNS:
+        body = pattern.sub(replacement, body)
     return body if len(body) <= limit else body[: limit - 1] + "…"
 
 
@@ -130,7 +149,7 @@ def classify_issue(issue: dict[str, Any], comments: list[dict[str, Any]]) -> tup
         flags.append("unknown_gstack_update_path")
     if "draft issue exists" in lower or "awaiting ceo approval" in lower:
         flags.append("draft_handoff")
-    if "approved" in lower and not any(pattern in lower for pattern in PUBLISHED_PATTERNS):
+    if "approved" in lower and not all(pattern in lower for pattern in PUBLISHED_PATTERNS):
         flags.append("approved_without_publish_marker")
     if not comments and issue.get("status") == "done":
         flags.append("no_comments")

--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -90,6 +90,14 @@ def get_issue(client: Paperclip, issue_id: str) -> dict[str, Any] | None:
     return issue if isinstance(issue, dict) else None
 
 
+def issue_runs(client: Paperclip, issue_id: str) -> list[dict[str, Any]]:
+    try:
+        runs = client.get(f"/api/issues/{issue_id}/runs")
+    except RuntimeError:
+        return []
+    return runs if isinstance(runs, list) else []
+
+
 def list_issues(client: Paperclip, company_id: str, status: str, limit: int = 100) -> list[dict]:
     issues = client.get(
         f"/api/companies/{company_id}/issues",
@@ -173,7 +181,17 @@ def audit_routines(client: Paperclip, company_id: str, focus: str) -> list[dict[
         issue_id = run.get("linkedIssueId")
         issue = get_issue(client, issue_id) if issue_id else None
         comments = issue_comments(client, issue_id) if issue_id else []
+        runs = issue_runs(client, issue_id) if issue_id else []
         flags, latest = classify_issue(issue or {}, comments)
+        if (issue or {}).get("status") == "in_progress" and not (issue or {}).get("activeRun"):
+            if any(item.get("status") == "running" for item in runs):
+                flags.append("zombie_execution_run")
+        payload_pr = str(((run.get("triggerPayload") or {}).get("pr_number")) or "")
+        issue_title = (
+            ((run.get("linkedIssue") or {}).get("title")) or (issue or {}).get("title") or ""
+        )
+        if payload_pr and f"[pr:{payload_pr}]" not in issue_title:
+            flags.append("coalesced_pr_review_mismatch")
         row = {
             "routine": name,
             "routineId": routine.get("id"),


### PR DESCRIPTION
## Summary
- add `scripts/paperclip_routine_audit.py` for compact read-only Paperclip routine outcome checks
- document outcome contracts for Daily Channel Post, gstack Update Check, and Paperclip Update Check
- fix CEO/Comms handoff so approved `[post:...]` issues return to Comms and only close after publishing
- update QA Process Health Check to flag outcome failures, not just `lastRun.status != failed`
- save May 1 Paperclip/gstack changelog findings for future update routines

## Why
`@ffnerdbot` shows activity but not delivered value. The Apr 30 Daily Channel Post was approved but never published because the approval issue closed green without handing the task back to Comms. Update-check routines also closed green without useful changelog/system-impact criteria.

## Verification
- `python -m py_compile scripts/paperclip_routine_audit.py`
- `ruff check scripts/paperclip_routine_audit.py`
- `git diff --check`
- live read-only audit flags the current known issues: `sha_only_update_check`, `unknown_gstack_update_path`, `draft_handoff`

## Live Paperclip
Agent instructions were also deployed to live Paperclip on 2026-05-01 so the next wakes use the fixed handoff/watchdog prompts.
