### PR TITLE
fix(tgbot): canonicalize manual TG source URLs + guard candidate promote UPDATE [FFM-940]

### DIFF
--- a/src/storage/etl.py
+++ b/src/storage/etl.py
@@ -22,7 +22,7 @@ from src.storage.parsers.schemas import (
 _TG_FORWARD_URL_PATTERN = re.compile(r"^https?://t\.me/(?:s/)?([a-zA-Z0-9_]+)(?:/\d+)?/?$")
 
 
-def _normalize_telegram_channel_url(forwarded_url: str) -> Optional[str]:
+def normalize_telegram_channel_url(forwarded_url: str) -> Optional[str]:
     """Strip post id, lowercase username, return canonical https://t.me/<channel>.
 
     Returns None for joinchat/private/invite links and anything we can't safely
@@ -30,7 +30,11 @@ def _normalize_telegram_channel_url(forwarded_url: str) -> Optional[str]:
     """
     if not forwarded_url:
         return None
-    match = _TG_FORWARD_URL_PATTERN.match(forwarded_url.strip())
+    # Drop query string + fragment so `?utm=...` or `#anchor` don't break the
+    # regex and so manual moderator entries collapse onto the same canonical
+    # form as discovery-pipeline candidates.
+    cleaned = forwarded_url.strip().split("?", 1)[0].split("#", 1)[0]
+    match = _TG_FORWARD_URL_PATTERN.match(cleaned)
     if not match:
         return None
     username = match.group(1).lower()
@@ -100,7 +104,7 @@ async def discover_source_candidates_from_telegram_posts(
     seen_post_ids: dict[str, int] = {}  # canonical_url -> first sample TG post id
     increments: dict[str, int] = {}
     for post in telegram_posts:
-        canonical = _normalize_telegram_channel_url(post.forwarded_url or "")
+        canonical = normalize_telegram_channel_url(post.forwarded_url or "")
         if canonical is None:
             continue
         increments[canonical] = increments.get(canonical, 0) + 1

--- a/src/tgbot/handlers/moderator/meme_source.py
+++ b/src/tgbot/handlers/moderator/meme_source.py
@@ -6,6 +6,7 @@ from telegram.ext import (
 from src.flows.parsers.tg import parse_telegram_source
 from src.flows.parsers.vk import parse_vk_source
 from src.storage.constants import MemeSourceStatus, MemeSourceType
+from src.storage.etl import normalize_telegram_channel_url
 from src.tgbot.constants import UserType
 from src.tgbot.logs import log
 from src.tgbot.senders.keyboards import (
@@ -31,6 +32,18 @@ async def handle_meme_source_link(update: Update, context: ContextTypes.DEFAULT_
 
     url = update.message.text.strip().lower()
     if "https://t.me/" in url:
+        # Route through the same canonicalizer as the discovery pipeline
+        # so trailing slashes, post ids, and `?utm=...` suffixes collapse onto
+        # the canonical https://t.me/<channel> form. Without this, manual
+        # entries can leave duplicate `discovered` rows in the moderator queue
+        # because list_pending_source_candidates anti-joins on exact url match.
+        canonical = normalize_telegram_channel_url(url)
+        if canonical is None:
+            await update.message.reply_text(
+                "Unsupported telegram URL (private/invite link or unrecognized format)"
+            )
+            return
+        url = canonical
         meme_source_type = MemeSourceType.TELEGRAM
     elif "https://vk.com/" in url:
         meme_source_type = MemeSourceType.VK

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -216,9 +216,16 @@ async def promote_source_candidate(
     if promoted is None:
         return None
 
+    # Status guard prevents TOCTOU between concurrent moderator clicks: two
+    # callers can both pass the existence check, both insert into meme_source
+    # (one no-ops via on_conflict_do_nothing), but without this WHERE the
+    # second UPDATE would silently overwrite a `rejected` / `dismissed` status
+    # set by another moderator in the gap. With the guard, the trailing UPDATE
+    # is a no-op once the candidate has been resolved.
     await execute(
         meme_source_candidate.update()
         .where(meme_source_candidate.c.id == candidate_id)
+        .where(meme_source_candidate.c.status == "discovered")
         .values(
             status="promoted",
             promoted_meme_source_id=promoted["id"],

--- a/tests/storage/test_etl_candidates.py
+++ b/tests/storage/test_etl_candidates.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.storage.etl import _normalize_telegram_channel_url
+from src.storage.etl import normalize_telegram_channel_url
 
 
 @pytest.mark.parametrize(
@@ -12,6 +12,12 @@ from src.storage.etl import _normalize_telegram_channel_url
         ("https://t.me/somechannel/12345", "https://t.me/somechannel"),
         ("https://t.me/s/somechannel/12345", "https://t.me/somechannel"),
         ("http://t.me/somechannel/12345", "https://t.me/somechannel"),
+        # Query strings and fragments must collapse onto the canonical form so
+        # manual moderator entries dedupe against discovery-pipeline candidates.
+        ("https://t.me/somechannel?utm_source=share", "https://t.me/somechannel"),
+        ("https://t.me/somechannel/?utm_source=share", "https://t.me/somechannel"),
+        ("https://t.me/somechannel/12345?single", "https://t.me/somechannel"),
+        ("https://t.me/somechannel#anchor", "https://t.me/somechannel"),
         # Private/invite links and aliases must not become candidates.
         ("https://t.me/joinchat/abc123", None),
         ("https://t.me/+invite", None),
@@ -20,4 +26,4 @@ from src.storage.etl import _normalize_telegram_channel_url
     ],
 )
 def test_normalize_telegram_channel_url(raw, expected):
-    assert _normalize_telegram_channel_url(raw) == expected
+    assert normalize_telegram_channel_url(raw) == expected

--- a/tests/tgbot/test_promote_source_candidate.py
+++ b/tests/tgbot/test_promote_source_candidate.py
@@ -1,0 +1,123 @@
+"""Tests for promote_source_candidate idempotency + TOCTOU guard (FFM-940)."""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncConnection
+from tests.factories import TEST_ID_START, cleanup_test_data, create_user
+
+from src.database import engine, fetch_one, meme_source, meme_source_candidate
+from src.tgbot.service import promote_source_candidate
+
+TOCTOU_URL = "https://t.me/ffm940_toctou_candidate"
+ALREADY_DISMISSED_URL = "https://t.me/ffm940_dismissed_candidate"
+PROMOTING_USER_ID = TEST_ID_START + 940
+
+
+async def _create_discovered_candidate(conn: AsyncConnection, url: str) -> int:
+    await conn.execute(
+        insert(meme_source_candidate)
+        .values(
+            type="telegram",
+            url=url,
+            status="discovered",
+            times_forwarded=3,
+            created_at=datetime(2024, 6, 1, 12, 0, 0),
+            updated_at=datetime(2024, 6, 1, 12, 0, 0),
+        )
+        .on_conflict_do_nothing()
+    )
+    row = (
+        await conn.execute(
+            select(meme_source_candidate.c.id).where(meme_source_candidate.c.url == url)
+        )
+    ).one()
+    return int(row.id)
+
+
+@pytest_asyncio.fixture()
+async def conn():
+    async with engine.connect() as conn:
+        await create_user(conn, id=PROMOTING_USER_ID, type="moderator")
+        await conn.commit()
+        yield conn
+        await conn.execute(
+            delete(meme_source_candidate).where(
+                meme_source_candidate.c.url.in_([TOCTOU_URL, ALREADY_DISMISSED_URL])
+            )
+        )
+        await conn.execute(
+            delete(meme_source).where(meme_source.c.url.in_([TOCTOU_URL, ALREADY_DISMISSED_URL]))
+        )
+        await conn.commit()
+        await cleanup_test_data(conn)
+
+
+@pytest.mark.asyncio
+async def test_promote_skips_already_dismissed_candidate(conn: AsyncConnection):
+    """Early-check path: a dismissed candidate is never promoted."""
+    candidate_id = await _create_discovered_candidate(conn, ALREADY_DISMISSED_URL)
+    await conn.execute(
+        meme_source_candidate.update()
+        .where(meme_source_candidate.c.id == candidate_id)
+        .values(status="dismissed", dismissed_reason="moderator")
+    )
+    await conn.commit()
+
+    result = await promote_source_candidate(candidate_id, added_by_user_id=PROMOTING_USER_ID)
+    assert result is None
+
+    final_row = await fetch_one(
+        select(meme_source_candidate).where(meme_source_candidate.c.id == candidate_id)
+    )
+    assert final_row["status"] == "dismissed"
+
+
+@pytest.mark.asyncio
+async def test_promote_does_not_clobber_concurrent_dismiss(conn: AsyncConnection):
+    """TOCTOU guard: simulate the candidate being dismissed AFTER the existence
+    check but BEFORE the trailing UPDATE. Without the `WHERE status='discovered'`
+    guard on that UPDATE, the dismiss would be silently overwritten with
+    'promoted'. With the guard, the trailing UPDATE is a no-op.
+    """
+    candidate_id = await _create_discovered_candidate(conn, TOCTOU_URL)
+    await conn.commit()
+
+    real_candidate = await fetch_one(
+        select(meme_source_candidate).where(meme_source_candidate.c.id == candidate_id)
+    )
+
+    async def get_then_dismiss(cand_id: int):
+        # Return the still-discovered snapshot the caller saw, then flip the
+        # real DB row to 'dismissed' as if a concurrent moderator clicked
+        # dismiss in the gap.
+        snapshot = dict(real_candidate)
+        async with engine.begin() as race_conn:
+            await race_conn.execute(
+                meme_source_candidate.update()
+                .where(meme_source_candidate.c.id == cand_id)
+                .values(status="dismissed", dismissed_reason="moderator-race")
+            )
+        return snapshot
+
+    with patch(
+        "src.tgbot.service.get_source_candidate_by_id",
+        side_effect=get_then_dismiss,
+    ):
+        promoted = await promote_source_candidate(candidate_id, added_by_user_id=PROMOTING_USER_ID)
+
+    # The meme_source insert still ran (it is idempotent + reflects moderator
+    # intent at the moment of click), but the candidate row must retain the
+    # 'dismissed' status set by the concurrent moderator.
+    assert promoted is not None
+    assert promoted["url"] == TOCTOU_URL
+
+    final_candidate = await fetch_one(
+        select(meme_source_candidate).where(meme_source_candidate.c.id == candidate_id)
+    )
+    assert final_candidate["status"] == "dismissed"
+    assert final_candidate["dismissed_reason"] == "moderator-race"


### PR DESCRIPTION
Fixes [FFM-940](https://github.com/ffmemes/ff-backend/issues/940). P2 polish followups for #227.

## Summary

- **P2a — Canonicalize manual TG source URLs**
  Promote `_normalize_telegram_channel_url` → `normalize_telegram_channel_url` (public) and route manual moderator entries in `src/tgbot/handlers/moderator/meme_source.py` through it. Without this, entering `https://t.me/<channel>/` (trailing slash) or `?utm=...` suffixes left duplicate `discovered` rows in `/discoveredsources` because `list_pending_source_candidates` anti-joins on exact `meme_source.url` match. Also extend the normalizer to strip query strings + fragments before the regex.

- **P2b — Status guard on `promote_source_candidate` UPDATE**
  Add `WHERE status='discovered'` to the trailing UPDATE in `src/tgbot/service.py`. Closes a TOCTOU race where two concurrent moderator clicks could both pass the existence check (`get_source_candidate_by_id` returns `discovered`), both insert into `meme_source` (one no-ops via `on_conflict_do_nothing`), and then both UPDATE the candidate row — silently overwriting any `dismissed`/`rejected` status set by another moderator in the gap. With the guard, the trailing UPDATE is a no-op once the candidate has been resolved.

## Test plan

- [x] `python3 -m ruff check src/ tests/` — passes
- [x] `python3 -m ruff format --check src/ tests/` — passes
- [x] Inline-verified extended normalizer cases (trailing slash, `?utm=...`, `#anchor`, post id stripping, joinchat/private rejection)
- [ ] CI: `tests/storage/test_etl_candidates.py` — extended parametrize cases for query strings + fragments
- [ ] CI: `tests/tgbot/test_promote_source_candidate.py` (new) — covers the early-return path and the TOCTOU guard via `unittest.mock.patch` on `get_source_candidate_by_id` to inject a stale `discovered` snapshot while the real DB row gets flipped to `dismissed` mid-call

## Notes

- Branched off `production` (PR #227 already merged). No new tables, no new endpoints.
- `_normalize_telegram_channel_url` had only two call sites (etl.py + the unit test); both updated.