### PR TITLE
Fix: handle chat agent max turns fallback

### DIFF
--- a/src/tgbot/handlers/chat/agent/runner.py
+++ b/src/tgbot/handlers/chat/agent/runner.py
@@ -4,6 +4,7 @@ import time
 from dataclasses import dataclass
 
 from agents import Agent, OpenAIChatCompletionsModel, Runner, set_tracing_export_api_key
+from agents.exceptions import MaxTurnsExceeded
 from openai import AsyncOpenAI
 from sqlalchemy import text
 
@@ -100,6 +101,14 @@ async def run_chat_agent(
             context=ctx,
             max_turns=MAX_TURNS,
         )
+    except MaxTurnsExceeded as e:
+        logger.warning(
+            "Chat agent hit max turns in chat %s after %s turns: %s",
+            chat_id,
+            MAX_TURNS,
+            e,
+        )
+        return None
     except Exception as e:
         logger.error("Agent SDK error in chat %s: %s", chat_id, e, exc_info=True)
         return None

--- a/tests/tgbot/test_chat_agent_runner.py
+++ b/tests/tgbot/test_chat_agent_runner.py
@@ -1,0 +1,34 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from agents.exceptions import MaxTurnsExceeded
+
+from src.tgbot.handlers.chat.agent import runner
+
+
+@pytest.mark.asyncio
+async def test_run_chat_agent_handles_max_turns_as_fallback(monkeypatch):
+    monkeypatch.setattr(runner.settings, "DEEPSEEK_API_KEY", "test-key")
+    monkeypatch.setattr(runner, "get_latest_chat_messages", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner, "_messages_to_text", MagicMock(return_value="user: ff memes?"))
+    monkeypatch.setattr(runner, "get_tools", MagicMock(return_value=[]))
+    monkeypatch.setattr(
+        runner.Runner,
+        "run",
+        AsyncMock(side_effect=MaxTurnsExceeded("Max turns exceeded")),
+    )
+    warning = MagicMock()
+    error = MagicMock()
+    monkeypatch.setattr(runner.logger, "warning", warning)
+    monkeypatch.setattr(runner.logger, "error", error)
+
+    response = await runner.run_chat_agent(
+        bot=object(),
+        chat_id=123,
+        user_id=456,
+        reply_to_message_id=789,
+    )
+
+    assert response is None
+    warning.assert_called_once()
+    error.assert_not_called()


### PR DESCRIPTION
Fixes FFM-1026.

## What
- Catches `agents.exceptions.MaxTurnsExceeded` explicitly in the chat agent runner.
- Logs max-turn exhaustion as a warning instead of `logger.error(..., exc_info=True)`.
- Keeps existing user behavior: `run_chat_agent()` returns `None`, so `handle_agent_trigger()` sends the fallback meme.
- Adds a regression test that verifies max-turn exhaustion does not hit the error logger.

## Why
`MaxTurnsExceeded` is the OpenAI Agents SDK circuit breaker for a tool-call loop that fails to finish inside `MAX_TURNS=5`. The app already had a fallback path, but the generic SDK exception handler logged this expected circuit-breaker path as an error with traceback, creating a Sentry incident instead of treating it as graceful fallback.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `PYTHONPATH=/tmp/openai_agents_04 DATABASE_URL=postgresql+asyncpg://test:test@localhost:5432/test REDIS_URL=redis://localhost:6379/0 CORS_ORIGINS='["*"]' CORS_HEADERS='["*"]' python3 -m pytest tests/tgbot/test_chat_agent_runner.py -q`

QA note: after deploy, verify a group-chat mention that causes agent fallback still replies with a meme and does not create a new Sentry issue for `MaxTurnsExceeded`.
