### PR TITLE
feat(start): document onboarding contract + ghost-user monitor (FFM-907)

### DIFF
--- a/scripts/serve_flows.py
+++ b/scripts/serve_flows.py
@@ -32,6 +32,9 @@ from src.flows.crossposting.meme import (
 from src.flows.crossposting.stats_collector import collect_channel_stats
 from src.flows.crossposting.weekly_report import post_weekly_burger_report
 
+# Monitors
+from src.flows.monitors.ghost_users import monitor_ghost_users
+
 # Parsers
 from src.flows.parsers.tg import parse_telegram_sources
 from src.flows.parsers.vk import parse_vk_sources
@@ -166,6 +169,11 @@ if __name__ == "__main__":
         reward_en_users_for_weekly_top_uploaded_memes.to_deployment(
             name="Reward EN weekly",
             schedules=[CronSchedule(cron="0 18 * * 3", timezone=LON)],
+        ),
+        # ── Monitors ──
+        monitor_ghost_users.to_deployment(
+            name="Monitor ghost users",
+            schedules=[CronSchedule(cron="* * * * *", timezone=LON)],
         ),
         # ── Storage ──
         describe_memes_flow.to_deployment(

--- a/src/flows/monitors/ghost_users.py
+++ b/src/flows/monitors/ghost_users.py
@@ -1,0 +1,131 @@
+"""Ghost user monitor.
+
+Catches the FFM-907 / Sega failure mode automatically: a new user
+presses /start, gets a `user` row, but never receives a meme. Before
+this monitor existed we only learned about ghosts when a friend of
+@ohld complained.
+
+Definition: a ghost is a `user` row created N seconds ago with no
+`user_meme_reaction` row. Two severities, both filtered by
+`user_tg.deep_link` to exclude blocked acquisition channels (where
+silent drop is by design):
+
+  - 60s ≤ age ≤ 300s        → WARN
+  - 300s < age ≤ 1500s      → ERROR (something stayed broken for 5+ min)
+
+Runs every minute. The 25-minute trailing window is wide enough that
+a couple of minutes of Prefect downtime won't lose the signal, narrow
+enough that a single regression spike fires 5+ ERROR runs in a row
+(easy to spot in the admin chat).
+"""
+
+import logging
+
+from prefect import flow
+from sqlalchemy import text
+
+from src.database import fetch_one
+from src.flows.hooks import notify_telegram_on_failure
+from src.tgbot.handlers.start import BLOCKED_ACQUISITION_CHANNELS
+from src.tgbot.logs import log
+
+logger = logging.getLogger(__name__)
+
+
+# Anything that early-returns BEFORE save_user_data must NOT contribute
+# to ghost counts. Today the only such path is the blocked-acquisition
+# branch (which doesn't insert a `user` row at all, so it's already
+# excluded). If a future deep_link branch inserts a row but intentionally
+# never serves a meme on first /start, add its prefix here.
+GHOST_EXEMPT_DEEP_LINK_PREFIXES: tuple[str, ...] = ("tapps",)
+GHOST_EXEMPT_DEEP_LINKS: frozenset[str] = BLOCKED_ACQUISITION_CHANNELS
+
+
+def _build_exempt_clause() -> str:
+    # Constants only — these come from Python source, never user input.
+    exempt_eq = ", ".join(f"'{name}'" for name in sorted(GHOST_EXEMPT_DEEP_LINKS))
+    prefix_clauses = " OR ".join(
+        f"deep_link LIKE '{prefix}%'" for prefix in GHOST_EXEMPT_DEEP_LINK_PREFIXES
+    )
+    parts = []
+    if exempt_eq:
+        parts.append(f"deep_link IN ({exempt_eq})")
+    if prefix_clauses:
+        parts.append(f"({prefix_clauses})")
+    if not parts:
+        return "FALSE"
+    return " OR ".join(parts)
+
+
+def _ghost_count_sql() -> str:
+    exempt = _build_exempt_clause()
+    return f"""
+        WITH candidates AS (
+            SELECT
+                u.id,
+                u.created_at,
+                ut.deep_link,
+                EXTRACT(EPOCH FROM (NOW() - u.created_at)) AS age_sec
+            FROM "user" u
+            LEFT JOIN user_tg ut ON ut.id = u.id
+            WHERE u.created_at BETWEEN NOW() - INTERVAL '25 minutes'
+                                  AND NOW() - INTERVAL '60 seconds'
+              AND u.type NOT IN ('blocked_bot', 'banned', 'waitlist')
+              AND NOT EXISTS (
+                  SELECT 1 FROM user_meme_reaction r WHERE r.user_id = u.id
+              )
+              AND NOT COALESCE({exempt}, FALSE)
+        )
+        SELECT
+            COUNT(*) FILTER (WHERE age_sec BETWEEN 60 AND 300) AS warn_count,
+            COUNT(*) FILTER (WHERE age_sec > 300) AS error_count,
+            COUNT(*) AS total_in_window,
+            ARRAY_AGG(id ORDER BY age_sec DESC)
+                FILTER (WHERE age_sec > 300) AS error_user_ids
+        FROM candidates
+    """
+
+
+def _format_alert(warn_count: int, error_count: int, sample_ids: list[int]) -> str:
+    sample = sample_ids[:5] if sample_ids else []
+    sample_str = ", ".join(f"#{uid}" for uid in sample)
+    parts = ["👻 Ghost-user monitor"]
+    if error_count:
+        parts.append(f"🔴 ERROR: {error_count} new users without a meme >5min")
+        if sample_str:
+            parts.append(f"   sample: {sample_str}")
+    if warn_count:
+        parts.append(f"🟡 WARN: {warn_count} new users without a meme 1–5min")
+    return "\n".join(parts)
+
+
+@flow(
+    name="Monitor ghost users",
+    retries=1,
+    retry_delay_seconds=15,
+    timeout_seconds=60,
+    on_failure=[notify_telegram_on_failure],
+)
+async def monitor_ghost_users() -> dict:
+    """Count new users who never got a meme; alert if any."""
+    row = await fetch_one(text(_ghost_count_sql()))
+    warn_count = int(row["warn_count"] or 0)
+    error_count = int(row["error_count"] or 0)
+    error_ids = [int(uid) for uid in (row["error_user_ids"] or [])]
+
+    summary = {
+        "warn_count": warn_count,
+        "error_count": error_count,
+        "total_in_window": int(row["total_in_window"] or 0),
+        "error_user_ids": error_ids,
+    }
+
+    if error_count:
+        logger.error("Ghost users (>5min): %d (sample %s)", error_count, error_ids[:5])
+    if warn_count:
+        logger.warning("Ghost users (1–5min): %d", warn_count)
+
+    if error_count or warn_count:
+        await log(_format_alert(warn_count, error_count, error_ids))
+
+    return summary

--- a/src/tgbot/handlers/start.py
+++ b/src/tgbot/handlers/start.py
@@ -82,6 +82,19 @@ def _is_blocked_acquisition_channel(deep_link: str | None) -> bool:
 
 
 async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    # Side effects every /start MUST run, regardless of deep_link branch:
+    #   1. user_tg + user upsert (save_user_data)
+    #   2. user_info cache populated (update_user_info_cache)
+    #   3. deep_link logged (log_user_deep_link)
+    #   4. admin chat notification (log_start_event)
+    #   5. user_language rows seeded if missing (lazy init below)
+    #
+    # If you add another universal onboarding side effect, hoist it
+    # ABOVE the deep_link ladder. Do NOT bury it inside a per-branch
+    # block — branches that early-return (kitchen, wrapped, giveaway,
+    # _is_blocked_acquisition_channel) silently skip anything below them.
+    # Drift here caused FFM-907 (kitchen ghosts: 9.4% of April 2026
+    # cohort registered but never received a meme).
     user_id = update.effective_user.id
     deep_link = context.args[0] if context.args else None
     language_code = update.effective_user.language_code
@@ -103,11 +116,11 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         created,
     )
 
-    # Ensure language rows exist before any branch that may serve memes.
-    # Covers: new users on every deep_link path (kitchen used to skip init),
-    # and historical orphans whose init was never run — they were stuck on
-    # "memes ended" because recommendations filter by user_language.
-    # Idempotent: add_user_languages uses ON CONFLICT DO NOTHING.
+    # Lazy language init. Covers: new users on every deep_link path
+    # (kitchen used to skip this), and historical orphans whose init
+    # was never run — they were stuck on "memes ended" because
+    # recommendations filter by user_language. Idempotent:
+    # add_user_languages uses ON CONFLICT DO NOTHING.
     if not await get_user_languages(user_id):
         await init_user_languages_from_tg_user(update.effective_user)
 

--- a/tests/tgbot/test_start.py
+++ b/tests/tgbot/test_start.py
@@ -1,0 +1,242 @@
+"""Regression coverage for handle_start side effects (FFM-907).
+
+Asserts that every onboarding side effect fires for `created=True`
+users on every deep_link branch — kitchen used to silently skip
+`init_user_languages_from_tg_user` (PR #222 fix), and we want a test
+guarding against a future branch dropping the same call again.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from telegram import User
+from telegram.ext import ContextTypes
+
+from src.database import (
+    engine,
+    user,
+    user_deep_link_log,
+    user_language,
+    user_tg,
+)
+
+NEW_USER_ID = 90201
+EXISTING_USER_ID = 90202
+
+
+def _make_tg_user(user_id: int = NEW_USER_ID) -> User:
+    # Real telegram.User so init_user_languages_from_tg_user can read
+    # full_name/language_code/id without us mocking the Cyrillic detection.
+    return User(
+        id=user_id,
+        first_name="Test",
+        last_name="User",
+        is_bot=False,
+        username=f"u{user_id}",
+        language_code="en",
+        is_premium=False,
+    )
+
+
+def _make_update(deep_link: str | None = None, user_id: int = NEW_USER_ID):
+    return SimpleNamespace(
+        effective_user=_make_tg_user(user_id),
+        message=SimpleNamespace(reply_text=AsyncMock(), reply_video=AsyncMock()),
+        callback_query=None,
+        effective_chat=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+
+def _make_context(deep_link: str | None) -> ContextTypes.DEFAULT_TYPE:
+    args = [deep_link] if deep_link else []
+    return SimpleNamespace(args=args, bot=AsyncMock())
+
+
+async def _cleanup_user(user_id: int) -> None:
+    async with engine.connect() as conn:
+        await conn.execute(
+            delete(user_deep_link_log).where(user_deep_link_log.c.user_id == user_id)
+        )
+        await conn.execute(delete(user_language).where(user_language.c.user_id == user_id))
+        await conn.execute(delete(user).where(user.c.id == user_id))
+        await conn.execute(delete(user_tg).where(user_tg.c.id == user_id))
+        await conn.commit()
+
+
+@pytest_asyncio.fixture()
+async def cleanup():
+    await _cleanup_user(NEW_USER_ID)
+    await _cleanup_user(EXISTING_USER_ID)
+    yield
+    await _cleanup_user(NEW_USER_ID)
+    await _cleanup_user(EXISTING_USER_ID)
+
+
+HANDLER_MODULE = "src.tgbot.handlers.start"
+
+
+def _patch_handlers():
+    """Patch every downstream handler so we test orchestration only."""
+    return [
+        patch(f"{HANDLER_MODULE}.handle_show_kitchen", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.handle_language_settings", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.handle_invited_user", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.handle_shared_meme_reward", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.next_message", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.log_start_event", new_callable=AsyncMock),
+        patch("src.tgbot.handlers.stats.wrapped.handle_wrapped", new_callable=AsyncMock),
+        patch(
+            "src.tgbot.handlers.treasury.giveaway.handle_giveaway",
+            new_callable=AsyncMock,
+        ),
+    ]
+
+
+async def _assert_universal_side_effects(user_id: int, expected_deep_link: str | None) -> None:
+    """Side effects every /start MUST run for created=True, all branches."""
+    async with engine.connect() as conn:
+        tg_row = (await conn.execute(select(user_tg).where(user_tg.c.id == user_id))).first()
+        u_row = (await conn.execute(select(user).where(user.c.id == user_id))).first()
+        lang_rows = (
+            await conn.execute(select(user_language).where(user_language.c.user_id == user_id))
+        ).fetchall()
+        dl_rows = (
+            await conn.execute(
+                select(user_deep_link_log).where(user_deep_link_log.c.user_id == user_id)
+            )
+        ).fetchall()
+
+    assert tg_row is not None, "user_tg row missing"
+    assert u_row is not None, "user row missing"
+    assert len(lang_rows) >= 1, "user_language rows missing — onboarding leak!"
+    assert len(dl_rows) == 1, "user_deep_link_log row missing"
+    assert dl_rows[0]._asdict()["deep_link"] == expected_deep_link
+
+
+async def _run_handle_start(deep_link: str | None, user_id: int = NEW_USER_ID):
+    from src.tgbot.handlers.start import handle_start
+
+    update = _make_update(deep_link, user_id)
+    context = _make_context(deep_link)
+
+    patches = _patch_handlers()
+    started = [p.start() for p in patches]
+    try:
+        await handle_start(update, context)
+    finally:
+        for p in patches:
+            p.stop()
+    return dict(
+        zip(
+            [
+                "kitchen",
+                "lang_settings",
+                "invited",
+                "shared_reward",
+                "next_message",
+                "log_start",
+                "wrapped",
+                "giveaway",
+            ],
+            started,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_user_no_deep_link_runs_universal_side_effects(cleanup):
+    mocks = await _run_handle_start(deep_link=None)
+    await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link=None)
+    mocks["lang_settings"].assert_called_once()
+    mocks["invited"].assert_called_once()
+    mocks["next_message"].assert_not_called()
+    mocks["kitchen"].assert_not_called()
+    mocks["wrapped"].assert_not_called()
+    mocks["giveaway"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_new_user_kitchen_branch_still_inits_languages(cleanup):
+    """The exact regression that broke Sega — kitchen used to skip init."""
+    mocks = await _run_handle_start(deep_link="kitchen")
+    await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link="kitchen")
+    mocks["kitchen"].assert_called_once()
+    mocks["lang_settings"].assert_not_called()
+    mocks["next_message"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_new_user_wrapped_branch_inits_languages(cleanup):
+    mocks = await _run_handle_start(deep_link="wrapped")
+    await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link="wrapped")
+    mocks["wrapped"].assert_called_once()
+    mocks["lang_settings"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_new_user_giveaway_branch_inits_languages(cleanup):
+    mocks = await _run_handle_start(deep_link="giveaway_77")
+    await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link="giveaway_77")
+    mocks["lang_settings"].assert_called_once()  # main `created` path runs
+    mocks["giveaway"].assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_new_user_share_link_branch_inits_languages(cleanup):
+    mocks = await _run_handle_start(deep_link="s_12345_678")
+    await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link="s_12345_678")
+    mocks["lang_settings"].assert_called_once()
+    mocks["invited"].assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_blocked_acquisition_channel_silently_drops_new_user(cleanup):
+    """Blocked acquisition channels: no user row created at all (by design)."""
+    mocks = await _run_handle_start(deep_link="likefollowbot")
+
+    async with engine.connect() as conn:
+        u_row = (await conn.execute(select(user).where(user.c.id == NEW_USER_ID))).first()
+        tg_row = (await conn.execute(select(user_tg).where(user_tg.c.id == NEW_USER_ID))).first()
+
+    assert u_row is None, "blocked channel should not create user row"
+    assert tg_row is None, "blocked channel should not create user_tg row"
+    mocks["lang_settings"].assert_not_called()
+    mocks["next_message"].assert_not_called()
+    mocks["log_start"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_user_no_deep_link_serves_meme(cleanup):
+    """Existing-user branch: must call next_message (the meme)."""
+    # First /start: bootstraps the user.
+    await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
+    await _assert_universal_side_effects(EXISTING_USER_ID, expected_deep_link=None)
+
+    # Second /start: same user → existing-user branch.
+    mocks = await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
+    mocks["next_message"].assert_called_once()
+    mocks["lang_settings"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lazy_init_is_idempotent(cleanup):
+    """Re-running /start should not duplicate or re-insert language rows."""
+    await _run_handle_start(deep_link=None)
+
+    async with engine.connect() as conn:
+        first_rows = (
+            await conn.execute(select(user_language).where(user_language.c.user_id == NEW_USER_ID))
+        ).fetchall()
+
+    await _run_handle_start(deep_link=None)
+
+    async with engine.connect() as conn:
+        second_rows = (
+            await conn.execute(select(user_language).where(user_language.c.user_id == NEW_USER_ID))
+        ).fetchall()
+
+    assert len(first_rows) == len(second_rows)
+    assert len(first_rows) >= 1


### PR DESCRIPTION
## Summary

Pattern-level fix for FFM-907 — Sega's kitchen-branch leak (PR #222) was a symptom; this PR makes the same regression impossible to silently re-introduce and adds an alarm so we never depend on a friend complaining again.

## Audit

`handle_start` does seven side effects every new user MUST get. After PR #222 they're all hoisted above the deep_link ladder:

| # | Side effect | Universal? |
|---|---|---|
| 1 | `user_tg` upsert | ✅ above ladder (`save_user_data`) |
| 2 | `user` upsert | ✅ above ladder |
| 3 | `deep_link` saved on `user_tg` | ✅ above ladder |
| 4 | `user_info` cache populated | ✅ above ladder |
| 5 | `user_deep_link_log` row | ✅ above ladder |
| 6 | Admin chat notification | ✅ above ladder |
| 7 | `user_language` rows seeded | ✅ above ladder (PR #222) |

Per-branch behaviour (`handle_language_settings`, `handle_invited_user`, `next_message`, etc.) is intentional and stays inside the ladder.

## What's in this PR

1. **Contributor comment** at the top of `handle_start` spelling out the rule: hoist universal side effects above the ladder; never bury them inside per-branch blocks. Cites the FFM-907 incident so future agents/humans understand the why.
2. **`src/flows/monitors/ghost_users.py`** — Prefect flow, runs every minute. Counts users created 1–5 min ago without a `user_meme_reaction` row (= WARN) and >5 min ago (= ERROR), posts a single summary to the admin chat with sample IDs. Filters out blocked-acquisition deep_links (silent drop is by design — they don't even create a `user` row, but the SQL is defensive).
3. **`tests/tgbot/test_start.py`** — regression coverage per deep_link variant: bare `/start`, `kitchen`, `wrapped`, `giveaway_77`, `s_*_*` share-link, `likefollowbot` blocked, plus existing-user path and idempotency of the lazy lang init. Each asserts the row-level post-conditions in `user_tg` + `user` + `user_language` + `user_deep_link_log`.

## Why a Prefect flow vs in-process timer

Per-request scheduling would burn an event-loop slot per /start and lose state on bot restart. A 1-min Prefect cron is one query against `user` + `user_meme_reaction` (both already covered by indexes on `created_at` / `user_id`), reuses the existing failure-alert path, and is easy to pause/inspect.

## Test plan

- [ ] CI: `tests/tgbot/test_start.py` passes (8 cases)
- [ ] After deploy: Prefect UI shows `Monitor ghost users` running every minute
- [ ] Manually trigger by creating a `user` row with no reactions — confirm WARN appears in admin chat within 60s
- [ ] No false positives on a normal day (most ghosts come from the language-picker drop-off; if rate is too noisy, raise the WARN threshold)
- [ ] Confirm `user.created_at` is real wall-clock (not `now()` skew across replicas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)