### PR TITLE
Fix: auto-snooze stale meme sources

### DIFF
--- a/scripts/serve_flows.py
+++ b/scripts/serve_flows.py
@@ -59,6 +59,7 @@ from src.flows.storage.memes import (
     tg_meme_pipeline,
     vk_meme_pipeline,
 )
+from src.flows.storage.source_health import auto_snooze_stale_sources_flow
 
 LON = "Europe/London"
 MSK = "Europe/Moscow"
@@ -104,6 +105,11 @@ if __name__ == "__main__":
         tg_meme_pipeline.to_deployment(name="TG Meme Pipeline"),
         vk_meme_pipeline.to_deployment(name="VK Meme Pipeline"),
         final_meme_pipeline.to_deployment(name="Final Meme Pipeline"),
+        # ── Source health (daily) ──
+        auto_snooze_stale_sources_flow.to_deployment(
+            name="Auto-snooze stale meme sources",
+            schedules=[CronSchedule(cron="15 1 * * *", timezone=LON)],
+        ),
         # ── Broadcasts ──
         broadcast_next_meme_to_active_15m_ago.to_deployment(
             name="Broadcast 15m",

--- a/src/flows/storage/source_health.py
+++ b/src/flows/storage/source_health.py
@@ -1,0 +1,62 @@
+import html
+import logging
+
+from prefect import flow
+
+from src.flows.hooks import notify_telegram_on_failure
+from src.storage.service import (
+    STALE_SOURCE_SNOOZE_AFTER_DAYS,
+    auto_snooze_stale_sources,
+)
+from src.tgbot.logs import log
+
+logger = logging.getLogger(__name__)
+
+
+def _format_snoozed_sources_alert(
+    sources: list[dict],
+    stale_after_days: int,
+) -> str:
+    sample_lines = []
+    for source in sources[:10]:
+        source_url = html.escape(str(source["url"]))
+        parsed_at = source["parsed_at"] or "never"
+        sample_lines.append(
+            f"- #{source['id']} {html.escape(source['type'])} "
+            f"<code>{source_url}</code> last_parse={html.escape(str(parsed_at))}"
+        )
+
+    sample = "\n".join(sample_lines)
+    return (
+        "🔕 Auto-snoozed stale meme sources\n"
+        f"Reason: <code>stale_no_raw_posts_7d</code>\n"
+        f"Rule: parsing_enabled, no successful parse/raw posts for {stale_after_days}+ days\n"
+        f"Count: {len(sources)}\n"
+        f"{sample}\n\n"
+        "Recovery: open the source admin card and set status to "
+        "<code>parsing_enabled</code>. TG/VK sources parse immediately after unsnooze; "
+        "Instagram currently has no active parser deployment."
+    )
+
+
+@flow(
+    name="Auto-snooze stale meme sources",
+    retries=1,
+    retry_delay_seconds=60,
+    timeout_seconds=300,
+    on_failure=[notify_telegram_on_failure],
+)
+async def auto_snooze_stale_sources_flow(
+    stale_after_days: int = STALE_SOURCE_SNOOZE_AFTER_DAYS,
+) -> dict:
+    snoozed_sources = await auto_snooze_stale_sources(stale_after_days=stale_after_days)
+    summary = {
+        "snoozed_count": len(snoozed_sources),
+        "source_ids": [source["id"] for source in snoozed_sources],
+    }
+
+    if snoozed_sources:
+        logger.warning("Auto-snoozed %d stale sources", len(snoozed_sources))
+        await log(_format_snoozed_sources_alert(snoozed_sources, stale_after_days))
+
+    return summary

--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -116,30 +116,47 @@ async def auto_snooze_stale_sources(
               )
             ORDER BY ms.parsed_at NULLS FIRST, ms.id
             LIMIT :limit
-        )
-        UPDATE meme_source ms
-        SET
-            status = 'snoozed',
-            data = COALESCE(ms.data, '{}'::jsonb) || jsonb_build_object(
-                'snoozed_reason',
-                'stale_no_raw_posts_7d',
-                'snoozed_at',
-                to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US'),
-                'stale_after_days',
-                :stale_after_days,
-                'stale_last_parsed_at',
-                stale_candidates.parsed_at,
-                'stale_last_raw_insert_at',
+        ),
+        updated_sources AS (
+            UPDATE meme_source ms
+            SET
+                status = 'snoozed',
+                data = COALESCE(ms.data, '{}'::jsonb) || jsonb_build_object(
+                    'snoozed_reason',
+                    'stale_no_raw_posts_7d',
+                    'snoozed_at',
+                    to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US'),
+                    'stale_after_days',
+                    :stale_after_days,
+                    'stale_last_parsed_at',
+                    stale_candidates.parsed_at,
+                    'stale_last_raw_insert_at',
+                    stale_candidates.last_raw_insert_at
+                )
+            FROM stale_candidates
+            WHERE ms.id = stale_candidates.id
+            RETURNING
+                ms.id,
+                ms.type,
+                ms.url,
+                ms.parsed_at,
                 stale_candidates.last_raw_insert_at
-            )
-        FROM stale_candidates
-        WHERE ms.id = stale_candidates.id
-        RETURNING
-            ms.id,
-            ms.type,
-            ms.url,
-            ms.parsed_at,
-            stale_candidates.last_raw_insert_at
+        ),
+        updated_memes AS (
+            UPDATE meme m
+            SET status = 'snoozed'
+            FROM updated_sources
+            WHERE m.meme_source_id = updated_sources.id
+              AND m.status = 'ok'
+            RETURNING m.id
+        )
+        SELECT
+            id,
+            type,
+            url,
+            parsed_at,
+            last_raw_insert_at
+        FROM updated_sources
         """
     )
     return await fetch_all(

--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -17,6 +17,8 @@ from src.storage.constants import (
     MemeStatus,
 )
 
+STALE_SOURCE_SNOOZE_AFTER_DAYS = 7
+
 
 async def get_telegram_sources_to_parse(limit=25) -> list[dict[str, Any]]:
     # Quality-weighted selection: best sources parse first.
@@ -58,6 +60,97 @@ async def update_meme_source(meme_source_id: int, **kwargs) -> dict[str, Any] | 
         .returning(meme_source)
     )
     return await fetch_one(update_query)
+
+
+async def auto_snooze_stale_sources(
+    stale_after_days: int = STALE_SOURCE_SNOOZE_AFTER_DAYS,
+    limit: int = 50,
+    meme_source_ids: list[int] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Snooze parsing-enabled sources that have produced no raw posts for a full stale window.
+
+    This catches sources that no longer reach maybe_auto_snooze_source because the
+    parser is gone, disabled, or failing before parsed_at can advance. The 7-day
+    floor keeps one quiet day from snoozing a valid low-volume source.
+    """
+    query = text(
+        """
+        WITH raw_activity AS (
+            SELECT
+                meme_source_id,
+                MAX(created_at) AS last_raw_insert_at
+            FROM (
+                SELECT meme_source_id, created_at FROM meme_raw_telegram
+                UNION ALL
+                SELECT meme_source_id, created_at FROM meme_raw_vk
+                UNION ALL
+                SELECT meme_source_id, created_at FROM meme_raw_ig
+            ) raw_posts
+            GROUP BY meme_source_id
+        ),
+        stale_candidates AS (
+            SELECT
+                ms.id,
+                ms.type,
+                ms.url,
+                ms.parsed_at,
+                raw_activity.last_raw_insert_at
+            FROM meme_source ms
+            LEFT JOIN raw_activity
+                ON raw_activity.meme_source_id = ms.id
+            WHERE ms.status = 'parsing_enabled'
+              AND (
+                  NOT :filter_meme_source_ids
+                  OR ms.id = ANY(:meme_source_ids)
+              )
+              AND ms.created_at < NOW() - make_interval(days => :stale_after_days)
+              AND (
+                  ms.parsed_at IS NULL
+                  OR ms.parsed_at < NOW() - make_interval(days => :stale_after_days)
+              )
+              AND (
+                  raw_activity.last_raw_insert_at IS NULL
+                  OR raw_activity.last_raw_insert_at
+                      < NOW() - make_interval(days => :stale_after_days)
+              )
+            ORDER BY ms.parsed_at NULLS FIRST, ms.id
+            LIMIT :limit
+        )
+        UPDATE meme_source ms
+        SET
+            status = 'snoozed',
+            data = COALESCE(ms.data, '{}'::jsonb) || jsonb_build_object(
+                'snoozed_reason',
+                'stale_no_raw_posts_7d',
+                'snoozed_at',
+                to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US'),
+                'stale_after_days',
+                :stale_after_days,
+                'stale_last_parsed_at',
+                stale_candidates.parsed_at,
+                'stale_last_raw_insert_at',
+                stale_candidates.last_raw_insert_at
+            )
+        FROM stale_candidates
+        WHERE ms.id = stale_candidates.id
+        RETURNING
+            ms.id,
+            ms.type,
+            ms.url,
+            ms.parsed_at,
+            stale_candidates.last_raw_insert_at
+        """
+    )
+    return await fetch_all(
+        query,
+        {
+            "stale_after_days": int(stale_after_days),
+            "limit": int(limit),
+            "filter_meme_source_ids": meme_source_ids is not None,
+            "meme_source_ids": meme_source_ids or [],
+        },
+    )
 
 
 async def maybe_auto_snooze_source(

--- a/tests/test_auto_snooze.py
+++ b/tests/test_auto_snooze.py
@@ -4,11 +4,12 @@ from datetime import datetime, timedelta
 
 import pytest
 import pytest_asyncio
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
-from src.database import engine, fetch_one, meme_source
-from src.storage.constants import MemeSourceStatus
-from src.storage.service import maybe_auto_snooze_source
+from src.database import engine, fetch_one, meme_raw_telegram, meme_source
+from src.storage.constants import MemeSourceStatus, MemeSourceType
+from src.storage.service import auto_snooze_stale_sources, maybe_auto_snooze_source
 from tests.factories import (
     TEST_ID_START,
     cleanup_test_data,
@@ -26,6 +27,31 @@ async def conn():
 
 
 SOURCE_ID = TEST_ID_START + 500
+STALE_INSTAGRAM_SOURCE_ID = TEST_ID_START + 501
+RECENT_TELEGRAM_SOURCE_ID = TEST_ID_START + 502
+RAW_ACTIVE_SOURCE_ID = TEST_ID_START + 503
+
+# Recent timestamp inside the 7d rolling window. Factory default FIXED_DT (2024-06-01)
+# is outside the window, so tests for time-based criteria must pass an explicit recent
+# created_at/parsed_at.
+RECENT = datetime.utcnow() - timedelta(hours=1)
+
+
+async def _insert_recent_raw_telegram(conn: AsyncConnection, source_id: int) -> None:
+    await conn.execute(
+        insert(meme_raw_telegram).values(
+            {
+                "meme_source_id": source_id,
+                "post_id": source_id,
+                "url": f"https://t.me/test_source_{source_id}/{source_id}",
+                "date": RECENT,
+                "content": "recent raw post",
+                "media": [],
+                "views": 1,
+                "created_at": RECENT,
+            }
+        )
+    )
 
 
 @pytest.mark.asyncio
@@ -160,11 +186,71 @@ async def test_already_snoozed_source_skipped(conn: AsyncConnection):
     assert result is None
 
 
-# Criterion 3: rolling 7d ad_rate > 30% with min 30 processed memes (FFM-847).
+@pytest.mark.asyncio
+async def test_auto_snooze_stale_source_without_recent_raw_posts(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=STALE_INSTAGRAM_SOURCE_ID,
+        type=MemeSourceType.INSTAGRAM.value,
+        status="parsing_enabled",
+    )
+    await conn.commit()
 
-# Recent timestamp inside the 7d rolling window. Factory default FIXED_DT (2024-06-01)
-# is outside the window, so tests for criterion 3 must pass an explicit recent created_at.
-RECENT = datetime.utcnow() - timedelta(hours=1)
+    result = await auto_snooze_stale_sources(meme_source_ids=[STALE_INSTAGRAM_SOURCE_ID])
+
+    assert [source["id"] for source in result] == [STALE_INSTAGRAM_SOURCE_ID]
+    source = await fetch_one(
+        meme_source.select().where(meme_source.c.id == STALE_INSTAGRAM_SOURCE_ID)
+    )
+    assert source["status"] == MemeSourceStatus.SNOOZED.value
+    assert source["data"]["snoozed_reason"] == "stale_no_raw_posts_7d"
+    assert source["data"]["stale_after_days"] == 7
+    assert "snoozed_at" in source["data"]
+
+
+@pytest.mark.asyncio
+async def test_no_stale_snooze_for_recently_parsed_source(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=RECENT_TELEGRAM_SOURCE_ID,
+        type=MemeSourceType.TELEGRAM.value,
+        status="parsing_enabled",
+    )
+    await conn.execute(
+        meme_source.update()
+        .where(meme_source.c.id == RECENT_TELEGRAM_SOURCE_ID)
+        .values(parsed_at=RECENT)
+    )
+    await conn.commit()
+
+    result = await auto_snooze_stale_sources(meme_source_ids=[RECENT_TELEGRAM_SOURCE_ID])
+
+    assert result == []
+    source = await fetch_one(
+        meme_source.select().where(meme_source.c.id == RECENT_TELEGRAM_SOURCE_ID)
+    )
+    assert source["status"] == MemeSourceStatus.PARSING_ENABLED.value
+
+
+@pytest.mark.asyncio
+async def test_no_stale_snooze_when_source_has_recent_raw_posts(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=RAW_ACTIVE_SOURCE_ID,
+        type=MemeSourceType.TELEGRAM.value,
+        status="parsing_enabled",
+    )
+    await _insert_recent_raw_telegram(conn, RAW_ACTIVE_SOURCE_ID)
+    await conn.commit()
+
+    result = await auto_snooze_stale_sources(meme_source_ids=[RAW_ACTIVE_SOURCE_ID])
+
+    assert result == []
+    source = await fetch_one(meme_source.select().where(meme_source.c.id == RAW_ACTIVE_SOURCE_ID))
+    assert source["status"] == MemeSourceStatus.PARSING_ENABLED.value
+
+
+# Criterion 3: rolling 7d ad_rate > 30% with min 30 processed memes (FFM-847).
 
 
 async def _seed_memes(

--- a/tests/test_auto_snooze.py
+++ b/tests/test_auto_snooze.py
@@ -7,8 +7,8 @@ import pytest_asyncio
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
-from src.database import engine, fetch_one, meme_raw_telegram, meme_source
-from src.storage.constants import MemeSourceStatus, MemeSourceType
+from src.database import engine, fetch_one, meme, meme_raw_telegram, meme_source
+from src.storage.constants import MemeSourceStatus, MemeSourceType, MemeStatus
 from src.storage.service import auto_snooze_stale_sources, maybe_auto_snooze_source
 from tests.factories import (
     TEST_ID_START,
@@ -30,6 +30,7 @@ SOURCE_ID = TEST_ID_START + 500
 STALE_INSTAGRAM_SOURCE_ID = TEST_ID_START + 501
 RECENT_TELEGRAM_SOURCE_ID = TEST_ID_START + 502
 RAW_ACTIVE_SOURCE_ID = TEST_ID_START + 503
+STALE_SOURCE_MEME_ID = TEST_ID_START + 1501
 
 # Recent timestamp inside the 7d rolling window. Factory default FIXED_DT (2024-06-01)
 # is outside the window, so tests for time-based criteria must pass an explicit recent
@@ -206,6 +207,29 @@ async def test_auto_snooze_stale_source_without_recent_raw_posts(conn: AsyncConn
     assert source["data"]["snoozed_reason"] == "stale_no_raw_posts_7d"
     assert source["data"]["stale_after_days"] == 7
     assert "snoozed_at" in source["data"]
+
+
+@pytest.mark.asyncio
+async def test_auto_snooze_stale_source_snoozes_existing_ok_memes(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=STALE_INSTAGRAM_SOURCE_ID,
+        type=MemeSourceType.INSTAGRAM.value,
+        status="parsing_enabled",
+    )
+    await create_meme(
+        conn,
+        id=STALE_SOURCE_MEME_ID,
+        meme_source_id=STALE_INSTAGRAM_SOURCE_ID,
+        status=MemeStatus.OK.value,
+    )
+    await conn.commit()
+
+    result = await auto_snooze_stale_sources(meme_source_ids=[STALE_INSTAGRAM_SOURCE_ID])
+
+    assert [source["id"] for source in result] == [STALE_INSTAGRAM_SOURCE_ID]
+    stored_meme = await fetch_one(meme.select().where(meme.c.id == STALE_SOURCE_MEME_ID))
+    assert stored_meme["status"] == MemeStatus.SNOOZED.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes FFM-1016.

## What changed

- Adds a daily Prefect source-health deployment: `Auto-snooze stale meme sources`.
- Snoozes `parsing_enabled` sources only when all conservative gates match:
  - source is older than 7 days,
  - `parsed_at` is missing or older than 7 days,
  - no raw Telegram/VK/Instagram posts were inserted in the last 7 days.
- Writes an audit trail into `meme_source.data` with `snoozed_reason=stale_no_raw_posts_7d`, `snoozed_at`, `stale_after_days`, `stale_last_parsed_at`, and `stale_last_raw_insert_at`.
- Sends an admin-chat alert listing snoozed source ids/URLs and the recovery path.

## Production audit evidence

Read-only production query on 2026-05-07 found:

- `parsing_enabled` total: 131
- stale `>24h`: 11
- stale `>48h`: 11
- stale `>7d`: 11
- existing `consecutive_empty_parses >= 3`: 0

All 11 stale sources are Instagram sources last parsed April 22-24, 2026, with no raw posts in 24h/48h/7d and zero `consecutive_empty_parses`. The active scheduler currently serves Telegram and VK parsers only; Instagram parser code/deployment was removed earlier, so these sources never reach the per-parse FFM-791 auto-snooze hook.

Dry-run of the new predicate matched exactly those 11 source ids: 194, 192, 173, 168, 202, 169, 166, 171, 167, 165, 189.

## Manual recovery path

Moderators can open the source admin card and set status back to `parsing_enabled`. For Telegram/VK sources, the existing handler triggers an immediate parse after unsnooze. Instagram currently has no active parser deployment, so Instagram recovery requires reinstating a parser before re-enabling the source.

## Verification

- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `python3 -m pytest tests/test_auto_snooze.py --collect-only -q` with CI-style dummy env: 20 tests collected
- Production read-only dry-run of the new predicate: 11 candidates, matching the audited stale cohort

Full integration test execution was not run in this workspace because Docker/Compose is unavailable and the heartbeat env does not provide a local Postgres/Redis test stack. I did not run write tests against production DB credentials.
