### PR TITLE
fix(audit): redact Paperclip HTTP errors

### DIFF
--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -73,7 +73,7 @@ class Paperclip:
             with urllib.request.urlopen(req, timeout=30) as resp:
                 return json.loads(resp.read())
         except urllib.error.HTTPError as exc:
-            body = exc.read().decode("utf-8", errors="replace")[:500]
+            body = compact_body(exc.read().decode("utf-8", errors="replace"), limit=500)
             raise RuntimeError(f"HTTP {exc.code} for {path}: {body}") from exc
 
 


### PR DESCRIPTION
## Summary
- redact Paperclip HTTPError response bodies through the same compact redaction path used for comments
- closes the remaining PR #215 follow-up about possible secret leakage in audit exceptions

## Verification
- python3 -m py_compile scripts/paperclip_routine_audit.py
- ./scripts/paperclip_routine_audit.py --focus comms