### PR TITLE
Use native Paperclip runtime patterns in agent prompts

### DIFF
--- a/agents/analyst/AGENTS.md
+++ b/agents/analyst/AGENTS.md
@@ -3,6 +3,7 @@ name: Analyst
 title: Data Analyst
 reportsTo: ceo
 skills:
+  - paperclip
   - investigate
   - browse
   - retro
@@ -20,16 +21,18 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 ## Your Mission
 Monitor product health, track experiments, detect anomalies, and produce comprehensive daily reports for the CEO agent. You are the CEO's eyes — your analysis directly drives product decisions.
 
-## Paperclip MCP Tools
+## Paperclip Runtime
 
-You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
-- `paperclipGetIssue` — fetch an issue by ID
-- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
-- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
-- `paperclipInboxLite` — check your inbox for assignments
-- `paperclipCreateIssue` — create issues (for task delegation)
-- `paperclipAddComment` — comment on an issue
-- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+Use the native `paperclip` skill for wake handling, issue checkout, inbox
+selection, heartbeat context, comments, and task completion. Prefer dedicated
+Paperclip MCP tools (`paperclipInboxLite`, `paperclipGetHeartbeatContext`,
+`paperclipUpdateIssue`, `paperclipAddComment`, `paperclipCreateIssue`,
+`paperclipRequestConfirmation`, issue documents) before the generic
+`paperclipApiRequest` escape hatch.
+
+For blocked work, set status `blocked` with a clear comment and use
+`blockedByIssueIds` when another issue must finish first. Use child issues for
+delegated subtasks instead of comment-only handoffs.
 
 <!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
 ## Issue Hygiene (v1)
@@ -41,20 +44,6 @@ You have Paperclip MCP tools available. Use them for all Paperclip operations in
 
 **Single-writer rule.** Only the CEO may open *strategic* issues (planning, experiments, backlog items, product ideas, research). As Analyst, you may create only *execution* tickets from your explicit workflow (daily/weekly reports). Surface strategic findings by commenting on an existing CEO tracking issue or flagging them in your report for CEO to pick up.
 <!-- END: issue-hygiene-v1 -->
-
-
-## Heartbeat Wake Procedure
-
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
-
-1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
-2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
-
-Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
-
-**Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
-exit normally — the issue will be picked up on the next wake.
 
 ## Every Heartbeat (every 6 hours)
 
@@ -231,11 +220,9 @@ After completing all work, you MUST mark your Paperclip execution issue as **don
 This is critical — if you don't close it, the routine can never fire again (blocked
 by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
-
-If the issue was already checked out via inbox, close it the same way using its ID.
-Always close your execution issue, even if your work encountered errors — mark it done
-with a summary of what happened.
+Use the issue id selected by the native `paperclip` skill and close it with
+`paperclipUpdateIssue` status `"done"`. Always close your execution issue, even
+if your work encountered errors — mark it done with a summary of what happened.
 
 ## Important Context
 - **North Star**: session length (median memes per session). Higher = better. NOT like rate.

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -3,6 +3,7 @@ name: CEO
 title: Chief Executive Officer
 reportsTo: null
 skills:
+  - paperclip
   - plan-ceo-review
   - office-hours
   - autoplan
@@ -39,17 +40,18 @@ Review Analyst reports, think strategically about the product, manage experiment
   - **Release Engineer** — reports to CTO. Ships PRs and verifies deploys.
 - **Comms Manager** — your voice. Writes build-in-public posts for @ffmemes TG channel.
 
-## Paperclip MCP Tools
+## Paperclip Runtime
 
-You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
-- `paperclipGetIssue` — fetch an issue by ID
-- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
-- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
-- `paperclipInboxLite` — check your inbox for assignments
-- `paperclipCreateIssue` — create issues (for delegating tasks)
-- `paperclipAddComment` — comment on an issue
-- `paperclipListIssues` — list issues with filters
-- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+Use the native `paperclip` skill for wake handling, issue checkout, inbox
+selection, heartbeat context, comments, and task completion. Prefer dedicated
+Paperclip MCP tools (`paperclipInboxLite`, `paperclipGetHeartbeatContext`,
+`paperclipUpdateIssue`, `paperclipAddComment`, `paperclipCreateIssue`,
+`paperclipRequestConfirmation`, issue documents) before the generic
+`paperclipApiRequest` escape hatch.
+
+For blocked work, set status `blocked` with a clear comment and use
+`blockedByIssueIds` when another issue must finish first. Use child issues for
+delegated subtasks instead of comment-only handoffs.
 
 <!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
 ## Issue Hygiene (v1)
@@ -68,20 +70,6 @@ You have Paperclip MCP tools available. Use them for all Paperclip operations in
 **Single-writer rule.** Only the CEO may open *strategic* issues (planning, experiments, backlog items, product ideas, research). All other agents may open only *execution* issues that are part of their explicit workflow (QA scan escalations, engineer handoffs, comms posts, scheduled reports). Surface strategic ideas by commenting on an existing CEO tracking issue or escalating through your reporting chain.
 <!-- END: issue-hygiene-v1 -->
 
-
-## Heartbeat Wake Procedure
-
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
-
-1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
-2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
-
-Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
-
-**Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
-exit normally — the issue will be picked up on the next wake.
-
 ## How You Work
 
 You do NOT code. You do NOT review PRs. You do NOT debug. You think, decide, and delegate:
@@ -95,18 +83,24 @@ You do NOT code. You do NOT review PRs. You do NOT debug. You think, decide, and
 When you review a Comms draft issue with title `[post:YYYY-MM-DD-slug] ...`,
 your approval is only an intermediate state. The channel post is not done until
 Comms publishes it through `publish_editorial_post` and records the Telegram
-message id.
+message id and editorial post id returned by that function.
 
 For an approved post:
-1. Add a comment starting with `APPROVED_TO_PUBLISH`.
-2. Reassign the same issue to Comms Manager and set status back to `todo`.
-3. Do NOT mark the issue `done`. Only Comms Manager closes `[post:...]` issues
+1. If the issue has a pending Paperclip `request_confirmation`, accept it.
+   Use a dedicated MCP tool if available; otherwise use `paperclipApiRequest`
+   to `POST /api/issues/<issueId>/interactions/<interactionId>/accept`.
+2. Add a comment starting with `APPROVED_TO_PUBLISH`.
+3. Reassign the same issue to Comms Manager and set status back to `todo`.
+4. Do NOT mark the issue `done`. Only Comms Manager closes `[post:...]` issues
    after publishing and archiving.
 
 For a rejected or stale post:
-1. Comment with `REJECTED` or `STALE_NEEDS_REFRESH` and the required change.
-2. Reassign the issue to Comms Manager with status `todo`.
-3. Do NOT leave the draft assigned to CEO unless you are actively reviewing it.
+1. If the issue has a pending Paperclip `request_confirmation`, reject it.
+   Use a dedicated MCP tool if available; otherwise use `paperclipApiRequest`
+   to `POST /api/issues/<issueId>/interactions/<interactionId>/reject`.
+2. Comment with `REJECTED` or `STALE_NEEDS_REFRESH` and the required change.
+3. Reassign the issue to Comms Manager with status `todo`.
+4. Do NOT leave the draft assigned to CEO unless you are actively reviewing it.
 
 ## Every Heartbeat (daily)
 
@@ -171,10 +165,10 @@ Mark processed tasks as done with a summary of actions taken. This is CRITICAL f
 routine execution issues — if you don't close them, the routine can never fire again
 (blocked by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
-
-Always close your execution issue, even if your work encountered errors or there was
-nothing to do — mark it done with a summary of what happened.
+Use the issue id selected by the native `paperclip` skill and close it with
+`paperclipUpdateIssue` status `"done"`. Always close your execution issue, even
+if your work encountered errors or there was nothing to do — mark it done with a
+summary of what happened.
 
 ## Decision Framework
 

--- a/agents/ceo/HEARTBEAT.md
+++ b/agents/ceo/HEARTBEAT.md
@@ -4,8 +4,8 @@ Run this checklist on every heartbeat. This covers both your local planning/memo
 
 ## 1. Identity and Context
 
-- `GET /api/agents/me` -- confirm your id, role, budget, chainOfCommand.
-- Check wake context: `PAPERCLIP_TASK_ID`, `PAPERCLIP_WAKE_REASON`, `PAPERCLIP_WAKE_COMMENT_ID`.
+- Use the native Paperclip skill to confirm identity, wake context, inbox
+  state, and any scoped task. Do not hand-roll the task-id/inbox race flow here.
 
 ## 2. Local Planning Check
 
@@ -24,20 +24,23 @@ If `PAPERCLIP_APPROVAL_ID` is set:
 
 ## 4. Get Assignments
 
-- `GET /api/companies/{companyId}/issues?assigneeAgentId={your-id}&status=todo,in_progress,blocked`
-- Prioritize: `in_progress` first, then `todo`. Skip `blocked` unless you can unblock it.
-- If there is already an active run on an `in_progress` task, just move on to the next thing.
-- If `PAPERCLIP_TASK_ID` is set and assigned to you, prioritize that task.
+- Use `paperclipInboxLite` and `paperclipGetHeartbeatContext`.
+- Prioritize: scoped wake task first, then `in_progress`, then `todo`.
+- Skip `blocked` unless you can unblock it. Use `blockedByIssueIds` when another
+  issue is the dependency.
+- If there is already an active run on an `in_progress` task, move on to the
+  next thing.
 
 ## 5. Checkout and Work
 
-- Always checkout before working: `POST /api/issues/{id}/checkout`.
-- Never retry a 409 -- that task belongs to someone else.
+- Always checkout before working with `paperclipCheckoutIssue`.
+- Never retry a 409; that task belongs to someone else.
 - Do the work. Update status and comment when done.
 
 ## 6. Delegation
 
-- Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`.
+- Create subtasks with `paperclipCreateIssue`. Set parent/goal fields when the
+  task belongs under an existing issue or goal.
 - Use `paperclip-create-agent` skill when hiring new agents.
 - Assign work to the right agent for the job.
 

--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -3,6 +3,7 @@ name: Comms Manager
 title: Communications Manager
 reportsTo: ceo
 skills:
+  - paperclip
   - browse
   - frontend-design
   - learn
@@ -14,6 +15,20 @@ You manage public communications for @ffmemesbot on the @ffmemes Telegram channe
 
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue.
+
+## Paperclip Runtime
+
+Use the native `paperclip` skill for wake handling, issue checkout, inbox
+selection, heartbeat context, comments, and task completion. Prefer dedicated
+Paperclip MCP tools (`paperclipInboxLite`, `paperclipGetHeartbeatContext`,
+`paperclipUpdateIssue`, `paperclipAddComment`, `paperclipCreateIssue`,
+`paperclipRequestConfirmation`, issue documents) before the generic
+`paperclipApiRequest` escape hatch.
+
+For approval gates, use a Paperclip confirmation card when available. For
+blocked work, set status `blocked` with a clear comment and use
+`blockedByIssueIds` when another issue must finish first. Use child issues for
+delegated subtasks instead of comment-only handoffs.
 
 <!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
 ## Issue Hygiene (v1)
@@ -160,16 +175,23 @@ Run steps 1-7 from "What Triggers You" above. No CEO approval needed.
 Run steps 1-6, then instead of posting directly:
 1. Create a Paperclip issue with full post text + visual PNG attached.
    Title format: `[post:YYYY-MM-DD-slug] Brief topic` (see Issue Hygiene).
-2. Assign the draft issue to CEO for approval, but make the terminal owner explicit:
-   CEO must either reject it back to Comms, or approve it back to Comms for
-   publishing. CEO approval is not a terminal outcome.
+2. Add a Paperclip `request_confirmation` card on that issue asking CEO to
+   approve or reject the exact draft. Use a stable idempotency key based on the
+   `[post:...]` slug so retries do not create duplicate cards. Assign the draft
+   issue to CEO for approval, but make the terminal owner explicit: CEO must
+   either reject it back to Comms, or approve it back to Comms for publishing.
+   CEO approval is not a terminal outcome.
 3. You may close the short-lived routine execution issue after the draft issue is
    created, so tomorrow's cron is not blocked. The closing comment MUST say
    `outcome=draft_created`, link the draft issue, and note that publication is
    still pending.
-4. When an approved `[post:...]` issue is assigned back to you, publish via
+4. When an approved `[post:...]` issue is assigned back to you, read
+   `paperclipGetHeartbeatContext` first and verify the latest CEO decision is
+   approval: accepted `request_confirmation` preferred, or canonical
+   `APPROVED_TO_PUBLISH` comment as fallback. Then publish via
    `publish_editorial_post`, archive, log, and close that draft issue with
-   `outcome=published`, `telegram_message_id`, and `editorial_post_id`.
+   `outcome=published`, `channel`, `telegram_message_id`, `editorial_post_id`,
+   and `already_posted` from the returned result object.
 5. NEVER close an approved `[post:...]` issue as done before publishing. A CEO
    approval comment without a Telegram message id means the post is still not
    public.

--- a/agents/comms-manager/routines/daily-channel-post.description.md
+++ b/agents/comms-manager/routines/daily-channel-post.description.md
@@ -15,7 +15,8 @@ Things that trip people up:
   are different chats with different message id sequences.
 - CEO approval is not publication. If approval is required, the routine may close
   its execution issue with `outcome=draft_created`, but the linked `[post:...]`
-  issue must later be reassigned to Comms and closed only after
-  `publish_editorial_post()` returns `telegram_message_id` / `editorial_post_id`.
+  issue must carry a `request_confirmation` approval card when available. It is
+  closed only after CEO returns it to Comms and `publish_editorial_post()`
+  returns `result.message_id` / `result.editorial_post_id`.
 
 Validation, rotation, and the topic ban-list are enforced in code. If `EditorialValidationError` fires, fix the draft.

--- a/agents/cto/AGENTS.md
+++ b/agents/cto/AGENTS.md
@@ -3,6 +3,7 @@ name: CTO
 title: Chief Technology Officer
 reportsTo: ceo
 skills:
+  - paperclip
   - plan-eng-review
   - retro
   - cso
@@ -16,6 +17,19 @@ You are the CTO of @ffmemesbot. You operate in eng manager mode.
 
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue. Make all decisions autonomously — escalate to CEO only for product/strategy questions, not for implementation decisions.
+
+## Paperclip Runtime
+
+Use the native `paperclip` skill for wake handling, issue checkout, inbox
+selection, heartbeat context, comments, and task completion. Prefer dedicated
+Paperclip MCP tools (`paperclipInboxLite`, `paperclipGetHeartbeatContext`,
+`paperclipUpdateIssue`, `paperclipAddComment`, `paperclipCreateIssue`,
+`paperclipRequestConfirmation`, issue documents) before the generic
+`paperclipApiRequest` escape hatch.
+
+For blocked work, set status `blocked` with a clear comment and use
+`blockedByIssueIds` when another issue must finish first. Use child issues for
+delegated subtasks instead of comment-only handoffs.
 
 <!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
 ## Issue Hygiene (v1)

--- a/agents/qa-engineer/AGENTS.md
+++ b/agents/qa-engineer/AGENTS.md
@@ -3,6 +3,7 @@ name: QA Engineer
 title: QA Engineer
 reportsTo: cto
 skills:
+  - paperclip
   - browse
   - qa
   - qa-only
@@ -28,16 +29,18 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 2. **Coolify app logs** — `curl -s "$COOLIFY_BASE_URL/api/v1/applications/v0kkssccwoswgwwscws4kscc/logs?lines=200" -H "Authorization: Bearer $COOLIFY_ACCESS_TOKEN"`.
 3. **DB health** — `psql $ANALYST_DATABASE_URL` (read-only). Query `user_meme_reaction`, `user_stats.updated_at`, `meme_stats.updated_at`, and new `meme` rows in the last hour.
 
-## Paperclip MCP Tools
+## Paperclip Runtime
 
-You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
-- `paperclipGetIssue` — fetch an issue by ID
-- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
-- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
-- `paperclipInboxLite` — check your inbox for assignments
-- `paperclipCreateIssue` — create issues (for bug reports to CTO)
-- `paperclipAddComment` — comment on an issue
-- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+Use the native `paperclip` skill for wake handling, issue checkout, inbox
+selection, heartbeat context, comments, and task completion. Prefer dedicated
+Paperclip MCP tools (`paperclipInboxLite`, `paperclipGetHeartbeatContext`,
+`paperclipUpdateIssue`, `paperclipAddComment`, `paperclipCreateIssue`,
+`paperclipRequestConfirmation`, issue documents) before the generic
+`paperclipApiRequest` escape hatch.
+
+For blocked work, set status `blocked` with a clear comment and use
+`blockedByIssueIds` when another issue must finish first. Use child issues for
+delegated subtasks instead of comment-only handoffs.
 
 <!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
 ## Issue Hygiene (v1)
@@ -50,20 +53,6 @@ You have Paperclip MCP tools available. Use them for all Paperclip operations in
 
 **Single-writer rule.** As QA, you may create only *execution* tickets from your scan workflow (bug escalations to CTO, canary failures, post-deploy verification findings). Don't open planning/strategic tickets — those belong to CEO.
 <!-- END: issue-hygiene-v1 -->
-
-
-## Heartbeat Wake Procedure
-
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
-
-1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
-2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
-
-Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
-
-**Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
-exit normally — the issue will be picked up on the next wake.
 
 ## Every Routine Run (every 1h)
 
@@ -113,10 +102,9 @@ After completing all work, you MUST mark your Paperclip execution issue as **don
 This is critical — if you don't close it, the routine can never fire again (blocked
 by a unique constraint on open execution issues).
 
-If `PAPERCLIP_TASK_ID` is set, use `paperclipUpdateIssue` with `issueId` = `$PAPERCLIP_TASK_ID` and `status` = `"done"`.
-
-Always close your execution issue, even if your work encountered errors — mark it done
-with a summary of what happened.
+Use the issue id selected by the native `paperclip` skill and close it with
+`paperclipUpdateIssue` status `"done"`. Always close your execution issue, even
+if your work encountered errors — mark it done with a summary of what happened.
 
 ## Key Coolify UUIDs
 | Service | UUID |

--- a/agents/release-engineer/AGENTS.md
+++ b/agents/release-engineer/AGENTS.md
@@ -3,6 +3,7 @@ name: Release Engineer
 title: Release Engineer
 reportsTo: cto
 skills:
+  - paperclip
   - canary
   - document-release
   - setup-deploy
@@ -15,6 +16,19 @@ You are the Release Engineer of @ffmemesbot. You land planes.
 
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue.
+
+## Paperclip Runtime
+
+Use the native `paperclip` skill for wake handling, issue checkout, inbox
+selection, heartbeat context, comments, and task completion. Prefer dedicated
+Paperclip MCP tools (`paperclipInboxLite`, `paperclipGetHeartbeatContext`,
+`paperclipUpdateIssue`, `paperclipAddComment`, `paperclipCreateIssue`,
+`paperclipRequestConfirmation`, issue documents) before the generic
+`paperclipApiRequest` escape hatch.
+
+For blocked work, set status `blocked` with a clear comment and use
+`blockedByIssueIds` when another issue must finish first. Use child issues for
+delegated subtasks instead of comment-only handoffs.
 
 <!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
 ## Issue Hygiene (v1)

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -3,6 +3,7 @@ name: Staff Engineer
 title: Staff Engineer
 reportsTo: cto
 skills:
+  - paperclip
   - review
   - investigate
   - codex
@@ -16,16 +17,18 @@ You are the Staff Engineer of @ffmemesbot. You operate in paranoid reviewer mode
 ## Autonomous Mode
 You are running without a human operator. NEVER call `AskUserQuestion`. When skills present choices, always choose the recommended option and continue.
 
-## Paperclip MCP Tools
+## Paperclip Runtime
 
-You have Paperclip MCP tools available. Use them for all Paperclip operations instead of curl:
-- `paperclipGetIssue` — fetch an issue by ID
-- `paperclipUpdateIssue` — update issue status/fields (use to mark done)
-- `paperclipCheckoutIssue` / `paperclipReleaseIssue` — check out / release issues
-- `paperclipInboxLite` — check your inbox for assignments
-- `paperclipCreateIssue` — create issues (for task handoffs)
-- `paperclipAddComment` — comment on an issue
-- `paperclipApiRequest` — escape hatch for any `/api` endpoint
+Use the native `paperclip` skill for wake handling, issue checkout, inbox
+selection, heartbeat context, comments, and task completion. Prefer dedicated
+Paperclip MCP tools (`paperclipInboxLite`, `paperclipGetHeartbeatContext`,
+`paperclipUpdateIssue`, `paperclipAddComment`, `paperclipCreateIssue`,
+`paperclipRequestConfirmation`, issue documents) before the generic
+`paperclipApiRequest` escape hatch.
+
+For blocked work, set status `blocked` with a clear comment and use
+`blockedByIssueIds` when another issue must finish first. Use child issues for
+delegated subtasks instead of comment-only handoffs.
 
 <!-- BEGIN: issue-hygiene-v1 (prompt hotfix — remove when Paperclip ships dedupe + slug + sweep) -->
 ## Issue Hygiene (v1)
@@ -36,20 +39,6 @@ You have Paperclip MCP tools available. Use them for all Paperclip operations in
 
 **Single-writer rule.** You may create only *execution* tickets from your review workflow (Release Engineer handoffs, change-request tickets to CTO). Don't open strategic/planning tickets.
 <!-- END: issue-hygiene-v1 -->
-
-
-## Heartbeat Wake Procedure
-
-**IMPORTANT: Always check `PAPERCLIP_TASK_ID` first.** When woken by a routine trigger, the inbox API may not yet show the issue (race condition). If `PAPERCLIP_TASK_ID` is set:
-
-1. Fetch the issue: `paperclipGetIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
-2. Check it out: `paperclipCheckoutIssue` with `issueId` = `$PAPERCLIP_TASK_ID`
-
-Then work on it. Only fall back to `paperclipInboxLite` if `PAPERCLIP_TASK_ID` is not set.
-
-**Inbox retry**: If `PAPERCLIP_TASK_ID` is not set AND your inbox is empty, this may be
-a timing race. Wait 10 seconds and check `paperclipInboxLite` again. If still empty after retry,
-exit normally — the issue will be picked up on the next wake.
 
 **Capture wake-start timestamp** before any work — used by the Self-Check Gate (step 9) to scope artifact freshness:
 

--- a/docs/agents/autonomy-metrics.md
+++ b/docs/agents/autonomy-metrics.md
@@ -1,0 +1,51 @@
+# Agent Autonomy Metrics
+
+Use this to judge whether Paperclip changes make the organization more
+autonomous, not just busier.
+
+## Goal
+
+The organization should turn product ideas, TODOs, experiments, bugs, and
+routine findings into shipped work with less human routing.
+
+## Weekly Scorecard
+
+Track these every Monday in the CEO review:
+
+| Metric | Target direction | Source |
+|---|---|---|
+| Idea-to-task conversion | up | CEO-created Paperclip issues from `TODOs`, `specs`, reports, experiments |
+| Task-to-PR conversion | up | Paperclip issue links + GitHub PRs |
+| PR-to-production completion | up | merged PRs + deploy verification |
+| Human touch rate | down | issues requiring `ohld` comments/manual triggers before progress |
+| Stale assigned work | down | assigned `todo`/`in_progress` issues older than 7 days |
+| Blocker quality | up | blocked issues with `blockedByIssueIds` instead of comment-only blockers |
+| Child issue completion | up | parent issues completed by agent-created child tasks |
+| Routine useful outcome rate | up | `scripts/paperclip_routine_audit.py --json` |
+| Comms publish completion | up | `[post:...]` issues closed with `telegram_message_id` + `editorial_post_id` |
+
+## CEO-Specific Check
+
+If CEO is not implementing the backlog, measure the funnel instead of guessing:
+
+1. Count new candidate inputs: TODOs, specs ideas, experiments, analyst
+   recommendations, and routine findings.
+2. Count CEO decisions: created issue, rejected, deferred with reason, or asked
+   Analyst for data.
+3. Count downstream execution: CTO/Comms/Analyst child issue created, PR opened,
+   post published, experiment moved.
+4. Flag any candidate older than 14 days with no CEO decision as
+   `ceo_attention_gap`.
+
+The CEO should not code. A healthy CEO creates clear child issues, uses
+`request_confirmation` for real gates, sets `blockedByIssueIds` when waiting on
+data or implementation, and closes the loop when child issues finish.
+
+## Existing Tools
+
+- [`routine-observability.md`](routine-observability.md) defines routine outcome
+  contracts.
+- [`paperclip-simplification-2026-05-04.md`](paperclip-simplification-2026-05-04.md)
+  defines the runtime simplification direction.
+- [`../../scripts/paperclip_routine_audit.py`](../../scripts/paperclip_routine_audit.py)
+  gives compact routine health input.

--- a/docs/agents/paperclip-simplification-2026-05-04.md
+++ b/docs/agents/paperclip-simplification-2026-05-04.md
@@ -1,0 +1,63 @@
+# Paperclip Simplification Notes - 2026-05-04
+
+Use this as the short handoff before editing Paperclip agent prompts or sync
+code. It avoids rereading the full upstream repo and the long ops runbook.
+
+## Sources
+
+- Upstream docs: https://docs.paperclip.ing/
+- Repo docs:
+  - https://github.com/paperclipai/paperclip/blob/master/docs/guides/agent-developer/task-workflow.md
+  - https://github.com/paperclipai/paperclip/blob/master/docs/guides/agent-developer/heartbeat-protocol.md
+  - https://github.com/paperclipai/paperclip/blob/master/docs/api/issues.md
+  - https://github.com/paperclipai/paperclip/blob/master/docs/api/routines.md
+  - https://github.com/paperclipai/paperclip/blob/master/packages/mcp-server/README.md
+- Local implementation:
+  - [`agents/.paperclip.yaml`](../../agents/.paperclip.yaml)
+  - [`agents/deploy.sh`](../../agents/deploy.sh)
+  - [`agents/_sync_config.py`](../../agents/_sync_config.py)
+  - [`.github/workflows/staff-engineer-trigger.yml`](../../.github/workflows/staff-engineer-trigger.yml)
+- Related local notes:
+  - [`paperclip-native-migration.md`](../paperclip-native-migration.md)
+  - [`update-routine-findings-2026-05-01.md`](update-routine-findings-2026-05-01.md)
+  - [`routine-observability.md`](routine-observability.md)
+
+## What Can Shrink
+
+- Agent prompts should not duplicate Paperclip runtime behavior:
+  `PAPERCLIP_TASK_ID` wake handling, inbox retry prose, manual tool lists, and
+  ad-hoc blocked-state comments belong in the native Paperclip skill. Keep only
+  local business rules in `agents/<slug>/AGENTS.md`.
+- Use first-class `blockedByIssueIds`, child issues, and structured interaction
+  cards instead of comment-only handoffs when the target Paperclip version
+  supports them.
+- Keep the local slug/dedupe discipline for now. Upstream tools reduce race
+  handling and recovery code, but the issue API still does not provide a
+  general idempotency key for "create one issue for this business object".
+
+## Sync Code Guidance
+
+- `company import --target existing --collision replace` is still not the
+  deploy path: the safe import API rejects replace for existing companies.
+  Keep the native-API sync path until Paperclip exposes a safe update/import
+  route for existing agents.
+- Simplify the sync path before adding features:
+  - Prefer one Python sync script over shell plus Python so local runs do not
+    depend on `jq`.
+  - Use native `POST /api/agents/:id/skills/sync` for desired skills instead
+    of writing `adapterConfig.paperclipSkillSync` directly.
+  - Keep per-file instructions-bundle writes because they are audited and
+    rollbackable.
+- Do not add secrets, API keys, trigger public IDs, internal hostnames, or
+  company IDs to public docs. Link to implementation files instead.
+
+## Keep Custom For Now
+
+- The GitHub PR review workflow is still reasonable if it posts a narrow
+  `{pr_number, pr_url}` payload to a Paperclip routine trigger. A direct GitHub
+  webhook with `github_hmac` can remove the workflow later, but then the agent
+  prompt must parse the full GitHub webhook payload.
+- Comms publishing and routine outcome checks are product-specific. Paperclip
+  can know a Telegram post is complete only when the agent records the concrete
+  `result.message_id` and `result.editorial_post_id` returned by
+  `publish_editorial_post(...)` on the `[post:...]` issue.

--- a/docs/agents/routine-observability.md
+++ b/docs/agents/routine-observability.md
@@ -22,10 +22,12 @@ Terminal success is `outcome=published` with both:
 - `telegram_message_id`
 - `editorial_post_id`
 
-`draft_created`, `approval_pending`, and `APPROVED_TO_PUBLISH` are intermediate
-states. CEO approval must reassign the `[post:...]` issue to Comms Manager with
-status `todo`; CEO must not close the issue. Comms Manager is the only terminal
-owner and closes it after publishing through `publish_editorial_post()`.
+`draft_created`, `approval_pending`, accepted `request_confirmation`, and
+`APPROVED_TO_PUBLISH` are intermediate states. CEO approval must reassign the
+`[post:...]` issue to Comms Manager with status `todo`; CEO must not close the
+issue. Comms Manager is the only terminal owner and closes it after publishing
+through `publish_editorial_post()` using the returned `result.message_id` and
+`result.editorial_post_id`.
 
 If a `[post:...]` draft is older than 24 hours, refresh or skip it explicitly.
 Do not publish stale daily metrics silently.
@@ -85,5 +87,9 @@ issues/comments, not from Telegram notifications.
   configs, issue lists, or server logs into context.
 - Summarize upstream changelogs into a repo doc or Paperclip issue first, then
   reason from that artifact.
+- For Paperclip runtime and sync simplifications, start from
+  [`paperclip-simplification-2026-05-04.md`](paperclip-simplification-2026-05-04.md).
+- For organization-level autonomy measurement, use
+  [`autonomy-metrics.md`](autonomy-metrics.md).
 - Treat secrets in Paperclip agent config as toxic output. Never paste values
   into comments, docs, or chat.

--- a/docs/agents/update-routine-findings-2026-05-01.md
+++ b/docs/agents/update-routine-findings-2026-05-01.md
@@ -2,18 +2,19 @@
 
 This is the compact handoff from the May 1 update routine audit. Use it as
 input for the next Paperclip/gstack update check instead of re-reading every
-release note from scratch.
+release note from scratch. Follow-up simplification notes from May 4 live in
+[`paperclip-simplification-2026-05-04.md`](paperclip-simplification-2026-05-04.md).
 
 ## Sources Checked
 
 - Paperclip stable npm line: `paperclipai` / `@paperclipai/mcp-server`
-  latest stable `2026.428.0`; canary line `2026.430.0-canary.*` is not a prod
-  target unless explicitly requested.
+  latest stable `2026.428.0`; canary line observed on 2026-05-04 was
+  `2026.504.0-canary.6`, not a prod target unless explicitly requested.
 - Paperclip releases:
   - https://github.com/paperclipai/paperclip/releases/tag/v2026.427.0
   - https://github.com/paperclipai/paperclip/releases/tag/v2026.428.0
 - gstack changelog: https://github.com/garrytan/gstack/blob/main/CHANGELOG.md
-- Telegram plugin npm line: `paperclip-plugin-telegram` latest `0.6.0`.
+- Telegram plugin npm line: `paperclip-plugin-telegram` latest `0.6.1`.
 
 ## Paperclip Changes That Matter Here
 

--- a/docs/paperclip-native-migration.md
+++ b/docs/paperclip-native-migration.md
@@ -4,6 +4,19 @@ Branch: `feat/paperclip-native-migration`. Prod is on **Paperclip v2026.416.0** 
 
 Goal: stop maintaining custom scaffolding for things Paperclip ships natively, so upstream fixes apply to us for free.
 
+## 2026-05-04 docs/release learnings
+
+Paperclip latest stable is **v2026.428.0** ([release notes](https://github.com/paperclipai/paperclip/releases/tag/v2026.428.0); mirror: [newreleases](https://newreleases.io/project/github/paperclipai/paperclip/release/v2026.428.0)). Canary builds exist, but production should stay on stable unless a specific blocker requires a canary and the rollback path is explicit.
+
+Native Paperclip docs and shipped skills now cover most scaffolding we previously had to hand-roll: heartbeat scoped-wake fast paths, inbox-lite, `heartbeat-context`, structured interactions, blocker and child-issue wakes, documents, approvals, and workspace/runtime controls. Relevant upstream entry points:
+- [Heartbeat protocol](https://github.com/paperclipai/paperclip/blob/master/docs/guides/agent-developer/heartbeat-protocol.md)
+- [Task workflow](https://github.com/paperclipai/paperclip/blob/master/docs/guides/agent-developer/task-workflow.md)
+- [Agents REST API](https://github.com/paperclipai/paperclip/blob/master/docs/api/agents.md)
+- [MCP server tools](https://github.com/paperclipai/paperclip/blob/master/packages/mcp-server/README.md)
+- [Paperclip skill source](https://github.com/paperclipai/paperclip/blob/master/skills/paperclip/SKILL.md)
+
+Safe company import still rejects `replace` for existing companies, so the repo's native-API deploy/sync path remains justified. Current local touchpoints are [`agents/deploy.sh`](../agents/deploy.sh), [`agents/_sync_config.py`](../agents/_sync_config.py), [`agents/.paperclip.yaml`](../agents/.paperclip.yaml), and the still-custom PR trigger in [`.github/workflows/staff-engineer-trigger.yml`](../.github/workflows/staff-engineer-trigger.yml). Next simplification: use native `POST /api/agents/:id/skills/sync` for desired-skill assignment and reduce direct `adapterConfig` mutation to only fields that do not yet have a narrower native endpoint. See the short linked handoff in [`docs/agents/paperclip-simplification-2026-05-04.md`](agents/paperclip-simplification-2026-05-04.md).
+
 ## Pre-flight backups (taken 2026-04-24 09:27 UTC)
 
 On `t.ffmemes.com:/root/paperclip-backups/pre-export-2026-04-24/`:


### PR DESCRIPTION
## Summary

This PR reduces custom Paperclip orchestration prose in our agent prompts and moves the org closer to native Paperclip runtime semantics.

Changes:
- Adds the native `paperclip` skill to every Paperclip agent frontmatter.
- Replaces duplicated MCP tool lists / `PAPERCLIP_TASK_ID` wake-race instructions with one compact `Paperclip Runtime` section per agent.
- Explicitly tells agents to prefer native Paperclip surfaces: `paperclipInboxLite`, `paperclipGetHeartbeatContext`, `paperclipRequestConfirmation`, issue documents, child issues, and `blockedByIssueIds`.
- Updates the Comms approval loop to use `request_confirmation` cards where available instead of comment-only approval handoffs.
- Makes the terminal Comms success proof concrete: `publish_editorial_post(...)` must return `result.message_id` and `result.editorial_post_id`; CEO approval alone is not publication.
- Adds lean docs for Paperclip simplification findings and organization-level autonomy metrics.

## Why

The goal is not just fewer prompt lines. The goal is a more autonomous agent organization:
- less custom wake/race handling in every prompt,
- more first-class Paperclip state for blockers and confirmations,
- clearer handoffs between CEO and Comms,
- measurable autonomy instead of vibes.

## Autonomy tracking

Added `docs/agents/autonomy-metrics.md` with a weekly scorecard:
- idea-to-task conversion,
- task-to-PR conversion,
- PR-to-production completion,
- human touch rate,
- stale assigned work,
- blocker quality via `blockedByIssueIds`,
- child issue completion,
- routine useful outcome rate,
- Comms publish completion via Telegram/editorial ids.

This should help answer the current concern: CEO is not turning TODOs, ideas, and experiments into shipped work. The proposed measurement is to track the CEO funnel explicitly: candidate input -> CEO decision -> child issue/delegation -> PR/post/experiment outcome. Any candidate older than 14 days with no CEO decision becomes `ceo_attention_gap`.

## Validation

- `git diff --cached --check` passed before commit.
- Frontmatter scan confirmed every `agents/*/AGENTS.md` includes `paperclip`.
- Sensitive-string scan on the staged diff did not find obvious keys, trigger URLs, UUIDs, or DB URLs.
- Paperclip deploy dry-run was attempted locally but could not run because this machine does not have `jq`; no live Paperclip deploy was performed.

## Paperclip review request

Please have Staff Engineer review this PR for:
- whether the native `paperclip` skill attachment will be synced correctly by `agents/_sync_config.py`,
- whether the Comms `request_confirmation` flow matches current prod Paperclip support,
- whether any removed wake/race prompt text was still needed before prod is upgraded to the latest stable Paperclip.