### PR TITLE
fix(start): lazy-init languages on /start to unblock cold-start orphans

### DIFF
--- a/src/tgbot/handlers/start.py
+++ b/src/tgbot/handlers/start.py
@@ -21,6 +21,7 @@ from src.tgbot.senders.next_message import next_message
 from src.tgbot.service import (
     create_or_update_user,
     get_tg_user_by_id,
+    get_user_languages,
     log_user_deep_link,
     save_tg_user,
 )
@@ -102,18 +103,23 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         created,
     )
 
+    # Ensure language rows exist before any branch that may serve memes.
+    # Covers: new users on every deep_link path (kitchen used to skip init),
+    # and historical orphans whose init was never run — they were stuck on
+    # "memes ended" because recommendations filter by user_language.
+    # Idempotent: add_user_languages uses ON CONFLICT DO NOTHING.
+    if not await get_user_languages(user_id):
+        await init_user_languages_from_tg_user(update.effective_user)
+
     if deep_link == "kitchen":
         return await handle_show_kitchen(update, context)
 
     if deep_link == "wrapped":
         from src.tgbot.handlers.stats.wrapped import handle_wrapped
 
-        if created:
-            await init_user_languages_from_tg_user(update.effective_user)
         return await handle_wrapped(update, context)
 
     if created:  # new user:
-        await init_user_languages_from_tg_user(update.effective_user)
         await handle_language_settings(update, context)
 
         await handle_invited_user(


### PR DESCRIPTION
## Summary

User #370728472 (Sega, RU) ran `/start`, instantly got "мемы кончились". DB showed `user_language` empty for his row. Recommendations filter on `user_language` → no candidates → cold-start "empty feed" message.

He landed there because he registered on 2026-04-01 via `?start=kitchen`. The kitchen branch in `handle_start` returns **before** any call to `init_user_languages_from_tg_user`:

```python
if deep_link == "kitchen":
    return await handle_show_kitchen(update, context)
```

`wrapped` and the main `if created:` branches both init; `kitchen` silently skipped it.

## Blast radius

Already-active orphans backfilled manually on prod:
- 6 users created in last 30 days (4 via `kitchen` deep_link, 2 via `None`)
- Sega (#370728472) included
- Set `user_language` from `user_tg.language_code` (5 → `ru`, 1 → `en`)

Long tail (not in scope): 893 total historical orphans, but only 3 active in last 7d — they self-heal on their next `/start` once this PR ships (the new lazy-init covers them).

Critically: **38/38 new users in the last 7 days have language rows** — the main onboarding funnel was not blocked. This was a long-tail correctness bug on share-link / deep-link branches that returned early.

## What I changed

`src/tgbot/handlers/start.py`: one idempotent check hoisted above the deep_link branching:

```python
if not await get_user_languages(user_id):
    await init_user_languages_from_tg_user(update.effective_user)
```

Removed the duplicate per-branch calls in `wrapped` and `if created:` (the new check supersedes them). `add_user_languages` uses `ON CONFLICT DO NOTHING` so this is safe to re-run.

## Test plan

- [ ] Merge → Coolify auto-deploys
- [ ] `/start` from a fresh account → confirm `user_language` row created
- [ ] `/start ?start=kitchen` from a fresh account → confirm `user_language` row created (was the bug)
- [ ] One of the orphans hits `/start` again → confirm no double-insert (idempotent path)