### PR TITLE
fix(audit): correct zombie_execution_run false positive [FFM-930]

### DIFF
--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -208,9 +208,16 @@ def audit_routines(client: Paperclip, company_id: str, focus: str) -> list[dict[
         comments = issue_comments(client, issue_id) if issue_id else []
         runs = issue_runs(client, issue_id) if issue_id else []
         flags, latest = classify_issue(issue or {}, comments)
-        if (issue or {}).get("status") == "in_progress" and not (issue or {}).get("activeRun"):
-            if any(item.get("status") == "running" for item in runs):
-                flags.append("zombie_execution_run")
+        # `GET /api/issues/{id}` does not serialize `activeRun` (only the list
+        # endpoint does), so check `executionRunId` plus a fresh /runs lookup
+        # instead. Zombie = issue is in_progress with an executionRunId set,
+        # but no run is currently running.
+        if (
+            (issue or {}).get("status") == "in_progress"
+            and (issue or {}).get("executionRunId")
+            and not any(item.get("status") == "running" for item in runs)
+        ):
+            flags.append("zombie_execution_run")
         payload_pr = str(((run.get("triggerPayload") or {}).get("pr_number")) or "")
         issue_title = (
             ((run.get("linkedIssue") or {}).get("title")) or (issue or {}).get("title") or ""


### PR DESCRIPTION
Fixes part 2 of [FFM-930](/FFM/issues/FFM-930).

## Summary

- `GET /api/issues/{id}` does not serialize `activeRun` (only the list endpoint does), so `not issue.get("activeRun")` was always true on the single-issue path.
- Combined with `any(running)` over `/runs`, the old check **always fired** on a healthy active execution (issue in_progress + running run = "zombie"). Confirmed by direct probe: `GET /api/issues/<id>` returns the full issue payload with `executionRunId` set but no `activeRun` key.
- Switched to `executionRunId` (which IS present on the single-issue endpoint) plus the same `/runs` running-status check. A true zombie is now: `status == in_progress` AND `executionRunId` is set AND no run with `status == running` exists in the runs feed.

## Test plan

- [x] Manually re-ran `python3 scripts/paperclip_routine_audit.py --focus updates --json`; FFM-929 (now done) and FFM-913 both report `flags: []`.
- [x] Logical trace for an in-flight in_progress run (FFM-930 itself): `executionRunId` set, `/runs` has a running entry → condition short-circuits, no flag fires. Correct.
- [x] Logical trace for a true zombie: in_progress + executionRunId set + no running run in /runs → flag fires. Correct.
- [x] `ruff check && ruff format` pass.

## Out of scope

The two orphaned skill records (`checkpoint`, `connect-chrome`) flagged in [FFM-930](/FFM/issues/FFM-930) require `agents:create` capability to delete via `DELETE /api/companies/{companyId}/skills/{id}`; CTO does not have it. Will escalate that piece to CEO in the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)