### PR TITLE
ops(broadcast): ghost-user recovery script

### DIFF
--- a/scripts/broadcast_ghost_recovery.py
+++ b/scripts/broadcast_ghost_recovery.py
@@ -40,7 +40,7 @@ def _lang_group(language_code: str | None) -> str:
 
 
 async def get_ghost_users() -> list[dict]:
-    """Registered ≤12mo, never delivered a meme, not blocked, not banned."""
+    """Registered ≤12mo, never delivered a meme, not blocked, not waitlisted."""
     return await fetch_all(
         text(
             """
@@ -55,7 +55,7 @@ async def get_ghost_users() -> list[dict]:
         LEFT JOIN user_tg ut ON ut.id = u.id
         WHERE u.created_at > NOW() - INTERVAL '12 months'
           AND u.blocked_bot_at IS NULL
-          AND u.type NOT IN ('blocked_bot', 'banned', 'waitlist')
+          AND u.type NOT IN ('blocked_bot', 'waitlist')
           AND NOT EXISTS (
               SELECT 1 FROM user_meme_reaction r WHERE r.user_id = u.id
           )

--- a/scripts/broadcast_ghost_recovery.py
+++ b/scripts/broadcast_ghost_recovery.py
@@ -1,0 +1,94 @@
+"""
+Broadcast a recovery message to ghost users — registered ≤12 months ago,
+never had a single meme delivered (no row in user_meme_reaction), not
+blocked. They were silently locked out by onboarding bugs (kitchen
+deep_link missed init_user_languages_from_tg_user; April 2026 cohort
+hit a 9.4% no-delivery rate vs ~3-5% baseline). PR #222 fixes the leak
+forward; this script recovers existing ghosts.
+
+Reuses src.broadcasts.service.send_broadcast — same Redis dedup,
+Forbidden handling, rate limiting as broadcast_wrapped.py.
+
+    PYTHONPATH=/src python scripts/broadcast_ghost_recovery.py ghost-recovery-2026-05 --dry-run
+    PYTHONPATH=/src python scripts/broadcast_ghost_recovery.py ghost-recovery-2026-05 --delay 0.5
+
+Re-running with the same broadcast_id is safe (skips already-sent).
+"""
+
+import asyncio
+import sys
+
+from sqlalchemy import text
+
+from src.broadcasts.service import send_broadcast
+from src.database import fetch_all
+from src.localizer import ALMOST_CIS_LANGUAGES
+
+MESSAGE_RU = (
+    "Привет! У нас был баг в боте: мемы тебе не приходили, хотя ты подписался. "
+    "Только что починили. Жми /start — и поедут. 🍔"
+)
+
+MESSAGE_EN = (
+    "Hey! Sorry — there was a bug in the bot: you signed up but never got any memes. "
+    "Just fixed it. Hit /start to start the flow. 🍔"
+)
+
+
+def _lang_group(language_code: str | None) -> str:
+    return "ru" if language_code in ALMOST_CIS_LANGUAGES else "en"
+
+
+async def get_ghost_users() -> list[dict]:
+    """Registered ≤12mo, never delivered a meme, not blocked, not banned."""
+    return await fetch_all(
+        text(
+            """
+        SELECT u.id AS user_id,
+               COALESCE(
+                   (SELECT ul.language_code FROM user_language ul
+                    WHERE ul.user_id = u.id LIMIT 1),
+                   ut.language_code,
+                   'en'
+               ) AS language_code
+        FROM "user" u
+        LEFT JOIN user_tg ut ON ut.id = u.id
+        WHERE u.created_at > NOW() - INTERVAL '12 months'
+          AND u.blocked_bot_at IS NULL
+          AND u.type NOT IN ('blocked_bot', 'banned', 'waitlist')
+          AND NOT EXISTS (
+              SELECT 1 FROM user_meme_reaction r WHERE r.user_id = u.id
+          )
+        ORDER BY u.created_at DESC
+    """
+        )
+    )
+
+
+async def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    if not args:
+        print("Usage: broadcast_ghost_recovery.py <broadcast_id> [--dry-run] [--delay 0.5]")
+        sys.exit(1)
+
+    broadcast_id = args[0]
+    dry_run = "--dry-run" in sys.argv
+
+    delay = 0.5
+    if "--delay" in sys.argv:
+        idx = sys.argv.index("--delay")
+        delay = float(sys.argv[idx + 1])
+
+    users = await get_ghost_users()
+    await send_broadcast(
+        broadcast_id=broadcast_id,
+        users=users,
+        messages={"ru": MESSAGE_RU, "en": MESSAGE_EN},
+        language_fn=_lang_group,
+        delay=delay,
+        dry_run=dry_run,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

One-shot script targeting users who registered but never got a meme delivered (silent onboarding-bug victims). Reuses `src.broadcasts.service.send_broadcast` so behavior matches `broadcast_wrapped.py` — no new infra.

## Scope

Dry-run on prod just now:
- **66 candidates** — 40 RU, 26 EN
- Filter: registered ≤12mo, `blocked_bot_at IS NULL`, type not in blocked/banned/waitlist, `NOT EXISTS` row in `user_meme_reaction`
- Skewed toward last 1–2 months (29 of 66) — freshest, highest reactivation odds

## Why now

Sega (#370728472) — friend of @ohld — registered 2026-04-01 via `?start=kitchen` and never received a meme; the kitchen branch in `handle_start` returned before `init_user_languages_from_tg_user`. On manual fix + apology DM he immediately produced a healthy session (4 likes / 1 dislike / 7 memes in 22min, 80% positive). Same trap caught:
- April 2026 cohort: **9.4%** no-delivery ghost rate (vs ~3-5% baseline)
- May 2025 cohort: **11.4%**

PR #222 plugs the leak forward; this script recovers existing ghosts.

## How to run

After merge, on the prefect runner:

```bash
docker exec <prefect-runner> bash -c \
  'cd /src && PYTHONPATH=/src python3 scripts/broadcast_ghost_recovery.py ghost-recovery-2026-05 --dry-run'

# When ready:
docker exec <prefect-runner> bash -c \
  'cd /src && PYTHONPATH=/src python3 scripts/broadcast_ghost_recovery.py ghost-recovery-2026-05'
```

Re-running the same broadcast_id is safe (Redis dedup).

## Test plan

- [x] Dry-run on prod: confirmed 66 users, two-language split, message text
- [ ] After merge: live dry-run again to confirm count hasn't drifted
- [ ] Send to small subset first if uneasy (we don't have `--limit` flag — would add if needed)
- [ ] Watch return rate over 72h (look for `last_active_at` updates + first reactions in `user_meme_reaction` for these IDs)