### PR TITLE
Fix QA monitoring config sync

### DIFF
--- a/agents/.paperclip.yaml
+++ b/agents/.paperclip.yaml
@@ -109,6 +109,9 @@ agents:
         SENTRY_AUTH_TOKEN:
           kind: "secret"
           requirement: "optional"
+        SENTRY_ORG:
+          kind: "secret"
+          requirement: "optional"
         COOLIFY_ACCESS_TOKEN:
           kind: "secret"
           requirement: "optional"
@@ -153,9 +156,8 @@ agents:
           default: "k4w804sco4s8kc88kwcw0ow4-131756368009"
           requirement: "optional"
         PREFECT_API_URL:
-          kind: "plain"
-          default: "http://65.108.127.32:4200/api"
-          requirement: "optional"
+          kind: "secret"
+          requirement: "required"
         ANALYST_DATABASE_URL:
           kind: "secret"
           requirement: "required"
@@ -163,6 +165,9 @@ agents:
           kind: "secret"
           requirement: "required"
         SENTRY_AUTH_TOKEN:
+          kind: "secret"
+          requirement: "required"
+        SENTRY_ORG:
           kind: "secret"
           requirement: "required"
         PREFECT_AUTH_STRING:

--- a/agents/_sync_config.py
+++ b/agents/_sync_config.py
@@ -23,7 +23,8 @@ COMPANY = os.environ["COMPANY_ID"]
 SCRIPT_DIR = os.environ["SCRIPT_DIR"]
 DRY = os.environ.get("DRY_RUN", "0") == "1"
 
-# Skills published under paperclipai/paperclip/ — preserve when present, don't expect them in frontmatter.
+# Skills published under paperclipai/paperclip/ are preserved when present; they
+# do not need to appear in frontmatter.
 PAPERCLIP_NS_SKILLS = {
     "paperclip",
     "paperclip-create-agent",
@@ -47,6 +48,23 @@ def api(method: str, path: str, body=None):
         raise
 
 
+def fetch_secrets_by_name() -> dict[str, str]:
+    """Return company secret name -> id when the deploy token can read secrets."""
+    try:
+        secrets = api("GET", f"/api/companies/{COMPANY}/secrets")
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403, 404):
+            return {}
+        raise
+    if not isinstance(secrets, list):
+        return {}
+    return {
+        item["name"]: item["id"]
+        for item in secrets
+        if isinstance(item, dict) and item.get("name") and item.get("id")
+    }
+
+
 def skill_to_path(slug: str) -> str:
     if slug in PAPERCLIP_NS_SKILLS:
         return f"paperclipai/paperclip/{slug}"
@@ -65,17 +83,76 @@ def read_frontmatter_skills(agents_md_path: str) -> list[str]:
     return list(fm.get("skills") or [])
 
 
+def target_env_bindings(
+    cur_env: dict | None,
+    target_inputs: dict | None,
+    secrets_by_name: dict[str, str],
+) -> tuple[dict, list[str]]:
+    """Build runtime adapterConfig.env bindings from portable manifest inputs."""
+    target_env = ((target_inputs or {}).get("env")) or {}
+    cur_env = cur_env or {}
+    bindings = {}
+    missing_required_secrets = []
+
+    for key, spec in target_env.items():
+        if not isinstance(spec, dict):
+            continue
+        if spec.get("kind") == "plain":
+            bindings[key] = {"type": "plain", "value": str(spec.get("default", ""))}
+            continue
+
+        current = cur_env.get(key)
+        if isinstance(current, dict) and current.get("type") == "secret_ref":
+            bindings[key] = current
+            continue
+
+        secret_id = secrets_by_name.get(key)
+        if secret_id:
+            bindings[key] = {
+                "type": "secret_ref",
+                "secretId": secret_id,
+                "version": "latest",
+            }
+        elif spec.get("requirement") == "required":
+            missing_required_secrets.append(key)
+
+    return bindings, missing_required_secrets
+
+
+def merged_adapter_env(cur_env: dict | None, target_bindings: dict) -> dict:
+    """Merge manifest-managed env keys without removing runtime-only env keys."""
+    return {**(cur_env or {}), **target_bindings}
+
+
+def adapter_env_changes(cur_env: dict | None, target_bindings: dict) -> list[str]:
+    """Return human-readable env binding drift without exposing secret values."""
+    cur_env = cur_env or {}
+    added = sorted(set(target_bindings) - set(cur_env))
+    changed = sorted(
+        k for k in set(target_bindings) & set(cur_env) if target_bindings[k] != cur_env[k]
+    )
+
+    changes = []
+    if added:
+        changes.append(f"+adapterConfig.env: {added}")
+    if changed:
+        changes.append(f"~adapterConfig.env: {changed}")
+    return changes
+
+
 def main() -> int:
     with open(f"{SCRIPT_DIR}/.paperclip.yaml") as f:
         manifest = yaml.safe_load(f)
 
     agents_list = api("GET", f"/api/companies/{COMPANY}/agents")
     by_slug = {a["urlKey"]: a for a in agents_list}
+    secrets_by_name = fetch_secrets_by_name()
 
     patched = 0
     skipped = 0
     failed = 0
     would_patch = 0
+    missing_required_secret_errors = 0
     for slug, mblock in (manifest.get("agents") or {}).items():
         if slug not in by_slug:
             print(f"  SKIP {slug} — not in prod")
@@ -88,6 +165,7 @@ def main() -> int:
         target_max_turns = ad_cfg.get("maxTurnsPerRun")
         target_heartbeat = (mblock.get("runtime") or {}).get("heartbeat") or {}
         target_perms = mblock.get("permissions") or {}
+        target_inputs = mblock.get("inputs") or {}
 
         # Frontmatter → desiredSkills (preserve any paperclipai/* currently attached)
         fm_skills = read_frontmatter_skills(f"{SCRIPT_DIR}/{slug}/AGENTS.md")
@@ -102,9 +180,7 @@ def main() -> int:
         if target_model and cur_ac.get("model") != target_model:
             changes.append(f"model: {cur_ac.get('model')} → {target_model}")
         if target_max_turns and cur_ac.get("maxTurnsPerRun") != target_max_turns:
-            changes.append(
-                f"maxTurnsPerRun: {cur_ac.get('maxTurnsPerRun')} → {target_max_turns}"
-            )
+            changes.append(f"maxTurnsPerRun: {cur_ac.get('maxTurnsPerRun')} → {target_max_turns}")
         if target_skills != cur_skills_sorted:
             added = sorted(set(target_skills) - set(cur_skills_sorted))
             removed = sorted(set(cur_skills_sorted) - set(target_skills))
@@ -126,6 +202,17 @@ def main() -> int:
                 perm_changes.append((k, v))
                 changes.append(f"permissions.{k}: {cur_perms.get(k)} → {v}")
 
+        cur_env = cur_ac.get("env") or {}
+        target_bindings, missing_required_secrets = target_env_bindings(
+            cur_env,
+            target_inputs,
+            secrets_by_name,
+        )
+        if missing_required_secrets:
+            changes.append(f"!missing required secrets: {missing_required_secrets}")
+            missing_required_secret_errors += 1
+        changes.extend(adapter_env_changes(cur_env, target_bindings))
+
         if not changes:
             print(f"  skip {slug} (no config drift)")
             skipped += 1
@@ -142,6 +229,8 @@ def main() -> int:
             new_ac["model"] = target_model
         if target_max_turns:
             new_ac["maxTurnsPerRun"] = target_max_turns
+        if target_bindings:
+            new_ac["env"] = merged_adapter_env(cur_env, target_bindings)
         new_skill_sync = dict(new_ac.get("paperclipSkillSync") or {})
         new_skill_sync["desiredSkills"] = target_skills
         new_ac["paperclipSkillSync"] = new_skill_sync
@@ -156,6 +245,7 @@ def main() -> int:
             "adapterConfig": new_ac,
             "runtimeConfig": new_rt,
         }
+
         try:
             api("PATCH", f"/api/agents/{cur['id']}", body)
             print(f"  PATCHED {slug}: {'; '.join(changes)}")
@@ -177,6 +267,13 @@ def main() -> int:
         print(f"\nConfig sync (dry-run): would patch {would_patch}, skip {skipped} (no drift).")
     else:
         print(f"\nConfig sync: patched={patched}, skipped={skipped}, failed={failed}.")
+    if missing_required_secret_errors:
+        print(
+            f"ERROR: {missing_required_secret_errors} agent(s) reference required secrets "
+            "that are not visible to this deploy token.",
+            file=sys.stderr,
+        )
+        return 1
     return 1 if failed > 0 else 0
 
 

--- a/specs/describe-memes.md
+++ b/specs/describe-memes.md
@@ -41,26 +41,23 @@ This happened in April 2026 when AI agents added paid fallbacks during unsupervi
 VISION_MODELS = [
     "google/gemma-4-31b-it:free",     # 262k context, primary
     "google/gemma-4-26b-a4b-it:free", # 262k context, MoE variant
-    "google/gemma-3-27b-it:free",     # 131k context, re-listed ~2026-04-20
-    "google/gemma-3-12b-it:free",     # 32k context, re-listed ~2026-04-20
 ]
 ```
 
 Falls through sequentially on 403 (access denied), timeout, or bad response.
 429 (rate limit) returns immediately — the 20 rpm limit is global across all free models, so trying the next model would also 429.
 
-**Model history** (Apr 2026): Gemma 3 free models delisted ~2026-04-15 (FFM-543), re-listed ~2026-04-20 and re-added to chain. `gemma-4-*:free` restored after earlier 403 issues (FFM-520).
+**Model history**: Gemma 3 free models delisted ~2026-04-15 (FFM-543), re-listed ~2026-04-20, then removed again by 2026-05-06. `gemma-4-*:free` restored after earlier 403 issues (FFM-520).
 
-### Available Free Vision Models (as of 2026-04-20)
+### Available Free Vision Models (as of 2026-05-06)
 
 | Model | Context | Notes |
 |-------|---------|-------|
 | `google/gemma-4-31b-it:free` | 262K | Primary |
 | `google/gemma-4-26b-a4b-it:free` | 262K | MoE variant fallback |
-| `google/gemma-3-27b-it:free` | 131K | Re-listed ~2026-04-20, restored as fallback |
-| `google/gemma-3-12b-it:free` | 32K | Re-listed ~2026-04-20, restored as fallback |
-| `google/gemma-3-4b-it:free` | 32K | Available but not used (4B too small for reliable JSON) |
-| `nvidia/nemotron-nano-12b-v2-vl:free` | 128K | **Removed** — returns 504s and invalid JSON/empty content |
+| `baidu/qianfan-ocr-fast:free` | Unknown | OCR-only fallback candidate, not used until quality is evaluated |
+| `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Unknown | Available but not used until JSON quality is evaluated |
+| `nvidia/nemotron-nano-12b-v2-vl:free` | 128K | Available but not used — returns 504s and invalid JSON/empty content |
 
 Check current availability: `curl https://openrouter.ai/api/v1/models | jq '.data[] | select(.id | endswith(":free")) | select(.architecture.modality | contains("image")) | .id'`
 

--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -45,13 +45,12 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 # lifetime purchases for 1,000 req/day (vs 50/day without).
 # See specs/describe-memes.md for full OpenRouter constraints.
 #
-# Verified available on OpenRouter API as of 2026-04-20.
-# Ordered by preference. Falls back to next model on 429/403/error.
+# Verified available on OpenRouter API as of 2026-05-06.
+# Ordered by preference. Falls back to next model on 403/error.
 VISION_MODELS = [
     "google/gemma-4-31b-it:free",  # 262k context, primary
     "google/gemma-4-26b-a4b-it:free",  # 262k context, MoE variant
-    "google/gemma-3-27b-it:free",  # 131k context, re-listed on OpenRouter ~2026-04-20
-    "google/gemma-3-12b-it:free",  # 32k context, re-listed on OpenRouter ~2026-04-20
+    # Gemma 3 free vision fallbacks were removed from OpenRouter by 2026-05-06.
     # nvidia/nemotron-nano-12b-v2-vl:free removed — returns 504s and invalid
     # JSON/empty content (see specs/describe-memes.md).
 ]

--- a/tests/agents/test_sync_config.py
+++ b/tests/agents/test_sync_config.py
@@ -1,0 +1,124 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_sync_config(monkeypatch):
+    monkeypatch.setenv("PAPERCLIP_URL", "https://paperclip.example")
+    monkeypatch.setenv("PAPERCLIP_API_KEY", "test-key")
+    monkeypatch.setenv("COMPANY_ID", "company-id")
+    monkeypatch.setenv("SCRIPT_DIR", str(Path("agents").resolve()))
+
+    module_path = Path("agents/_sync_config.py").resolve()
+    module_name = "_sync_config_for_test"
+    yaml_stub = types.ModuleType("yaml")
+    yaml_stub.safe_load = lambda _text: {}
+    monkeypatch.setitem(sys.modules, "yaml", yaml_stub)
+
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_target_env_bindings_resolve_plain_secret_and_missing_required(monkeypatch):
+    sync_config = load_sync_config(monkeypatch)
+
+    cur_env = {
+        "SENTRY_AUTH_TOKEN": {
+            "type": "secret_ref",
+            "secretId": "existing-token-secret",
+            "version": "latest",
+        },
+    }
+    target_inputs = {
+        "env": {
+            "OPENCLAW_SESSION": {"kind": "plain", "default": "1"},
+            "PREFECT_API_URL": {"kind": "secret", "requirement": "required"},
+            "SENTRY_AUTH_TOKEN": {"kind": "secret", "requirement": "required"},
+            "SENTRY_ORG": {"kind": "secret", "requirement": "required"},
+        }
+    }
+
+    bindings, missing = sync_config.target_env_bindings(
+        cur_env,
+        target_inputs,
+        {"PREFECT_API_URL": "prefect-secret"},
+    )
+
+    assert bindings == {
+        "OPENCLAW_SESSION": {"type": "plain", "value": "1"},
+        "PREFECT_API_URL": {
+            "type": "secret_ref",
+            "secretId": "prefect-secret",
+            "version": "latest",
+        },
+        "SENTRY_AUTH_TOKEN": {
+            "type": "secret_ref",
+            "secretId": "existing-token-secret",
+            "version": "latest",
+        },
+    }
+    assert missing == ["SENTRY_ORG"]
+
+
+def test_merged_adapter_env_preserves_runtime_only_keys(monkeypatch):
+    sync_config = load_sync_config(monkeypatch)
+
+    cur_env = {
+        "PATH": {"type": "plain", "value": "/paperclip/bin:/usr/bin"},
+        "PREFECT_API_URL": {
+            "type": "plain",
+            "value": "http://65.108.127.32:4200/api",
+        },
+    }
+    target_bindings = {
+        "PREFECT_API_URL": {
+            "type": "secret_ref",
+            "secretId": "prefect-secret",
+            "version": "latest",
+        }
+    }
+
+    merged = sync_config.merged_adapter_env(cur_env, target_bindings)
+
+    assert merged == {
+        "PATH": {"type": "plain", "value": "/paperclip/bin:/usr/bin"},
+        "PREFECT_API_URL": {
+            "type": "secret_ref",
+            "secretId": "prefect-secret",
+            "version": "latest",
+        },
+    }
+
+
+def test_adapter_env_changes_reports_added_and_changed_without_removing(monkeypatch):
+    sync_config = load_sync_config(monkeypatch)
+
+    cur_env = {
+        "PATH": {"type": "plain", "value": "/paperclip/bin:/usr/bin"},
+        "PREFECT_API_URL": {
+            "type": "plain",
+            "value": "http://65.108.127.32:4200/api",
+        },
+    }
+    target_bindings = {
+        "PREFECT_API_URL": {
+            "type": "secret_ref",
+            "secretId": "prefect-secret",
+            "version": "latest",
+        },
+        "SENTRY_ORG": {
+            "type": "secret_ref",
+            "secretId": "sentry-org-secret",
+            "version": "latest",
+        },
+    }
+
+    assert sync_config.adapter_env_changes(cur_env, target_bindings) == [
+        "+adapterConfig.env: ['SENTRY_ORG']",
+        "~adapterConfig.env: ['PREFECT_API_URL']",
+    ]

--- a/tests/storage/test_describe_memes_models.py
+++ b/tests/storage/test_describe_memes_models.py
@@ -1,0 +1,24 @@
+import ast
+from pathlib import Path
+
+
+def _vision_models() -> list[str]:
+    tree = ast.parse(Path("src/flows/storage/describe_memes.py").read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "VISION_MODELS":
+                    return ast.literal_eval(node.value)
+    raise AssertionError("VISION_MODELS assignment not found")
+
+
+def test_vision_models_are_free_only():
+    assert all(model.endswith(":free") for model in _vision_models())
+
+
+def test_removed_openrouter_vision_models_are_not_used():
+    models = _vision_models()
+
+    assert "google/gemma-3-27b-it:free" not in models
+    assert "google/gemma-3-12b-it:free" not in models
+    assert "nvidia/nemotron-nano-12b-v2-vl:free" not in models


### PR DESCRIPTION
Fixes [FFM-474](/FFM/issues/FFM-474).

## What changed
- Sync `.paperclip.yaml` `inputs.env` declarations into runtime `adapterConfig.env` bindings during agent deploy.
- Preserve existing runtime-only env keys while updating manifest-managed keys.
- Add QA `SENTRY_ORG` and move QA `PREFECT_API_URL` from the old firewalled `http://65.108.127.32:4200/api` default to a required Paperclip secret.
- Remove OpenRouter Gemma 3 free vision model IDs that now return 404 and update the Describe Memes spec.

## Root cause
- Paperclip agent env declarations in `.paperclip.yaml` were only portable metadata; `agents/_sync_config.py` never translated them into `adapterConfig.env`, so QA runtime config could stay stale.
- The QA Prefect URL was still the old direct port 4200 address in the repo manifest.
- OpenRouter no longer lists `google/gemma-3-27b-it:free` or `google/gemma-3-12b-it:free` as free vision models as of 2026-05-06.

## Verification
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `ruff check --fix agents/_sync_config.py && ruff format agents/_sync_config.py`
- `python3 -m pytest tests/agents/test_sync_config.py tests/storage/test_describe_memes_models.py -q`

## Remaining ops requirement
This PR cannot rotate secrets by itself. Current runtime probes still show:
- Sentry token returns 401 expired.
- `ANALYST_DATABASE_URL` fails password auth for `analyst_readonly`.

Before or immediately after merge, Paperclip company secrets need valid values for `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `ANALYST_DATABASE_URL`; otherwise QA will still report YELLOW/blocked even though deploy sync can now inject the right bindings.
