### PR TITLE
fix(snooze): early-kill pure-pumpers at >=80% ad_rate / >=10 sample [FFM-847]

### DIFF
--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -69,7 +69,9 @@ async def maybe_auto_snooze_source(
     Snoozes the source if any criterion is met:
       1. 3 consecutive parse attempts returned 0 posts.
       2. like_rate < 10% with at least 100 total reactions.
-      3. ad_rate > 30% over rolling 7d window with >= 30 processed memes.
+      3a. ad_rate >= 80% over rolling 7d window with >= 10 processed memes
+          (early-kill for extreme pumpers).
+      3b. ad_rate > 30% over rolling 7d window with >= 30 processed memes.
     Returns the snooze reason string if snoozed, None otherwise.
     """
     source = await fetch_one(select(meme_source).where(meme_source.c.id == meme_source_id))
@@ -140,9 +142,24 @@ async def maybe_auto_snooze_source(
         ),
         {"sid": meme_source_id},
     )
-    if ad_stats and ad_stats["n_processed"] >= 30:
+    if ad_stats and ad_stats["n_processed"] >= 10:
         ad_rate = ad_stats["n_ads"] / ad_stats["n_processed"]
-        if ad_rate > 0.30:
+        # Criterion 3a: pure-pumper early-kill. A 100%-ad source has no legitimate
+        # signal regardless of volume; the 30-meme floor only protects against
+        # noise, which doesn't apply at >=80% ad_rate.
+        if ad_rate >= 0.80:
+            await update_meme_source(
+                meme_source_id,
+                status=MemeSourceStatus.SNOOZED.value,
+                data={
+                    **updated_data,
+                    "snoozed_reason": "extreme_ad_rate",
+                    "snoozed_at": now_iso,
+                },
+            )
+            return "extreme_ad_rate"
+        # Criterion 3b: standard high-ad-rate gate.
+        if ad_stats["n_processed"] >= 30 and ad_rate > 0.30:
             await update_meme_source(
                 meme_source_id,
                 status=MemeSourceStatus.SNOOZED.value,

--- a/tests/test_auto_snooze.py
+++ b/tests/test_auto_snooze.py
@@ -286,3 +286,68 @@ async def test_failed_pipeline_memes_excluded_from_denominator(conn: AsyncConnec
     result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=5)
 
     assert result == "high_ad_rate"
+
+
+# Criterion 3a: extreme_ad_rate early-kill (FFM-847 follow-up).
+# Pure-pumper sources that post few but ~100% ad memes never reach the 30-meme
+# sample threshold on volume alone. Catch them at >=80% ad_rate with >=10 processed.
+
+
+@pytest.mark.asyncio
+async def test_snooze_on_extreme_ad_rate_below_standard_sample(conn: AsyncConnection):
+    """100% ad_rate with 12 processed memes (below the 30-meme standard threshold)
+    must early-kill via 'extreme_ad_rate'."""
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    await _seed_memes(conn, source_id=SOURCE_ID, n_ad=12, n_ok=0)
+    await conn.commit()
+
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=5)
+
+    assert result == "extreme_ad_rate"
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.SNOOZED.value
+    assert source["data"]["snoozed_reason"] == "extreme_ad_rate"
+
+
+@pytest.mark.asyncio
+async def test_snooze_on_extreme_ad_rate_at_80_pct_boundary(conn: AsyncConnection):
+    """Threshold is `>= 0.80`. Exactly 80% (8 ad / 10 processed) must snooze."""
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    await _seed_memes(conn, source_id=SOURCE_ID, n_ad=8, n_ok=2)
+    await conn.commit()
+
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=5)
+
+    assert result == "extreme_ad_rate"
+
+
+@pytest.mark.asyncio
+async def test_no_snooze_on_extreme_ad_rate_below_min_sample(conn: AsyncConnection):
+    """9 processed memes (9 ad = 100% ad_rate) is below the 10-meme minimum sample
+    for the early-kill. Don't snooze — wait for one more meme."""
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    await _seed_memes(conn, source_id=SOURCE_ID, n_ad=9, n_ok=0)
+    await conn.commit()
+
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=5)
+
+    assert result is None
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.PARSING_ENABLED.value
+
+
+@pytest.mark.asyncio
+async def test_no_snooze_just_below_extreme_threshold(conn: AsyncConnection):
+    """79% ad_rate (mid-band: too high to be healthy, too low for early-kill, sample
+    too small for standard gate) must NOT snooze. Wait for the standard gate to
+    kick in once n_processed >= 30."""
+    await create_meme_source(conn, id=SOURCE_ID, status="parsing_enabled")
+    # 11 ad + 3 ok = 14 processed, ad_rate ≈ 78.6% — under 80%, under 30 sample
+    await _seed_memes(conn, source_id=SOURCE_ID, n_ad=11, n_ok=3)
+    await conn.commit()
+
+    result = await maybe_auto_snooze_source(SOURCE_ID, new_posts_count=5)
+
+    assert result is None
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.PARSING_ENABLED.value


### PR DESCRIPTION
## Summary

Follow-up to #214. The 30%/30-sample gate is correct for noise-bounded mid-band cases, but misses pure-pumper sources that post few but ~100% ad memes — they take 1-7 days to self-snooze on volume alone, during which user sessions keep seeing ads. FFM-847 cohort sources 148/149/155/156 are in this exact mid-band trap (155/156 are 100% ad_rate over the rolling window).

Adds an additive sub-criterion: **ad_rate >= 80% AND n_processed >= 10 → snooze with reason `extreme_ad_rate`**.

- Sample floor of 10 still guards against noise (a single-meme 100%-ad reading isn't a signal).
- 80% threshold sits well above any plausible noise band, so the standard 30-meme floor is unnecessary for extreme cases.
- Distinct reason string (`extreme_ad_rate` vs `high_ad_rate`) so we can attribute snoozes separately in monitoring and the next post-deploy reality check.
- Standard 3b gate (>30% ad_rate / >=30 sample) stays intact and unchanged.

Per CEO greenlight on [FFM-847 comment 097e1f25](https://github.com/ffmemes/ff-backend/issues/FFM-847).

## Test plan

- [x] `tests/test_auto_snooze.py` — 4 new cases:
  - 100% ad_rate with 12 memes (below standard sample) → `extreme_ad_rate`
  - 80% boundary (8 ad / 10 ok=2) → `extreme_ad_rate` (strict `>=`)
  - 100% ad_rate with 9 memes (below 10-sample floor) → no snooze
  - 78.6% ad_rate / 14 sample (mid-band: not extreme, not standard) → no snooze
- [x] Existing 9 tests for criteria 1, 2, 3b still pass (no behavior change for them).
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Post-deploy: verify cohort sources 148/149/155/156 snooze on next parse cycle with `data->>'snoozed_reason' = 'extreme_ad_rate'` and ok_pct climbs back ≥90%.