### PR TITLE
Extract feed turn recommendation planner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ src/
 │   ├── blender.py       # Weighted random sampling across engines
 │   ├── meme_queue.py    # Redis queue: check_queue, generate_recommendations
 │   └── service.py       # Reaction persistence, stats triggers
+├── feed_turn/
+│   └── planner.py       # Pure maturity-stage decision table (engine plan + mod quota); no DB/Redis/TG. Contract for upcoming Feed Turn refactor; not yet wired into hot path.
 ├── storage/
 │   ├── parsers/         # TG (BeautifulSoup HTML), VK (API), IG (HikerAPI)
 │   ├── etl.py           # Raw posts -> processed memes pipeline

--- a/specs/feed-turn-module.md
+++ b/specs/feed-turn-module.md
@@ -1,0 +1,319 @@
+# Feed Turn Module Refactor Brief
+
+Status: research / implementation handoff.
+Goal: make the reaction -> next meme path easier to change, test, and measure without changing product behavior.
+
+## Why This Matters
+
+The Feed Turn is the product's critical hot path:
+
+```text
+user taps like/dislike
+-> reaction is persisted
+-> next meme or popup is delivered
+-> next impression row is created
+-> queue refill is triggered
+```
+
+Today this is spread across these modules:
+
+- `src/tgbot/handlers/reaction.py`
+- `src/tgbot/senders/next_message.py`
+- `src/tgbot/senders/meme.py`
+- `src/recommendations/service.py`
+- `src/recommendations/meme_queue.py`
+- `src/recommendations/candidates.py`
+- `src/redis.py`
+
+The target is a deeper Module: a small Interface that owns one Feed Turn while keeping the existing implementations behind adapters until parity is proven.
+
+## Current Invariants
+
+- One `user_meme_reaction` row per `(user_id, meme_id)`.
+- A delivered meme is considered seen when the pending `user_meme_reaction` row is inserted, even before the user reacts.
+- `update_user_meme_reaction()` is the idempotency seam: it only updates rows with `reaction_id IS NULL` and returns `rowcount > 0`.
+- Duplicate callback clicks must not trigger another next meme.
+- Queue candidates must be `status='ok'`, language-compatible, unseen for the user, and contain `id`, `type`, `telegram_file_id`, and `recommended_by`.
+- Queue refill uses a Redis lock and only generates when queue length is `<= 8`.
+- Redis queue key format and queued meme JSON shape must not change during the refactor.
+
+## Known Failure Modes To Preserve Or Fix Deliberately
+
+- Malformed callback data can raise before persistence because the handler pattern is broad.
+- Duplicate callbacks currently still run counter cache update, moderator invite check, last active update, and daily reward scheduling before DB dedupe.
+- If no pending reaction row exists, the feed does not advance, but pre-dedupe side effects may already have happened.
+- `Forbidden` in `send_new_message_with_meme()` marks the user blocked and returns `None`; the caller may still create a pending next-impression row.
+- `TimedOut` retries after popping a meme. If Telegram actually delivered, no pending row is created for that popped meme.
+- `BadRequest` disables broken media and retries; after too many failures the user gets the queue-preparing alert.
+- `check_queue()` logs and swallows generation failures, so users may fall through to empty queue behavior.
+
+Do not "clean these up" silently. Write characterization tests first, then decide which behaviors are bugs worth changing.
+
+## Proposed Module Shape
+
+Create a new package only after tests lock current behavior:
+
+```text
+src/feed_turn/
+  __init__.py
+  contracts.py        # TurnRequest, TurnResult, QueueSnapshot, CandidateBatch
+  ports.py            # Protocols for queue, candidates, reactions, user info, delivery, observability
+  planner.py          # pure maturity-stage / engine-plan selection
+  refill.py           # queue refill orchestration
+  turn.py             # FeedTurnService: one feed turn = react + find + deliver + record + refill
+  adapters/
+    legacy_queue.py
+    legacy_candidates.py
+    legacy_reactions.py
+    telegram_delivery.py
+    user_info.py
+```
+
+Keep these public functions import-compatible at first:
+
+- `src.tgbot.handlers.reaction.handle_reaction`
+- `src.tgbot.senders.next_message.next_message`
+- `src.recommendations.meme_queue.check_queue`
+- `src.recommendations.meme_queue.generate_recommendations`
+- `src.tgbot.senders.meme.send_meme_to_user`
+
+## Adapter Seams
+
+- `ReactionLedgerPort`: wraps `create_user_meme_reaction`, `update_user_meme_reaction`, and `user_meme_reaction_exists`.
+- `QueuePort`: wraps Redis LIST operations, queue length, queued IDs, and per-user refill lock.
+- `CandidateRetrieverPort`: wraps `CandidatesRetriever`.
+- `BlenderPort`: wraps `blend()` exactly, including `fixed_pos` and `random_seed`.
+- `DeliveryPort`: wraps caption creation, keyboard creation, send/edit behavior, broken media handling, and blocked-user handling.
+- `UserInfoPort`: wraps cached user info and language lookup.
+- `ObservabilityPort`: structured logs / async analytics writes, never blocking Telegram delivery.
+
+## Safe Implementation Plan
+
+1. Freeze current behavior with characterization tests.
+   Cover reaction idempotency, duplicate callbacks, positive/negative delivery path, stale queue entries, popup branch, first-meme nudge ordering, empty queue alert, `Forbidden`, `TimedOut`, `BadRequest`, and `check_queue` lock behavior.
+
+2. Extract a pure planner.
+   Move only the decision table from `generate_recommendations()`: cold start phases, growing, mature, moderator/admin quota, fixed positions, weights, and fallback chain. No Redis writes, SQL, or Telegram calls in this step.
+
+3. Split candidate selection from enqueue.
+   Keep `generate_recommendations()` as the compatibility wrapper, but introduce internal `select_candidates()` and `enqueue_candidates()` so tests can exercise the selection Interface without mutating Redis.
+
+4. Add observability wrappers around the legacy path.
+   First instrument existing behavior before moving behavior. This gives baseline metrics for parity.
+
+5. Introduce `FeedTurnService` behind `next_message()`.
+   `next_message()` should delegate to the service through legacy adapters while preserving the old function signature.
+
+6. Move `handle_reaction()` orchestration behind the service.
+   Only after delivery behavior is locked and monitored.
+
+7. Move secondary entry points last.
+   Examples: empty queue alert, language reset queue clear, upload completion queue check, broadcasts, moderator manual queue edits.
+
+## Feature Flag And Rollback
+
+Add a config flag such as:
+
+```text
+FEED_TURN_MODULE_ENABLED=false
+```
+
+Default it to false until tests and production telemetry prove parity.
+
+Rollback must be a config flip, not a data migration. Keep these stable:
+
+- Redis key format: `meme_queue:{user_id}`
+- queued meme JSON shape
+- `recommended_by` values
+- `user_meme_reaction` write timing
+- existing public function signatures
+
+Shadow mode is allowed only for pure planning/candidate selection. Do not shadow queue writes or reaction writes.
+
+## Test Gate
+
+Run this focused gate before and after each phase:
+
+```bash
+pytest \
+  tests/recommendations/test_blender.py \
+  tests/recommendations/test_meme_queue.py \
+  tests/recommendations/test_queue_correctness.py \
+  tests/recommendations/test_engine_contracts.py \
+  tests/recommendations/test_reaction_service.py \
+  tests/tgbot/test_reaction_handler.py \
+  tests/tgbot/test_first_meme_nudge.py \
+  tests/test_redis.py
+```
+
+Add new tests before moving behavior:
+
+- `tests/feed_turn/test_planner.py`
+- `tests/feed_turn/test_turn_service.py`
+- `tests/feed_turn/test_refill.py`
+- `tests/tgbot/test_next_message_delivery.py`
+
+Test doubles should sit at adapter seams, not inside implementation details.
+
+## Observability Contract
+
+The refactor is not done until Feed Turn can be monitored.
+
+Use low-cardinality structured logs or a non-blocking analytics writer for always-on data. If a table is added, make it append-only and time-retained.
+
+Recommended event names:
+
+- `ff.feed_turn.started`
+- `ff.feed_turn.completed`
+- `ff.feed_turn.failed`
+- `ff.recs.batch.generated`
+- `ff.recs.engine.completed`
+
+Recommended bounded dimensions:
+
+- `outcome`
+- `failure_class`
+- `reaction_id`
+- `maturity_stage`: `cold_start_1`, `cold_start_2`, `cold_start_3`, `growing`, `mature`, `moderator`
+- `user_type`
+- `prev_engine`
+- `next_engine`
+- `send_method`: `new`, `edit`, `popup`, `alert`
+- `media_type`
+- `language_bucket`: `ru`, `en`, `other`, `multi`
+- `queue_len_bucket`: `0`, `1-2`, `3-8`, `9+`
+
+Never use `user_id`, `meme_id`, `telegram_file_id`, caption text, queue key, or source URL as metric labels. Raw IDs can exist only in sampled logs or analytics tables.
+
+Core metrics:
+
+- `feed_turn_completed_total`
+- `reaction_duplicate_total`
+- `reaction_to_next_delivery_ms`
+- `component_latency_ms` for reaction DB update, queue pop, caption build, Telegram send/edit, impression insert
+- `queue_pop_attempts`
+- `queue_stale_pop_total`
+- `queue_refill_total`
+- `recommendation_batch_duration_ms`
+- `engine_candidate_count`
+- `engine_empty_total`
+- `blend_selected_count`
+- `delivery_failure_total`
+- `continuation_rate_30m`
+- `next_reaction_rate`
+- `fast_dislike_rate`
+
+Recommended alerts:
+
+- p95 `reaction_to_next_delivery_ms` regression
+- queue-empty alert rate spike
+- stale pop rate spike
+- refill failure rate spike
+- Telegram timeout rate spike
+- duplicate reaction rate spike
+- recommendation engine empty rate spike
+- stats freshness lag
+
+## Optional Analytics Tables
+
+If structured logs are not enough, add these only after validating write volume.
+
+`feed_turn_event`:
+
+```text
+turn_id
+event_version
+started_at
+completed_at
+user_id
+prev_meme_id
+prev_engine
+reaction_id
+reaction_is_new
+next_meme_id
+next_engine
+outcome
+failure_class
+maturity_stage
+user_type
+language_bucket
+send_method
+media_type
+queue_before
+queue_after
+pop_attempts
+stale_pops
+refill_triggered
+latencies_ms JSONB
+experiments JSONB
+created_at
+```
+
+`feed_recommendation_batch`:
+
+```text
+batch_id
+created_at
+user_id
+maturity_stage
+limit
+queue_len_before
+exclude_count
+engine_counts JSONB
+selected_counts JSONB
+fallback_used
+enqueued_count
+duration_ms
+lock_status
+error_class
+```
+
+For debugging recommendation decisions, prefer sampled or failure-only decision logs modeled after `crossposting_decision_log`.
+
+## New Session Prompt
+
+Use this prompt to continue in a new session:
+
+```text
+We are in /Users/ohld/Documents/GitHub/ff-backend.
+
+Read AGENTS.md and specs/feed-turn-module.md first. Then inspect the current Feed Turn hot path:
+- src/tgbot/handlers/reaction.py
+- src/tgbot/senders/next_message.py
+- src/tgbot/senders/meme.py
+- src/recommendations/service.py
+- src/recommendations/meme_queue.py
+- src/recommendations/candidates.py
+- src/redis.py
+
+Goal: implement the Feed Turn Module refactor incrementally without changing behavior.
+
+Start by writing characterization tests for the current behavior. Do not move production code until tests cover the behavior being moved.
+
+Initial preferred slice:
+1. Add tests for the pure planner shape you want.
+2. Extract a pure planner from generate_recommendations() into src/feed_turn/planner.py.
+3. Keep generate_recommendations() behavior and public signature unchanged.
+4. Run the focused test gate from specs/feed-turn-module.md.
+
+Architecture vocabulary:
+- Module: anything with an Interface and Implementation.
+- Interface: all facts callers must know, including invariants and error modes.
+- Seam: where behavior can vary without editing the caller.
+- Adapter: concrete implementation at a Seam.
+- Deep Module: lots of behavior behind a small Interface.
+
+Constraints:
+- Preserve Redis queue key format and queued meme JSON shape.
+- Preserve user_meme_reaction semantics.
+- No synchronous analytics writes in the hot path.
+- Do not introduce a broad abstraction unless there are at least two real adapters or it hides real complexity.
+- Keep feature flag / rollback in mind for later phases.
+
+Before finalizing, summarize:
+- what behavior is now covered by tests,
+- what behavior changed, if any,
+- which metrics or logs were added,
+- exact test commands run.
+```
+

--- a/specs/feed-turn-ralphex-plan.md
+++ b/specs/feed-turn-ralphex-plan.md
@@ -185,9 +185,9 @@ tail -f .ralphex/progress/progress-feed-turn-ralphex-plan.txt
 
 ## Babysitting Checklist
 
-- [ ] Stop or redirect if Ralphex edits `meme_queue.py`, `next_message.py`,
+- [x] Stop or redirect if Ralphex edits `meme_queue.py`, `next_message.py`,
   `reaction.py`, Redis helpers, migrations, schemas, or observability writes.
-- [ ] Watch for changed engine names, weights, boundaries, fallback order, or
+- [x] Watch for changed engine names, weights, boundaries, fallback order, or
   `min_sends=10`.
-- [ ] Watch for weakened assertions in existing tests.
-- [ ] Before PR creation, inspect `git diff --stat` and `git diff`.
+- [x] Watch for weakened assertions in existing tests.
+- [x] Before PR creation, inspect `git diff --stat` and `git diff`.

--- a/specs/feed-turn-ralphex-plan.md
+++ b/specs/feed-turn-ralphex-plan.md
@@ -1,0 +1,193 @@
+---
+status: IMPLEMENTED
+---
+# Ralphex Plan: Feed Turn Planner Contract
+
+Repo: ffmemes/ff-backend
+Primary brief: specs/feed-turn-module.md
+Target PR: first safe Feed Turn Module slice
+
+## Goal
+
+Add a pure Feed Turn recommendation planner contract and tests. This first PR
+must not wire the planner into the production recommendation path yet.
+
+The goal is to lock the current maturity-stage decision table before any hot
+path refactor touches Redis, Postgres, Telegram delivery, or queue mutation.
+
+## Hard Constraints
+
+- Do not edit `src/recommendations/meme_queue.py` in this PR.
+- Do not change `generate_recommendations()` behavior or public signature.
+- Do not change `src/tgbot/senders/next_message.py`.
+- Do not change `src/tgbot/handlers/reaction.py`.
+- Do not change Redis key format or queued meme JSON shape.
+- Do not add migrations, schema changes, feature flags, or observability writes.
+- Do not rename engine names or production `recommended_by` strings.
+- Do not weaken existing tests.
+
+## Planner Contract
+
+Create:
+
+```text
+src/feed_turn/
+  __init__.py
+  planner.py
+```
+
+The planner must be pure:
+
+- no Redis imports
+- no SQLAlchemy imports
+- no Telegram imports
+- no `CandidatesRetriever` imports
+- no async functions
+- no DB or network access
+
+Required public interface:
+
+```python
+@dataclass(frozen=True)
+class EngineFallback:
+    engine: str
+    kwargs: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class CandidateSelectionPlan:
+    maturity_stage: str
+    primary_engine: str | None
+    blend_weights: Mapping[str, float]
+    fixed_pos: Mapping[int, str]
+    fallback_engines: tuple[EngineFallback, ...]
+
+
+def plan_candidate_selection(nmemes_sent: int) -> CandidateSelectionPlan:
+    ...
+
+
+def low_sent_quota(limit: int, user_type: str | None) -> int:
+    ...
+```
+
+## Current Behavior To Encode
+
+Regular users:
+
+- `nmemes_sent < 6`
+  - primary engine: `cold_start_explore`
+  - fallback engines: `lr_smoothed` with `min_sends=10`, then `best_uploaded_memes`
+- `6 <= nmemes_sent < 16`
+  - primary engine: `cold_start_adapt`
+  - fallback engines: `lr_smoothed` with `min_sends=10`, then `best_uploaded_memes`
+- `16 <= nmemes_sent < 30`
+  - blend weights: `cold_start_adapt=0.5`, `lr_smoothed=0.3`,
+    `like_spread_and_recent_memes=0.2`
+  - fixed position: `{0: "cold_start_adapt"}`
+  - if blend is empty, fallback engines: `cold_start_adapt`, `lr_smoothed` with
+    `min_sends=10`, then `best_uploaded_memes`
+- `30 <= nmemes_sent < 100`
+  - blend weights: `best_uploaded_memes=0.1`, `lr_smoothed=0.3`,
+    `recently_liked=0.2`, `goat=0.1`, `es_ranked=0.1`,
+    `like_spread_and_recent_memes=0.2`
+  - fixed position: `{0: "lr_smoothed"}`
+  - no fallback after blend
+- `nmemes_sent >= 100`
+  - blend weights: `best_uploaded_memes=0.3`,
+    `like_spread_and_recent_memes=0.3`, `lr_smoothed=0.4`,
+    `recently_liked=0.2`, `goat=0.1`, `es_ranked=0.1`
+  - fixed position: `{0: "lr_smoothed"}`
+  - no fallback after blend
+
+Moderator/admin quota:
+
+- `low_sent_quota(limit, "moderator") == ceil(limit * 0.75)`
+- `low_sent_quota(limit, "admin") == ceil(limit * 0.75)`
+- regular, unknown, and null user types get quota `0`
+
+## Tasks
+
+Ralphex may enforce one task per iteration. Keep checkbox status accurate and
+do not mark later tasks complete until their own verification has run.
+
+### Task 1: Add Pure Planner Tests
+
+- [x] Add `tests/feed_turn/test_planner.py`.
+- [x] Cover exact stage boundaries: `5/6`, `15/16`, `29/30`, `99/100`.
+- [x] Assert cold-start primary engines and fallback engines.
+- [x] Assert `lr_smoothed` cold-start fallback keeps `kwargs == {"min_sends": 10}`.
+- [x] Assert transition, growing, and mature blend weights and fixed positions.
+- [x] Assert moderator/admin low-sent quota uses `ceil(limit * 0.75)`.
+- [x] Assert regular, unknown, and null user types get no low-sent quota.
+- [x] Ensure tests do not hit Redis, Postgres, Telegram, or `CandidatesRetriever`.
+
+### Task 2: Add Pure Planner Module
+
+- [x] Create `src/feed_turn/__init__.py`.
+- [x] Create `src/feed_turn/planner.py`.
+- [x] Add frozen dataclasses for `EngineFallback` and `CandidateSelectionPlan`.
+- [x] Implement `plan_candidate_selection()`.
+- [x] Implement `low_sent_quota()`.
+- [x] Keep mapping fields read-only where practical.
+- [x] Do not edit `src/recommendations/meme_queue.py`.
+
+### Task 3: Verify Local Safety
+
+- [x] Run:
+
+```bash
+pytest tests/feed_turn/test_planner.py tests/recommendations/test_meme_queue.py -q
+ruff check src/ tests/
+ruff format --check src/ tests/
+```
+
+- [x] If the full integration gate is run, run it inside compose/test infra,
+  not host-mode defaults that cannot resolve `redis` or `app_db`.
+- [x] In the PR body, state behavior changed: `none`.
+- [x] In the PR body, state production path wiring is intentionally deferred to
+  the next PR.
+
+## Suggested Ralphex Command
+
+The tasks above are already complete in this branch. Use review mode for this
+branch to avoid re-running the implementation task:
+
+```bash
+ralphex --review specs/feed-turn-ralphex-plan.md
+```
+
+For a fresh implementation from `production`, use:
+
+From the repo root:
+
+```bash
+ralphex \
+  --worktree \
+  --max-iterations 4 \
+  --review-patience 2 \
+  --session-timeout 30m \
+  --idle-timeout 5m \
+  specs/feed-turn-ralphex-plan.md
+```
+
+Optional dashboard/watch mode in a separate terminal:
+
+```bash
+ralphex --serve --port 8081 --watch .ralphex/progress
+```
+
+Progress log is expected near:
+
+```bash
+tail -f .ralphex/progress/progress-feed-turn-ralphex-plan.txt
+```
+
+## Babysitting Checklist
+
+- [ ] Stop or redirect if Ralphex edits `meme_queue.py`, `next_message.py`,
+  `reaction.py`, Redis helpers, migrations, schemas, or observability writes.
+- [ ] Watch for changed engine names, weights, boundaries, fallback order, or
+  `min_sends=10`.
+- [ ] Watch for weakened assertions in existing tests.
+- [ ] Before PR creation, inspect `git diff --stat` and `git diff`.

--- a/src/feed_turn/__init__.py
+++ b/src/feed_turn/__init__.py
@@ -1,0 +1,1 @@
+"""Feed turn planning primitives."""

--- a/src/feed_turn/planner.py
+++ b/src/feed_turn/planner.py
@@ -37,6 +37,7 @@ class CandidateSelectionPlan:
     def __post_init__(self) -> None:
         object.__setattr__(self, "blend_weights", MappingProxyType(dict(self.blend_weights)))
         object.__setattr__(self, "fixed_pos", MappingProxyType(dict(self.fixed_pos)))
+        object.__setattr__(self, "fallback_engines", tuple(self.fallback_engines))
 
 
 LR_SMOOTHED_COLD_FALLBACK = EngineFallback("lr_smoothed", {"min_sends": 10})

--- a/src/feed_turn/planner.py
+++ b/src/feed_turn/planner.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import ceil
+from types import MappingProxyType
+from typing import Any, Mapping
+
+COLD_START_1 = "cold_start_1"
+COLD_START_2 = "cold_start_2"
+COLD_START_3 = "cold_start_3"
+GROWING = "growing"
+MATURE = "mature"
+
+MODERATOR_USER_TYPES = frozenset({"moderator", "admin"})
+
+
+def _empty_str_any_mapping() -> Mapping[str, Any]:
+    return MappingProxyType({})
+
+
+def _empty_str_float_mapping() -> Mapping[str, float]:
+    return MappingProxyType({})
+
+
+def _empty_int_str_mapping() -> Mapping[int, str]:
+    return MappingProxyType({})
+
+
+@dataclass(frozen=True)
+class EngineFallback:
+    engine: str
+    kwargs: Mapping[str, Any] = field(default_factory=_empty_str_any_mapping)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "kwargs", MappingProxyType(dict(self.kwargs)))
+
+
+@dataclass(frozen=True)
+class CandidateSelectionPlan:
+    maturity_stage: str
+    primary_engine: str | None
+    blend_weights: Mapping[str, float] = field(default_factory=_empty_str_float_mapping)
+    fixed_pos: Mapping[int, str] = field(default_factory=_empty_int_str_mapping)
+    fallback_engines: tuple[EngineFallback, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "blend_weights", MappingProxyType(dict(self.blend_weights)))
+        object.__setattr__(self, "fixed_pos", MappingProxyType(dict(self.fixed_pos)))
+        object.__setattr__(self, "fallback_engines", tuple(self.fallback_engines))
+
+
+LR_SMOOTHED_COLD_FALLBACK = EngineFallback("lr_smoothed", {"min_sends": 10})
+BEST_UPLOADED_FALLBACK = EngineFallback("best_uploaded_memes")
+
+
+def plan_candidate_selection(nmemes_sent: int) -> CandidateSelectionPlan:
+    if nmemes_sent < 6:
+        return CandidateSelectionPlan(
+            maturity_stage=COLD_START_1,
+            primary_engine="cold_start_explore",
+            fallback_engines=(LR_SMOOTHED_COLD_FALLBACK, BEST_UPLOADED_FALLBACK),
+        )
+
+    if nmemes_sent < 16:
+        return CandidateSelectionPlan(
+            maturity_stage=COLD_START_2,
+            primary_engine="cold_start_adapt",
+            fallback_engines=(LR_SMOOTHED_COLD_FALLBACK, BEST_UPLOADED_FALLBACK),
+        )
+
+    if nmemes_sent < 30:
+        return CandidateSelectionPlan(
+            maturity_stage=COLD_START_3,
+            primary_engine=None,
+            blend_weights={
+                "cold_start_adapt": 0.5,
+                "lr_smoothed": 0.3,
+                "like_spread_and_recent_memes": 0.2,
+            },
+            fixed_pos={0: "cold_start_adapt"},
+            fallback_engines=(
+                EngineFallback("cold_start_adapt"),
+                LR_SMOOTHED_COLD_FALLBACK,
+                BEST_UPLOADED_FALLBACK,
+            ),
+        )
+
+    if nmemes_sent < 100:
+        return CandidateSelectionPlan(
+            maturity_stage=GROWING,
+            primary_engine=None,
+            blend_weights={
+                "best_uploaded_memes": 0.1,
+                "lr_smoothed": 0.3,
+                "recently_liked": 0.2,
+                "goat": 0.1,
+                "es_ranked": 0.1,
+                "like_spread_and_recent_memes": 0.2,
+            },
+            fixed_pos={0: "lr_smoothed"},
+        )
+
+    return CandidateSelectionPlan(
+        maturity_stage=MATURE,
+        primary_engine=None,
+        blend_weights={
+            "best_uploaded_memes": 0.3,
+            "like_spread_and_recent_memes": 0.3,
+            "lr_smoothed": 0.4,
+            "recently_liked": 0.2,
+            "goat": 0.1,
+            "es_ranked": 0.1,
+        },
+        fixed_pos={0: "lr_smoothed"},
+    )
+
+
+def low_sent_quota(limit: int, user_type: str | None) -> int:
+    value = getattr(user_type, "value", user_type)
+    if value is None or str(value) not in MODERATOR_USER_TYPES:
+        return 0
+    return ceil(limit * 0.75)

--- a/src/feed_turn/planner.py
+++ b/src/feed_turn/planner.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from math import ceil
 from types import MappingProxyType
 from typing import Any, Mapping
@@ -14,22 +14,13 @@ MATURE = "mature"
 MODERATOR_USER_TYPES = frozenset({"moderator", "admin"})
 
 
-def _empty_str_any_mapping() -> Mapping[str, Any]:
-    return MappingProxyType({})
-
-
-def _empty_str_float_mapping() -> Mapping[str, float]:
-    return MappingProxyType({})
-
-
-def _empty_int_str_mapping() -> Mapping[int, str]:
-    return MappingProxyType({})
+_EMPTY_MAPPING: Mapping[Any, Any] = MappingProxyType({})
 
 
 @dataclass(frozen=True)
 class EngineFallback:
     engine: str
-    kwargs: Mapping[str, Any] = field(default_factory=_empty_str_any_mapping)
+    kwargs: Mapping[str, Any] = _EMPTY_MAPPING
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "kwargs", MappingProxyType(dict(self.kwargs)))
@@ -39,14 +30,13 @@ class EngineFallback:
 class CandidateSelectionPlan:
     maturity_stage: str
     primary_engine: str | None
-    blend_weights: Mapping[str, float] = field(default_factory=_empty_str_float_mapping)
-    fixed_pos: Mapping[int, str] = field(default_factory=_empty_int_str_mapping)
+    blend_weights: Mapping[str, float] = _EMPTY_MAPPING
+    fixed_pos: Mapping[int, str] = _EMPTY_MAPPING
     fallback_engines: tuple[EngineFallback, ...] = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "blend_weights", MappingProxyType(dict(self.blend_weights)))
         object.__setattr__(self, "fixed_pos", MappingProxyType(dict(self.fixed_pos)))
-        object.__setattr__(self, "fallback_engines", tuple(self.fallback_engines))
 
 
 LR_SMOOTHED_COLD_FALLBACK = EngineFallback("lr_smoothed", {"min_sends": 10})

--- a/tests/feed_turn/test_planner.py
+++ b/tests/feed_turn/test_planner.py
@@ -124,6 +124,20 @@ def test_planner_mappings_are_read_only():
         plan.fixed_pos[0] = "x"
 
 
+def test_fallback_engines_coerced_to_tuple():
+    from src.feed_turn.planner import CandidateSelectionPlan, EngineFallback
+
+    plan = CandidateSelectionPlan(
+        maturity_stage="x",
+        primary_engine=None,
+        fallback_engines=[EngineFallback("a")],
+    )
+
+    assert isinstance(plan.fallback_engines, tuple)
+    with pytest.raises(AttributeError):
+        plan.fallback_engines.append(EngineFallback("b"))
+
+
 def test_engine_fallback_kwargs_are_read_only():
     cold_plan = plan_candidate_selection(0)
     lr_fallback = cold_plan.fallback_engines[0]

--- a/tests/feed_turn/test_planner.py
+++ b/tests/feed_turn/test_planner.py
@@ -120,3 +120,14 @@ def test_planner_mappings_are_read_only():
 
     with pytest.raises(TypeError):
         plan.blend_weights["lr_smoothed"] = 0.9
+    with pytest.raises(TypeError):
+        plan.fixed_pos[0] = "x"
+
+
+def test_engine_fallback_kwargs_are_read_only():
+    cold_plan = plan_candidate_selection(0)
+    lr_fallback = cold_plan.fallback_engines[0]
+
+    assert lr_fallback.engine == "lr_smoothed"
+    with pytest.raises(TypeError):
+        lr_fallback.kwargs["min_sends"] = 1

--- a/tests/feed_turn/test_planner.py
+++ b/tests/feed_turn/test_planner.py
@@ -1,0 +1,122 @@
+import pytest
+
+from src.feed_turn.planner import (
+    COLD_START_1,
+    COLD_START_2,
+    COLD_START_3,
+    GROWING,
+    MATURE,
+    low_sent_quota,
+    plan_candidate_selection,
+)
+
+
+def _fallbacks(nmemes_sent: int) -> tuple[tuple[str, dict], ...]:
+    plan = plan_candidate_selection(nmemes_sent)
+    return tuple((fallback.engine, dict(fallback.kwargs)) for fallback in plan.fallback_engines)
+
+
+@pytest.mark.parametrize(
+    ("nmemes_sent", "stage", "primary_engine"),
+    [
+        (5, COLD_START_1, "cold_start_explore"),
+        (6, COLD_START_2, "cold_start_adapt"),
+        (15, COLD_START_2, "cold_start_adapt"),
+        (16, COLD_START_3, None),
+        (29, COLD_START_3, None),
+        (30, GROWING, None),
+        (99, GROWING, None),
+        (100, MATURE, None),
+    ],
+)
+def test_stage_boundaries(nmemes_sent, stage, primary_engine):
+    plan = plan_candidate_selection(nmemes_sent)
+
+    assert plan.maturity_stage == stage
+    assert plan.primary_engine == primary_engine
+
+
+@pytest.mark.parametrize("nmemes_sent", [0, 5, 6, 15])
+def test_cold_start_fallback_order_and_min_sends(nmemes_sent):
+    assert _fallbacks(nmemes_sent) == (
+        ("lr_smoothed", {"min_sends": 10}),
+        ("best_uploaded_memes", {}),
+    )
+
+
+def test_transition_blend_and_empty_blend_fallback_order():
+    plan = plan_candidate_selection(16)
+
+    assert dict(plan.blend_weights) == {
+        "cold_start_adapt": 0.5,
+        "lr_smoothed": 0.3,
+        "like_spread_and_recent_memes": 0.2,
+    }
+    assert dict(plan.fixed_pos) == {0: "cold_start_adapt"}
+    assert _fallbacks(16) == (
+        ("cold_start_adapt", {}),
+        ("lr_smoothed", {"min_sends": 10}),
+        ("best_uploaded_memes", {}),
+    )
+
+
+def test_growing_blend_plan():
+    plan = plan_candidate_selection(30)
+
+    assert dict(plan.blend_weights) == {
+        "best_uploaded_memes": 0.1,
+        "lr_smoothed": 0.3,
+        "recently_liked": 0.2,
+        "goat": 0.1,
+        "es_ranked": 0.1,
+        "like_spread_and_recent_memes": 0.2,
+    }
+    assert dict(plan.fixed_pos) == {0: "lr_smoothed"}
+    assert plan.fallback_engines == ()
+
+
+def test_mature_blend_plan():
+    plan = plan_candidate_selection(100)
+
+    assert dict(plan.blend_weights) == {
+        "best_uploaded_memes": 0.3,
+        "like_spread_and_recent_memes": 0.3,
+        "lr_smoothed": 0.4,
+        "recently_liked": 0.2,
+        "goat": 0.1,
+        "es_ranked": 0.1,
+    }
+    assert dict(plan.fixed_pos) == {0: "lr_smoothed"}
+    assert plan.fallback_engines == ()
+
+
+@pytest.mark.parametrize(
+    ("limit", "user_type", "quota"),
+    [
+        (4, "moderator", 3),
+        (15, "admin", 12),
+        (1, "moderator", 1),
+        (0, "admin", 0),
+    ],
+)
+def test_low_sent_quota_for_moderators_and_admins(limit, user_type, quota):
+    assert low_sent_quota(limit, user_type) == quota
+
+
+@pytest.mark.parametrize("user_type", ["user", "active_user", "blocked_bot", "unknown", None])
+def test_low_sent_quota_for_regular_or_unknown_user_types(user_type):
+    assert low_sent_quota(15, user_type) == 0
+
+
+def test_low_sent_quota_accepts_enum_like_values_without_importing_tgbot():
+    class UserTypeLike:
+        value = "moderator"
+
+    assert low_sent_quota(4, UserTypeLike()) == 3
+
+
+def test_planner_mappings_are_read_only():
+    plan = plan_candidate_selection(30)
+
+    with pytest.raises(TypeError):
+        plan.blend_weights["lr_smoothed"] = 0.9


### PR DESCRIPTION
## Summary
- Add a pure `src/feed_turn` planner contract for feed-turn recommendation stage decisions.
- Add planner tests that lock stage boundaries, blend weights, fixed positions, cold-start fallback kwargs, moderator/admin quota, and immutability behavior.
- Add Feed Turn architecture / Ralphex handoff specs; production hot path wiring is intentionally deferred.

## Behavior changed
None. This PR does not wire the planner into `generate_recommendations()` and does not change Redis, DB schema, Telegram delivery, queue JSON, or recommendation execution.

## Files changed
- `src/feed_turn/planner.py`
- `tests/feed_turn/test_planner.py`
- `specs/feed-turn-module.md`
- `specs/feed-turn-ralphex-plan.md`
- `CLAUDE.md`

## Verification
- `pytest tests/feed_turn/test_planner.py tests/recommendations/test_meme_queue.py -q` — 38 passed
- `ruff check src/ tests/` — passed
- `ruff format --check src/ tests/` — passed
- `docker compose exec -T app pytest tests/feed_turn/test_planner.py -q` — 28 passed
- `docker compose exec -T app pytest tests/recommendations/test_blender.py tests/recommendations/test_meme_queue.py tests/recommendations/test_queue_correctness.py tests/recommendations/test_engine_contracts.py tests/recommendations/test_reaction_service.py tests/tgbot/test_reaction_handler.py tests/tgbot/test_first_meme_nudge.py tests/test_redis.py -q` — 88 passed, 2 skipped
- `ralphex --review --review-patience 2 --session-timeout 30m --idle-timeout 5m specs/feed-turn-ralphex-plan.md` — completed successfully; Claude critical/major review and Codex external review found no remaining issues

## Next slice
Wire `plan_candidate_selection()` into `generate_recommendations()` in a separate PR, preserving current behavior and reusing the tests added here as the contract.