### PR TITLE
Fix: return chat agent max turns message

### DIFF
--- a/src/tgbot/handlers/chat/agent/runner.py
+++ b/src/tgbot/handlers/chat/agent/runner.py
@@ -18,6 +18,7 @@ from src.tgbot.handlers.chat.service import get_latest_chat_messages
 logger = logging.getLogger(__name__)
 
 MAX_TURNS = 5
+MAX_TURNS_FALLBACK_RESPONSE = "Слишком сложный вопрос, попробуй переформулировать покороче."
 
 # DSML cleanup: DeepSeek sometimes leaks internal XML as plain text
 _DSML_RE = re.compile(r"<[｜\|]DSML[｜\|].*?</[｜\|]DSML[｜\|]\w+>", re.DOTALL)
@@ -108,7 +109,7 @@ async def run_chat_agent(
             MAX_TURNS,
             e,
         )
-        return None
+        return MAX_TURNS_FALLBACK_RESPONSE
     except Exception as e:
         logger.error("Agent SDK error in chat %s: %s", chat_id, e, exc_info=True)
         return None

--- a/tests/tgbot/test_chat_agent_runner.py
+++ b/tests/tgbot/test_chat_agent_runner.py
@@ -29,6 +29,6 @@ async def test_run_chat_agent_handles_max_turns_as_fallback(monkeypatch):
         reply_to_message_id=789,
     )
 
-    assert response is None
+    assert response == runner.MAX_TURNS_FALLBACK_RESPONSE
     warning.assert_called_once()
     error.assert_not_called()


### PR DESCRIPTION
Fixes FFM-1031.

## What changed
- Returns a deterministic Russian fallback text when the OpenAI Agents SDK raises `MaxTurnsExceeded`.
- Updates the runner regression test so max-turn exhaustion must produce a user-visible reply instead of `None`.

## Why
The current production catch logs `MaxTurnsExceeded` but returns `None`, which sends the caller through a meme fallback path that can no-op when no eligible meme is found. This keeps the user from seeing a silent drop for tool-heavy chats.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `python3 -m pytest tests/tgbot/test_chat_agent_runner.py -q` attempted locally; blocked because host Python 3.13 lacks `agents.exceptions` from the repo dependency stack.
- Docker verification attempted; blocked because `docker` is not installed in this execution environment.

## QA notes
After deploy, trigger @ffmemesbot with a tool-heavy/complex prompt and confirm it replies with fallback text rather than staying silent when the SDK hits max turns.