### PR TITLE
feat(comms): add @ffmemes channel routing to publish_editorial_post

### DIFF
--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -347,7 +347,7 @@ from src.comms.publishing import publish_editorial_post, EditorialValidationErro
 try:
     result = await publish_editorial_post(
         text=final_post_text,           # HTML-formatted, see "Post Formatting"
-        channel="ru",                    # or "en" for @fast_food_memes
+        channel="ffmemes",               # "ffmemes" build-in-public, "ru" @fastfoodmemes, "en" @fast_food_memes
         category="C",                    # A/B/C/D/E/F — see "Content Categories"
         entity_id="dau_delta_2026_04_24",# stable slug for the specific anomaly/topic
         photo_file_id=telegram_file_id,  # OR photo_url — always include a visual
@@ -381,25 +381,23 @@ don't try):
 - **Stats registration.** Inserts into `editorial_posts` so the stats
   collector (every 6h) picks up views/forwards/reactions automatically.
 
-Channel constants (for reference, but you pass `channel="ru"` / `"en"`, not
-raw IDs):
+Channel constants (for reference — pass the `channel` slug, not the raw ID):
 
-- `@ffmemes` (RU build-in-public/product/process) → `-1001472939243`
-- `@fastfoodmemes` (RU main meme channel) → `-1001152876229`
-- `@fast_food_memes` (EN meme channel) → `-1002120551028`
+- `channel="ffmemes"` → `@ffmemes` RU build-in-public/product/process → `-1001472939243`
+- `channel="ru"` → `@fastfoodmemes` RU main meme channel → `-1001152876229`
+- `channel="en"` → `@fast_food_memes` EN meme channel → `-1002120551028`
 - Moderator chat → `-1001305866294` (separate flow, see "Moderator Chat
   Monitoring")
 
 Channel targeting rule:
 
-- Use `@ffmemes` for build-in-public updates about the product, experiments,
-  incidents, agent work, and operational learnings.
-- Use `@fastfoodmemes` for fun findings that work as standalone channel
+- Use `channel="ffmemes"` for build-in-public updates about the product,
+  experiments, incidents, agent work, and operational learnings.
+- Use `channel="ru"` for fun findings that work as standalone @fastfoodmemes
   content, such as most-liked meme / meme-of-the-month posts. These may still
   be archived in `docs/comms/published/`, but the issue outcome must name the
   actual channel and link.
-- If the sanctioned `publish_editorial_post` path cannot target the intended
-  channel, do not fall back to raw Bot API calls. Escalate a code fix instead.
+- Use `channel="en"` for the EN @fast_food_memes meme channel.
 
 ## Post Formatting (HTML)
 

--- a/agents/comms-manager/capabilities.md
+++ b/agents/comms-manager/capabilities.md
@@ -12,7 +12,7 @@ from src.comms.publishing import publish_editorial_post, EditorialValidationErro
 try:
     result = await publish_editorial_post(
         text=html,                       # ≤1024 chars when there's a photo
-        channel="ru",                    # current sanctioned RU publish path; name actual channel in the outcome
+        channel="ffmemes",               # "ffmemes" build-in-public, "ru" @fastfoodmemes, "en" @fast_food_memes
         category="C",                    # A–F, see AGENTS.md
         entity_id="dau_drop_2026_04_26", # stable slug for this anomaly
         photo_file_id=tg_file_id,        # or photo_url=
@@ -29,4 +29,4 @@ Raw `curl`, `sendPhoto`, `sendMessage`, or `bot.send_*` to a public channel prod
 
 You run autonomously. Skip `AskUserQuestion`; pick the recommended option and continue.
 
-Channel targeting: publish product/process/build-in-public updates to @ffmemes. Publish fun meme findings, meme-of-the-month, and broadly entertaining data-meme posts to @fastfoodmemes when they fit the main audience. Always record the actual channel and Telegram URL in the Paperclip outcome.
+Channel targeting: pass `channel="ffmemes"` for product/process/build-in-public updates (@ffmemes). Pass `channel="ru"` for fun meme findings, meme-of-the-month, and broadly entertaining data-meme posts that fit the main @fastfoodmemes audience. Pass `channel="en"` for @fast_food_memes (EN). Always record the actual channel and Telegram URL in the Paperclip outcome.

--- a/src/comms/publishing.py
+++ b/src/comms/publishing.py
@@ -124,7 +124,7 @@ def _normalize_lookalikes(text: str) -> str:
     return text.translate(_CYRILLIC_TO_LATIN)
 
 
-ALLOWED_CHANNELS = frozenset({"ru", "en"})
+ALLOWED_CHANNELS = frozenset({"ru", "en", "ffmemes"})
 
 
 class EditorialValidationError(Exception):
@@ -324,7 +324,9 @@ async def publish_editorial_post(
     read the error list, fix the draft, and call again.
     """
     if channel not in ALLOWED_CHANNELS:
-        raise EditorialValidationError([f"Invalid channel {channel!r}; use 'ru' or 'en'"])
+        raise EditorialValidationError(
+            [f"Invalid channel {channel!r}; use 'ru', 'en', or 'ffmemes'"]
+        )
 
     normalized_text = normalize_blockquote(text)
     photo_key = photo_file_id or photo_url

--- a/src/flows/crossposting/editorial.py
+++ b/src/flows/crossposting/editorial.py
@@ -16,8 +16,15 @@ from src.flows.hooks import notify_telegram_on_failure
 from src.tgbot.bot import bot
 from src.tgbot.constants import (
     TELEGRAM_CHANNEL_EN_CHAT_ID,
+    TELEGRAM_CHANNEL_FFMEMES_CHAT_ID,
     TELEGRAM_CHANNEL_RU_CHAT_ID,
 )
+
+CHANNEL_CHAT_IDS: dict[str, int] = {
+    "ru": TELEGRAM_CHANNEL_RU_CHAT_ID,
+    "en": TELEGRAM_CHANNEL_EN_CHAT_ID,
+    "ffmemes": TELEGRAM_CHANNEL_FFMEMES_CHAT_ID,
+}
 
 
 @flow(
@@ -34,11 +41,13 @@ async def post_editorial_to_channel(
     button_text: str | None = None,
     button_url: str | None = None,
 ):
-    """Post an editorial message to the @ffmemes channel.
+    """Post an editorial message to one of the FFMemes Telegram channels.
 
     Args:
         text: HTML-formatted message text.
-        channel: "ru" or "en".
+        channel: "ru" (@fastfoodmemes — main RU meme channel),
+            "en" (@fast_food_memes — EN meme channel), or
+            "ffmemes" (@ffmemes — RU build-in-public / product / process).
         photo_url: URL to a photo to attach.
         photo_file_id: Telegram file_id of a photo to attach.
         button_text: Optional inline button label.
@@ -46,7 +55,12 @@ async def post_editorial_to_channel(
     """
     logger = get_run_logger()
 
-    chat_id = TELEGRAM_CHANNEL_RU_CHAT_ID if channel == "ru" else TELEGRAM_CHANNEL_EN_CHAT_ID
+    try:
+        chat_id = CHANNEL_CHAT_IDS[channel]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown channel {channel!r}; expected one of {sorted(CHANNEL_CHAT_IDS)}"
+        ) from exc
 
     reply_markup = None
     if button_text and button_url:

--- a/src/tgbot/constants.py
+++ b/src/tgbot/constants.py
@@ -73,6 +73,10 @@ TELEGRAM_CHANNEL_EN_LINK = "https://t.me/fast_food_memes"
 
 TELEGRAM_CHANNEL_RU_CHAT_ID = -1001152876229
 TELEGRAM_CHANNEL_RU_LINK = "https://t.me/fastfoodmemes"
+
+# @ffmemes — RU build-in-public / product / process channel.
+TELEGRAM_CHANNEL_FFMEMES_CHAT_ID = -1001472939243
+TELEGRAM_CHANNEL_FFMEMES_LINK = "https://t.me/ffmemes"
 TELEGRAM_CHAT_RU_CHAT_ID = -1001202214427
 TELEGRAM_CHAT_EN_CHAT_ID = -1001586135039
 

--- a/tests/comms/test_publishing.py
+++ b/tests/comms/test_publishing.py
@@ -7,6 +7,7 @@ that would block a bad draft before any async work runs.
 import pytest
 
 from src.comms.publishing import (
+    ALLOWED_CHANNELS,
     ALLOWED_HTML_TAGS,
     TELEGRAM_CAPTION_MAX,
     compute_draft_hash,
@@ -285,3 +286,30 @@ def test_compute_draft_hash_includes_button():
     assert with_button != compute_draft_hash(
         "ru", "hello", "f1", "C", "e1", button_text="Поехали", button_url="https://t.me/x"
     )
+
+
+# ── Channel routing ───────────────────────────────────────────────────────
+
+
+def test_allowed_channels_includes_ffmemes():
+    # @ffmemes (build-in-public/product/process) is a sanctioned target.
+    assert ALLOWED_CHANNELS == {"ru", "en", "ffmemes"}
+
+
+def test_post_editorial_to_channel_routes_ffmemes_to_correct_chat_id():
+    from src.flows.crossposting.editorial import CHANNEL_CHAT_IDS
+    from src.tgbot.constants import (
+        TELEGRAM_CHANNEL_EN_CHAT_ID,
+        TELEGRAM_CHANNEL_FFMEMES_CHAT_ID,
+        TELEGRAM_CHANNEL_RU_CHAT_ID,
+    )
+
+    assert CHANNEL_CHAT_IDS == {
+        "ru": TELEGRAM_CHANNEL_RU_CHAT_ID,
+        "en": TELEGRAM_CHANNEL_EN_CHAT_ID,
+        "ffmemes": TELEGRAM_CHANNEL_FFMEMES_CHAT_ID,
+    }
+    # Hard-coded per the issue spec — keep these wired to the right chat ids.
+    assert TELEGRAM_CHANNEL_FFMEMES_CHAT_ID == -1001472939243
+    assert TELEGRAM_CHANNEL_RU_CHAT_ID == -1001152876229
+    assert TELEGRAM_CHANNEL_EN_CHAT_ID == -1002120551028


### PR DESCRIPTION
## Summary

- Adds `channel="ffmemes"` (build-in-public / product / process) as a sanctioned target on `publish_editorial_post` so build-in-public posts use the same single-message publishing path as the meme channels.
- Removes the "escalate a code fix" gap that PR #216 documented in the comms-manager spec.

## Changes

- `src/tgbot/constants.py` — `TELEGRAM_CHANNEL_FFMEMES_CHAT_ID = -1001472939243` + link.
- `src/flows/crossposting/editorial.py` — replace inline `if/else` with `CHANNEL_CHAT_IDS` dispatch dict supporting `ru`, `en`, `ffmemes`. Unknown channel now raises a clear `ValueError`.
- `src/comms/publishing.py` — `ALLOWED_CHANNELS += {"ffmemes"}`, sharper validation message.
- `agents/comms-manager/AGENTS.md`, `agents/comms-manager/capabilities.md` — drop the escalation note, document `channel="ffmemes"` as the build-in-public target alongside `ru`/`en`.
- `tests/comms/test_publishing.py` — add channel routing tests covering `ALLOWED_CHANNELS` and `CHANNEL_CHAT_IDS`.

Fixes [FFM-875](/FFM/issues/FFM-875).

## Test plan
- [x] `python3 -m ruff check src/ tests/` — clean
- [x] `python3 -m ruff format --check src/ tests/` — clean
- [x] `python3 -m py_compile` on touched modules
- [ ] CI — `pytest tests/comms/test_publishing.py` covers `ALLOWED_CHANNELS == {"ru","en","ffmemes"}` and `CHANNEL_CHAT_IDS` dispatch.
- [ ] Post-deploy smoke: publish a tiny build-in-public draft via `publish_editorial_post(channel="ffmemes", ...)` and confirm it lands in @ffmemes (-1001472939243).

🤖 Generated with [Claude Code](https://claude.com/claude-code)