### PR TITLE
feat(storage): self-growing TG source discovery from forwarded posts [FFM-933]

### DIFF
--- a/alembic/versions/2026-05-04_meme_source_candidate.py
+++ b/alembic/versions/2026-05-04_meme_source_candidate.py
@@ -1,0 +1,91 @@
+"""add meme_source_candidate table
+
+Revision ID: 24cd1a8bd9b8
+Revises: 78054f923898
+Create Date: 2026-05-04 04:05:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "24cd1a8bd9b8"
+down_revision = "78054f923898"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "meme_source_candidate",
+        sa.Column("id", sa.Integer(), sa.Identity(always=False), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(),
+            server_default="discovered",
+            nullable=False,
+        ),
+        sa.Column(
+            "times_forwarded",
+            sa.Integer(),
+            server_default="1",
+            nullable=False,
+        ),
+        sa.Column(
+            "first_seen_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("sample_meme_raw_telegram_id", sa.Integer(), nullable=True),
+        sa.Column("promoted_meme_source_id", sa.Integer(), nullable=True),
+        sa.Column("dismissed_reason", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["promoted_meme_source_id"],
+            ["meme_source.id"],
+            name=op.f("meme_source_candidate_promoted_meme_source_id_fkey"),
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("meme_source_candidate_pkey")),
+        sa.UniqueConstraint("url", name=op.f("meme_source_candidate_url_key")),
+    )
+    op.create_index(
+        op.f("ix_meme_source_candidate_status"),
+        "meme_source_candidate",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_meme_source_candidate_status_times",
+        "meme_source_candidate",
+        ["status", sa.text("times_forwarded DESC")],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_meme_source_candidate_status_times",
+        table_name="meme_source_candidate",
+    )
+    op.drop_index(
+        op.f("ix_meme_source_candidate_status"),
+        table_name="meme_source_candidate",
+    )
+    op.drop_table("meme_source_candidate")

--- a/alembic/versions/2026-05-04_meme_source_candidate.py
+++ b/alembic/versions/2026-05-04_meme_source_candidate.py
@@ -46,7 +46,8 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.Column("sample_meme_raw_telegram_id", sa.Integer(), nullable=True),
+        sa.Column("sample_meme_source_id", sa.Integer(), nullable=True),
+        sa.Column("sample_meme_raw_telegram_post_id", sa.Integer(), nullable=True),
         sa.Column("promoted_meme_source_id", sa.Integer(), nullable=True),
         sa.Column("dismissed_reason", sa.String(), nullable=True),
         sa.Column(

--- a/src/database.py
+++ b/src/database.py
@@ -157,7 +157,8 @@ meme_source_candidate = Table(
     Column("times_forwarded", Integer, nullable=False, server_default="1"),
     Column("first_seen_at", DateTime, server_default=func.now(), nullable=False),
     Column("last_seen_at", DateTime, server_default=func.now(), nullable=False),
-    Column("sample_meme_raw_telegram_id", Integer),
+    Column("sample_meme_source_id", Integer),
+    Column("sample_meme_raw_telegram_post_id", Integer),
     Column(
         "promoted_meme_source_id",
         ForeignKey("meme_source.id", ondelete="SET NULL"),

--- a/src/database.py
+++ b/src/database.py
@@ -144,6 +144,35 @@ meme_source = Table(
 )
 
 
+# Pool of channels we've seen forwarded into already-tracked sources, awaiting
+# moderator promotion into `meme_source`. Never auto-enabled; populated by the
+# TG ETL hook in `discover_source_candidates_from_telegram_posts`.
+meme_source_candidate = Table(
+    "meme_source_candidate",
+    metadata,
+    Column("id", Integer, Identity(), primary_key=True),
+    Column("type", String, nullable=False),
+    Column("url", String, nullable=False, unique=True),
+    Column("status", String, nullable=False, server_default="discovered", index=True),
+    Column("times_forwarded", Integer, nullable=False, server_default="1"),
+    Column("first_seen_at", DateTime, server_default=func.now(), nullable=False),
+    Column("last_seen_at", DateTime, server_default=func.now(), nullable=False),
+    Column("sample_meme_raw_telegram_id", Integer),
+    Column(
+        "promoted_meme_source_id",
+        ForeignKey("meme_source.id", ondelete="SET NULL"),
+    ),
+    Column("dismissed_reason", String),
+    Column("created_at", DateTime, server_default=func.now(), nullable=False),
+    Column("updated_at", DateTime, onupdate=func.now()),
+    Index(
+        "ix_meme_source_candidate_status_times",
+        "status",
+        text("times_forwarded DESC"),
+    ),
+)
+
+
 meme_raw_telegram = Table(
     "meme_raw_telegram",
     metadata,

--- a/src/storage/etl.py
+++ b/src/storage/etl.py
@@ -55,11 +55,9 @@ async def insert_parsed_posts_from_telegram(
     )
     post_ids_in_db = {row["post_id"] for row in result}
 
-    posts_to_create = [
-        post.model_dump() | {"meme_source_id": meme_source_id}
-        for post in telegram_posts
-        if post.post_id not in post_ids_in_db
-    ]
+    new_posts = [post for post in telegram_posts if post.post_id not in post_ids_in_db]
+
+    posts_to_create = [post.model_dump() | {"meme_source_id": meme_source_id} for post in new_posts]
 
     if len(posts_to_create) > 0:
         print(f"Going to insert {len(posts_to_create)} new posts.")
@@ -84,10 +82,13 @@ async def insert_parsed_posts_from_telegram(
         )
         await execute(update_query)
 
-    await discover_source_candidates_from_telegram_posts(telegram_posts)
+    # Only newly-inserted posts feed candidate discovery; otherwise every parse
+    # cycle re-counts the same forwarded URLs and corrupts times_forwarded.
+    await discover_source_candidates_from_telegram_posts(meme_source_id, new_posts)
 
 
 async def discover_source_candidates_from_telegram_posts(
+    meme_source_id: int,
     telegram_posts: list[TgChannelPostParsingResult],
 ) -> None:
     """Upsert forward-source candidates from a parsed TG batch.
@@ -96,14 +97,14 @@ async def discover_source_candidates_from_telegram_posts(
     auto-promote to `meme_source`. Skips URLs already tracked as sources to
     keep the moderator queue clean. See FFM-933.
     """
-    seen: dict[str, int] = {}  # canonical_url -> first sample raw row id
+    seen_post_ids: dict[str, int] = {}  # canonical_url -> first sample TG post id
     increments: dict[str, int] = {}
     for post in telegram_posts:
         canonical = _normalize_telegram_channel_url(post.forwarded_url or "")
         if canonical is None:
             continue
         increments[canonical] = increments.get(canonical, 0) + 1
-        seen.setdefault(canonical, post.post_id)
+        seen_post_ids.setdefault(canonical, post.post_id)
 
     if not increments:
         return
@@ -127,7 +128,8 @@ async def discover_source_candidates_from_telegram_posts(
                     "url": canonical,
                     "status": "discovered",
                     "times_forwarded": delta,
-                    "sample_meme_raw_telegram_id": seen.get(canonical),
+                    "sample_meme_source_id": meme_source_id,
+                    "sample_meme_raw_telegram_post_id": seen_post_ids.get(canonical),
                 }
             )
             .on_conflict_do_update(

--- a/src/storage/etl.py
+++ b/src/storage/etl.py
@@ -1,4 +1,6 @@
+import re
 from datetime import datetime, timezone
+from typing import Optional
 
 from sqlalchemy import select, text
 from sqlalchemy.dialects.postgresql import insert
@@ -9,11 +11,33 @@ from src.database import (
     meme,
     meme_raw_telegram,
     meme_raw_vk,
+    meme_source_candidate,
 )
+from src.storage.constants import MemeSourceType
 from src.storage.parsers.schemas import (
     TgChannelPostParsingResult,
     VkGroupPostParsingResult,
 )
+
+_TG_FORWARD_URL_PATTERN = re.compile(r"^https?://t\.me/(?:s/)?([a-zA-Z0-9_]+)(?:/\d+)?/?$")
+
+
+def _normalize_telegram_channel_url(forwarded_url: str) -> Optional[str]:
+    """Strip post id, lowercase username, return canonical https://t.me/<channel>.
+
+    Returns None for joinchat/private/invite links and anything we can't safely
+    promote to a public channel source.
+    """
+    if not forwarded_url:
+        return None
+    match = _TG_FORWARD_URL_PATTERN.match(forwarded_url.strip())
+    if not match:
+        return None
+    username = match.group(1).lower()
+    # private/invite links and bot-update aliases aren't usable as sources
+    if username in {"joinchat", "addstickers", "share", "proxy"}:
+        return None
+    return f"https://t.me/{username}"
 
 
 async def insert_parsed_posts_from_telegram(
@@ -59,6 +83,63 @@ async def insert_parsed_posts_from_telegram(
             .values(post)
         )
         await execute(update_query)
+
+    await discover_source_candidates_from_telegram_posts(telegram_posts)
+
+
+async def discover_source_candidates_from_telegram_posts(
+    telegram_posts: list[TgChannelPostParsingResult],
+) -> None:
+    """Upsert forward-source candidates from a parsed TG batch.
+
+    Conservative-by-default: candidates land with status='discovered' and never
+    auto-promote to `meme_source`. Skips URLs already tracked as sources to
+    keep the moderator queue clean. See FFM-933.
+    """
+    seen: dict[str, int] = {}  # canonical_url -> first sample raw row id
+    increments: dict[str, int] = {}
+    for post in telegram_posts:
+        canonical = _normalize_telegram_channel_url(post.forwarded_url or "")
+        if canonical is None:
+            continue
+        increments[canonical] = increments.get(canonical, 0) + 1
+        seen.setdefault(canonical, post.post_id)
+
+    if not increments:
+        return
+
+    # Drop any URL that is already a tracked source — no point queueing it for
+    # moderator promotion if we're already parsing it.
+    existing_rows = await fetch_all(
+        text("SELECT url FROM meme_source WHERE url = ANY(:urls)"),
+        {"urls": list(increments.keys())},
+    )
+    already_tracked = {row["url"] for row in existing_rows}
+
+    for canonical, delta in increments.items():
+        if canonical in already_tracked:
+            continue
+        stmt = (
+            insert(meme_source_candidate)
+            .values(
+                {
+                    "type": MemeSourceType.TELEGRAM.value,
+                    "url": canonical,
+                    "status": "discovered",
+                    "times_forwarded": delta,
+                    "sample_meme_raw_telegram_id": seen.get(canonical),
+                }
+            )
+            .on_conflict_do_update(
+                index_elements=[meme_source_candidate.c.url],
+                set_={
+                    "times_forwarded": (meme_source_candidate.c.times_forwarded + delta),
+                    "last_seen_at": text("now()"),
+                    "updated_at": text("now()"),
+                },
+            )
+        )
+        await execute(stmt)
 
 
 async def insert_parsed_posts_from_vk(

--- a/src/tgbot/app.py
+++ b/src/tgbot/app.py
@@ -22,6 +22,7 @@ from src.tgbot.constants import (
     MEME_SOURCE_SET_LANG_REGEXP,
     MEME_SOURCE_SET_STATUS_REGEXP,
     POPUP_BUTTON_CALLBACK_DATA_REGEXP,
+    SOURCE_CANDIDATE_ACTION_REGEXP,
     TELEGRAM_CHANNEL_RU_CHAT_ID,
     TELEGRAM_FEEDBACK_CHAT_ID,
     TELEGRAM_MODERATOR_CHAT_ID,
@@ -69,6 +70,10 @@ from src.tgbot.handlers.moderator import get_meme, meme_source
 from src.tgbot.handlers.moderator.invite import (
     MODERATOR_INVITE_CALLBACK_DATA,
     handle_moderator_invite_callback,
+)
+from src.tgbot.handlers.moderator.source_candidates import (
+    handle_discovered_sources_command,
+    handle_source_candidate_action,
 )
 from src.tgbot.handlers.payments.purchase import (
     PURCHASE_TOKEN_CALLBACK_DATA_REGEXP,
@@ -407,6 +412,15 @@ def add_handlers(application: Application) -> None:
             CallbackQueryHandler(
                 meme_source.handle_meme_source_change_status,
                 pattern=MEME_SOURCE_SET_STATUS_REGEXP,
+            ),
+            CommandHandler(
+                "discoveredsources",
+                handle_discovered_sources_command,
+                filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
+            ),
+            CallbackQueryHandler(
+                handle_source_candidate_action,
+                pattern=SOURCE_CANDIDATE_ACTION_REGEXP,
             ),
         ]
     )

--- a/src/tgbot/constants.py
+++ b/src/tgbot/constants.py
@@ -41,6 +41,10 @@ MEME_SOURCE_SET_LANG_REGEXP = r"^ms:\d+:set_lang:\w{2}$"
 MEME_SOURCE_SET_STATUS_PATTERN = "ms:{meme_source_id}:set_status:{status}"
 MEME_SOURCE_SET_STATUS_REGEXP = r"^ms:\d+:set_status:\w+$"
 
+# Source-candidate (discovered from forwarded TG posts) approval buttons.
+SOURCE_CANDIDATE_ACTION_PATTERN = "msc:{candidate_id}:{action}"
+SOURCE_CANDIDATE_ACTION_REGEXP = r"^msc:\d+:(promote|dismiss)$"
+
 LOADING_EMOJIS = [
     "🕛",
     "🕧",

--- a/src/tgbot/handlers/moderator/source_candidates.py
+++ b/src/tgbot/handlers/moderator/source_candidates.py
@@ -1,0 +1,101 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from src.tgbot.constants import UserType
+from src.tgbot.handlers.moderator.meme_source import meme_source_admin_pipeline
+from src.tgbot.logs import log
+from src.tgbot.senders.keyboards import source_candidate_actions_keyboard
+from src.tgbot.service import (
+    dismiss_source_candidate,
+    get_source_candidate_by_id,
+    list_pending_source_candidates,
+    promote_source_candidate,
+)
+from src.tgbot.user_info import get_user_info
+
+_LIST_LIMIT = 20
+
+
+def _format_candidate_line(candidate: dict) -> str:
+    return f"#{candidate['id']} • {candidate['url']} • forwarded ×{candidate['times_forwarded']}"
+
+
+async def handle_discovered_sources_command(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    user_info = await get_user_info(update.effective_user.id)
+    if not UserType(user_info["type"]).is_moderator:
+        return
+
+    candidates = await list_pending_source_candidates(limit=_LIST_LIMIT)
+    if not candidates:
+        await update.message.reply_text("No discovered TG source candidates pending.")
+        return
+
+    await update.message.reply_text(
+        f"Top {len(candidates)} discovered TG source candidates "
+        "(promote to enter moderation pipeline)."
+    )
+    for candidate in candidates:
+        await update.message.reply_text(
+            _format_candidate_line(candidate),
+            reply_markup=source_candidate_actions_keyboard(candidate["id"]),
+            disable_web_page_preview=True,
+        )
+
+
+async def handle_source_candidate_action(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    user_id = update.effective_user.id
+    user_info = await get_user_info(user_id)
+    if not UserType(user_info["type"]).is_moderator:
+        await update.callback_query.answer("🤷‍♀️ Only moderators can act on source candidates 🤷‍♂️")
+        return
+
+    args = update.callback_query.data.split(":")
+    candidate_id, action = int(args[1]), args[2]
+
+    candidate = await get_source_candidate_by_id(candidate_id)
+    if candidate is None:
+        await update.callback_query.answer("Candidate not found")
+        return
+    if candidate["status"] != "discovered":
+        await update.callback_query.answer(f"Already {candidate['status']}; nothing to do.")
+        return
+
+    if action == "dismiss":
+        await dismiss_source_candidate(candidate_id, reason=f"by:{user_id}")
+        await log(
+            f"🗑 SourceCandidate #{candidate_id} {candidate['url']}: dismissed (by {user_id})",
+            context.bot,
+        )
+        await update.callback_query.answer("Dismissed.")
+        await update.callback_query.edit_message_text(
+            f"~~{_format_candidate_line(candidate)}~~ — dismissed",
+            parse_mode=None,
+        )
+        return
+
+    if action == "promote":
+        promoted_meme_source = await promote_source_candidate(
+            candidate_id=candidate_id,
+            added_by_user_id=user_id,
+        )
+        if promoted_meme_source is None:
+            await update.callback_query.answer("Promotion failed.")
+            return
+        await log(
+            f"✅ SourceCandidate #{candidate_id} {candidate['url']}: "
+            f"promoted to MemeSource {promoted_meme_source['id']} (by {user_id})",
+            context.bot,
+        )
+        await update.callback_query.answer("Promoted to in_moderation.")
+        await update.callback_query.edit_message_text(
+            f"✅ {candidate['url']} → MemeSource #{promoted_meme_source['id']}"
+        )
+        # Funnel into the existing admin pipeline so the moderator can pick a
+        # language and flip status — same UX as adding a source by URL.
+        await meme_source_admin_pipeline(promoted_meme_source, update)

--- a/src/tgbot/senders/keyboards.py
+++ b/src/tgbot/senders/keyboards.py
@@ -9,6 +9,7 @@ from src.tgbot.constants import (
     MEME_BUTTON_CALLBACK_DATA_PATTERN,
     MEME_QUEUE_IS_EMPTY_ALERT_CALLBACK_DATA,
     MEME_SOURCE_SET_LANG_PATTERN,
+    SOURCE_CANDIDATE_ACTION_PATTERN,
     Reaction,
 )
 
@@ -132,5 +133,26 @@ def meme_source_change_status_keyboard(
             ]
             for status in MemeSourceStatus
             if status != current_status
+        ]
+    )
+
+
+def source_candidate_actions_keyboard(candidate_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    "✅ Promote",
+                    callback_data=SOURCE_CANDIDATE_ACTION_PATTERN.format(
+                        candidate_id=candidate_id, action="promote"
+                    ),
+                ),
+                InlineKeyboardButton(
+                    "🗑 Dismiss",
+                    callback_data=SOURCE_CANDIDATE_ACTION_PATTERN.format(
+                        candidate_id=candidate_id, action="dismiss"
+                    ),
+                ),
+            ]
         ]
     )

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -146,9 +146,13 @@ async def update_meme_source(
 
 
 async def list_pending_source_candidates(limit: int = 20) -> list[dict[str, Any]]:
+    # Exclude candidates whose URL was added to meme_source via the manual URL
+    # flow — discovery's own dedup only fires at insert time, so without this
+    # filter such rows re-surface in /discoveredsources forever.
     select_statement = (
         select(meme_source_candidate)
         .where(meme_source_candidate.c.status == "discovered")
+        .where(~select(1).where(meme_source.c.url == meme_source_candidate.c.url).exists())
         .order_by(meme_source_candidate.c.times_forwarded.desc())
         .limit(limit)
     )

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -14,6 +14,7 @@ from src.database import (
     inline_search_logs,
     meme,
     meme_source,
+    meme_source_candidate,
     meme_source_stats,
     meme_stats,
     user,
@@ -23,7 +24,7 @@ from src.database import (
     user_tg,
     user_tg_chat_membership,
 )
-from src.storage.constants import MemeStatus, MemeType
+from src.storage.constants import MemeSourceStatus, MemeStatus, MemeType
 from src.tgbot.constants import UserType
 
 
@@ -142,6 +143,85 @@ async def update_meme_source(
     )
 
     return await fetch_one(update_statement)
+
+
+async def list_pending_source_candidates(limit: int = 20) -> list[dict[str, Any]]:
+    select_statement = (
+        select(meme_source_candidate)
+        .where(meme_source_candidate.c.status == "discovered")
+        .order_by(meme_source_candidate.c.times_forwarded.desc())
+        .limit(limit)
+    )
+    return await fetch_all(select_statement)
+
+
+async def get_source_candidate_by_id(id: int) -> dict[str, Any] | None:
+    select_statement = select(meme_source_candidate).where(meme_source_candidate.c.id == id)
+    return await fetch_one(select_statement)
+
+
+async def dismiss_source_candidate(
+    id: int,
+    reason: str = "moderator",
+) -> dict[str, Any] | None:
+    update_statement = (
+        meme_source_candidate.update()
+        .where(meme_source_candidate.c.id == id)
+        .where(meme_source_candidate.c.status == "discovered")
+        .values(
+            status="dismissed",
+            dismissed_reason=reason,
+            updated_at=datetime.utcnow(),
+        )
+        .returning(meme_source_candidate)
+    )
+    return await fetch_one(update_statement)
+
+
+async def promote_source_candidate(
+    candidate_id: int,
+    added_by_user_id: int,
+) -> dict[str, Any] | None:
+    """Promote a candidate into `meme_source` with `status=in_moderation`.
+
+    Idempotent: if the URL already exists in `meme_source`, returns that row
+    and marks the candidate as promoted. Never auto-enables parsing — the
+    moderator still has to flip status via the existing admin pipeline.
+    """
+    candidate = await get_source_candidate_by_id(candidate_id)
+    if candidate is None or candidate["status"] != "discovered":
+        return None
+
+    insert_statement = (
+        insert(meme_source)
+        .values(
+            {
+                "url": candidate["url"],
+                "type": candidate["type"],
+                "status": MemeSourceStatus.IN_MODERATION.value,
+                "added_by": added_by_user_id,
+            }
+        )
+        .on_conflict_do_update(
+            index_elements=(meme_source.c.url,),
+            set_={"updated_at": datetime.utcnow()},
+        )
+        .returning(meme_source)
+    )
+    promoted = await fetch_one(insert_statement)
+    if promoted is None:
+        return None
+
+    await execute(
+        meme_source_candidate.update()
+        .where(meme_source_candidate.c.id == candidate_id)
+        .values(
+            status="promoted",
+            promoted_meme_source_id=promoted["id"],
+            updated_at=datetime.utcnow(),
+        )
+    )
+    return promoted
 
 
 async def search_memes_for_inline_query(search_query: str, limit: int) -> list[dict[str, Any]]:

--- a/tests/storage/test_etl_candidates.py
+++ b/tests/storage/test_etl_candidates.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.storage.etl import _normalize_telegram_channel_url
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("https://t.me/somechannel", "https://t.me/somechannel"),
+        ("https://t.me/SomeChannel", "https://t.me/somechannel"),
+        ("https://t.me/somechannel/", "https://t.me/somechannel"),
+        ("https://t.me/somechannel/12345", "https://t.me/somechannel"),
+        ("https://t.me/s/somechannel/12345", "https://t.me/somechannel"),
+        ("http://t.me/somechannel/12345", "https://t.me/somechannel"),
+        # Private/invite links and aliases must not become candidates.
+        ("https://t.me/joinchat/abc123", None),
+        ("https://t.me/+invite", None),
+        ("https://example.com/", None),
+        ("", None),
+    ],
+)
+def test_normalize_telegram_channel_url(raw, expected):
+    assert _normalize_telegram_channel_url(raw) == expected

--- a/tests/storage/test_etl_discover_candidates.py
+++ b/tests/storage/test_etl_discover_candidates.py
@@ -1,0 +1,102 @@
+"""Integration tests for discover_source_candidates_from_telegram_posts.
+
+Covers the FFM-936 review fixes:
+- Re-parsing the same post must NOT re-increment `times_forwarded`.
+- The sample columns must store `(meme_source_id, post_id)`, not the autoincrement
+  `meme_raw_telegram.id`.
+"""
+
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from src.database import (
+    engine,
+    fetch_one,
+    meme_source_candidate,
+)
+from src.storage.etl import insert_parsed_posts_from_telegram
+from src.storage.parsers.schemas import TgChannelPostParsingResult
+from tests.factories import TEST_ID_START, cleanup_test_data, create_meme_source
+
+PARSING_SOURCE_ID = TEST_ID_START + 600
+DISCOVERED_CANDIDATE_URL = "https://t.me/ffm936_discovered_channel"
+
+
+def _post(post_id: int, forwarded_url: str | None) -> TgChannelPostParsingResult:
+    return TgChannelPostParsingResult(
+        post_id=post_id,
+        url=f"https://t.me/test_source_{PARSING_SOURCE_ID}/{post_id}",
+        content="hello",
+        media=[{"url": "https://example.com/x.jpg"}],
+        views=100,
+        date=datetime(2024, 6, 1, 12, 0, 0),
+        forwarded_url=forwarded_url,
+    )
+
+
+@pytest_asyncio.fixture()
+async def conn():
+    async with engine.connect() as conn:
+        yield conn
+        await conn.execute(
+            delete(meme_source_candidate).where(
+                meme_source_candidate.c.url == DISCOVERED_CANDIDATE_URL
+            )
+        )
+        await conn.commit()
+        await cleanup_test_data(conn)
+
+
+@pytest.mark.asyncio
+async def test_reparsing_same_post_does_not_double_count_times_forwarded(
+    conn: AsyncConnection,
+):
+    await create_meme_source(conn, id=PARSING_SOURCE_ID, status="parsing_enabled")
+    await conn.commit()
+
+    posts = [_post(post_id=1001, forwarded_url=DISCOVERED_CANDIDATE_URL)]
+
+    # First parse: fresh insert → candidate counted once.
+    await insert_parsed_posts_from_telegram(PARSING_SOURCE_ID, posts)
+    # Second parse of the *same* post (e.g. the next hourly cron picking it up
+    # again because views/content shifted) must NOT bump the counter again.
+    await insert_parsed_posts_from_telegram(PARSING_SOURCE_ID, posts)
+
+    candidate = await fetch_one(
+        select(meme_source_candidate).where(meme_source_candidate.c.url == DISCOVERED_CANDIDATE_URL)
+    )
+    assert candidate is not None
+    assert candidate["times_forwarded"] == 1
+    assert candidate["sample_meme_source_id"] == PARSING_SOURCE_ID
+    assert candidate["sample_meme_raw_telegram_post_id"] == 1001
+
+
+@pytest.mark.asyncio
+async def test_new_distinct_posts_increment_times_forwarded(conn: AsyncConnection):
+    await create_meme_source(conn, id=PARSING_SOURCE_ID, status="parsing_enabled")
+    await conn.commit()
+
+    await insert_parsed_posts_from_telegram(
+        PARSING_SOURCE_ID,
+        [_post(post_id=2001, forwarded_url=DISCOVERED_CANDIDATE_URL)],
+    )
+    await insert_parsed_posts_from_telegram(
+        PARSING_SOURCE_ID,
+        [
+            # 2001 already in DB → should be skipped by discovery.
+            _post(post_id=2001, forwarded_url=DISCOVERED_CANDIDATE_URL),
+            _post(post_id=2002, forwarded_url=DISCOVERED_CANDIDATE_URL),
+            _post(post_id=2003, forwarded_url=DISCOVERED_CANDIDATE_URL),
+        ],
+    )
+
+    candidate = await fetch_one(
+        select(meme_source_candidate).where(meme_source_candidate.c.url == DISCOVERED_CANDIDATE_URL)
+    )
+    assert candidate is not None
+    # 1 from first batch + 2 newly inserted on second batch = 3.
+    assert candidate["times_forwarded"] == 3

--- a/tests/tgbot/test_source_candidates_listing.py
+++ b/tests/tgbot/test_source_candidates_listing.py
@@ -1,0 +1,76 @@
+"""Tests for list_pending_source_candidates filtering (FFM-938).
+
+Discovery's own dedup only fires at INSERT time, so a candidate URL that gets
+manually added to meme_source via the existing URL flow leaves a stale
+`discovered` row that would re-surface in /discoveredsources forever without
+the listing-time filter under test here.
+"""
+
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncConnection
+from tests.factories import TEST_ID_START, cleanup_test_data, create_meme_source
+
+from src.database import engine, meme_source_candidate
+from src.tgbot.service import list_pending_source_candidates
+
+ORPHAN_CANDIDATE_URL = "https://t.me/ffm938_orphan_candidate"
+PROMOTED_CANDIDATE_URL = "https://t.me/ffm938_promoted_candidate"
+PROMOTED_SOURCE_ID = TEST_ID_START + 938
+
+
+async def _create_candidate(conn: AsyncConnection, url: str, times_forwarded: int) -> None:
+    await conn.execute(
+        insert(meme_source_candidate)
+        .values(
+            type="telegram",
+            url=url,
+            status="discovered",
+            times_forwarded=times_forwarded,
+            created_at=datetime(2024, 6, 1, 12, 0, 0),
+            updated_at=datetime(2024, 6, 1, 12, 0, 0),
+        )
+        .on_conflict_do_nothing()
+    )
+
+
+@pytest_asyncio.fixture()
+async def conn():
+    async with engine.connect() as conn:
+        yield conn
+        await conn.execute(
+            delete(meme_source_candidate).where(
+                meme_source_candidate.c.url.in_([ORPHAN_CANDIDATE_URL, PROMOTED_CANDIDATE_URL])
+            )
+        )
+        await conn.commit()
+        await cleanup_test_data(conn)
+
+
+@pytest.mark.asyncio
+async def test_candidate_already_in_meme_source_is_excluded(conn: AsyncConnection):
+    # Candidate exists in the discovery queue …
+    await _create_candidate(conn, PROMOTED_CANDIDATE_URL, times_forwarded=5)
+    # … and the same URL was added to meme_source via the manual URL flow.
+    await create_meme_source(conn, id=PROMOTED_SOURCE_ID, url=PROMOTED_CANDIDATE_URL)
+    await conn.commit()
+
+    rows = await list_pending_source_candidates(limit=50)
+
+    urls = {row["url"] for row in rows}
+    assert PROMOTED_CANDIDATE_URL not in urls
+
+
+@pytest.mark.asyncio
+async def test_candidate_without_meme_source_match_is_returned(conn: AsyncConnection):
+    await _create_candidate(conn, ORPHAN_CANDIDATE_URL, times_forwarded=3)
+    await conn.commit()
+
+    rows = await list_pending_source_candidates(limit=50)
+
+    urls = {row["url"] for row in rows}
+    assert ORPHAN_CANDIDATE_URL in urls


### PR DESCRIPTION
Fixes [FFM-933](/FFM/issues/FFM-933).

## Why

The 2026-05-04 analyst report flagged content-pool stagnation (low_sent_pool absorbing 38% of weekly sends at 28% LR, new-user inflow at 2-8/day) as the next bottleneck after goat. The TG parser already extracts `forwarded_url` per post (`src/storage/parsers/tg.py:128–131`) and persists it on `meme_raw_telegram`, but that signal was never used. This wires it into a self-growing source-candidate pipeline.

## What changed

- **New `meme_source_candidate` table** (id, type, url unique, status, times_forwarded, first_seen_at, last_seen_at, sample_meme_raw_telegram_id, promoted_meme_source_id FK→meme_source ON DELETE SET NULL, dismissed_reason). Indexed on `(status, times_forwarded DESC)` for the moderator queue. Migration `24cd1a8bd9b8` parents off the current production head `78054f923898` (single alembic head verified locally).
- **`discover_source_candidates_from_telegram_posts()`** hook called inside `insert_parsed_posts_from_telegram()` after the raw insert. Per parsed batch it normalizes each `forwarded_url` to `https://t.me/<channel>` (strips post id, lowercases, rejects private/invite links) and upserts with `ON CONFLICT (url) DO UPDATE SET times_forwarded = times_forwarded + delta, last_seen_at = now()`. URLs already in `meme_source` are filtered out before insert so the moderator queue stays clean.
- **`/discoveredsources` moderator command** lists top-N pending candidates with `times_forwarded` count and Promote / Dismiss inline buttons (gated on `UserType.is_moderator`).
- **Promote** creates a `meme_source` row with `status='in_moderation'` (idempotent on URL conflict) and funnels into the existing `meme_source_admin_pipeline`, so the moderator still picks a language and flips status to `parsing_enabled` — same gate every manually-added source goes through.
- **Dismiss** flips the candidate to `status='dismissed'` with a `by:<user_id>` reason.
- Unit test for the URL normalizer (positive + private-link rejection cases).

## Guardrails (per FFM-933 'never auto-enable' requirement)

- No write to `meme_source` from the ETL path. Discovery only writes to `meme_source_candidate`.
- Promotion always lands as `in_moderation` — moderator click required to enable parsing.
- Moderator-only command + callbacks (mirrors `handle_meme_source_link`).
- `joinchat`, `+invite`, `addstickers`, `share`, `proxy` aliases rejected by the URL normalizer.
- No backfill from historical `meme_raw_telegram.forwarded_url` — fresh start lets us measure inflow rate before deciding.

## Migration & deploy risk

- `alembic heads` returns a single revision (`24cd1a8bd9b8`). CI lint job will re-verify.
- Rollback is clean: `drop_table` + `Table` removal in `database.py`. No data dependency elsewhere.
- New per-batch work in the parser hook: at most one `INSERT … ON CONFLICT` per unique forwarded source per parse run. Negligible vs existing per-post UPDATE loop. Hot user path untouched.
- Public-repo safety: no new secrets, no PII beyond `t.me/<channel>` URLs already on `meme_raw_telegram`.

## Test plan

- [x] Unit test for url normalizer passes positive cases + rejects private/invite/empty inputs.
- [ ] CI integration tests pass (alembic heads check + pytest).
- [ ] Post-deploy: trigger one TG source parse, verify rows appear in `meme_source_candidate` with `status='discovered'` and `times_forwarded ≥ 1`.
- [ ] Moderator runs `/discoveredsources` in DM, sees candidates with Promote / Dismiss buttons.
- [ ] Promote → `meme_source` row appears with `status='in_moderation'`, candidate row flips to `status='promoted'` with FK populated, language-selection keyboard renders.
- [ ] Dismiss → candidate row flips to `status='dismissed'`, `dismissed_reason` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)