### PR TITLE
Fix: match wrapped asyncpg transient errors

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -27,7 +27,6 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -81,19 +80,40 @@ def _mark_bad_connection_as_disconnect(context: object) -> None:
     it is never handed out again.
     """
     original = getattr(context, "original_exception", None)
-    if original is not None and type(original).__name__ in (
-        "ConnectionDoesNotExistError",
-        "InternalClientError",
+    if original is not None and (
+        _has_exception_named(original, "ConnectionDoesNotExistError")
+        or _is_concurrent_use_error(original)
     ):
         context.is_disconnect = True  # type: ignore[union-attr]
 
 
+def _walk_exception_chain(exc: BaseException) -> list[BaseException]:
+    """Return SQLAlchemy + asyncpg wrapper exceptions without looping forever."""
+    chain: list[BaseException] = []
+    stack: list[BaseException] = [exc]
+    seen: set[int] = set()
+
+    while stack:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        chain.append(current)
+
+        for attr in ("orig", "__cause__", "__context__"):
+            nested = getattr(current, attr, None)
+            if isinstance(nested, BaseException):
+                stack.append(nested)
+
+    return chain
+
+
+def _has_exception_named(exc: BaseException, name: str) -> bool:
+    return any(type(current).__name__ == name for current in _walk_exception_chain(exc))
+
+
 def _is_stale_connection_error(exc: BaseException) -> bool:
-    return (
-        isinstance(exc, DBAPIError)
-        and exc.__cause__ is not None
-        and type(exc.__cause__).__name__ == "ConnectionDoesNotExistError"
-    )
+    return _has_exception_named(exc, "ConnectionDoesNotExistError")
 
 
 def _is_concurrent_use_error(exc: BaseException) -> bool:
@@ -104,11 +124,13 @@ def _is_concurrent_use_error(exc: BaseException) -> bool:
     InternalClientError("cannot switch to state …; another operation … is in
     progress").  Retrying with a fresh connection resolves the issue.
     """
-    return (
-        isinstance(exc, DBAPIError)
-        and exc.__cause__ is not None
-        and type(exc.__cause__).__name__ == "InternalClientError"
-    )
+    for current in _walk_exception_chain(exc):
+        if type(current).__name__ != "InternalClientError":
+            continue
+        message = str(current)
+        if "another operation" in message and "in progress" in message:
+            return True
+    return False
 
 
 def _is_deadlock_error(exc: BaseException) -> bool:
@@ -118,11 +140,7 @@ def _is_deadlock_error(exc: BaseException) -> bool:
     automatically.  Retrying the statement (with a small backoff to let the
     winning transaction finish) is the standard resolution per PG docs.
     """
-    return (
-        isinstance(exc, DBAPIError)
-        and exc.__cause__ is not None
-        and type(exc.__cause__).__name__ == "DeadlockDetectedError"
-    )
+    return _has_exception_named(exc, "DeadlockDetectedError")
 
 
 metadata = MetaData(naming_convention=DB_NAMING_CONVENTION)

--- a/tests/test_database_transient_errors.py
+++ b/tests/test_database_transient_errors.py
@@ -1,0 +1,72 @@
+import asyncpg
+from sqlalchemy.dialects.postgresql.asyncpg import AsyncAdapt_asyncpg_dbapi
+from sqlalchemy.exc import DBAPIError
+
+from src import database
+
+
+def _dbapi_error_wrapping(exc: BaseException) -> DBAPIError:
+    translated = AsyncAdapt_asyncpg_dbapi.Error(f"{type(exc)}: {exc}")
+    try:
+        raise translated from exc
+    except Exception as wrapped:
+        return DBAPIError.instance(
+            "SELECT 1",
+            {},
+            wrapped,
+            Exception,
+            connection_invalidated=False,
+            dialect=None,
+        )
+
+
+def test_stale_connection_error_matches_sqlalchemy_asyncpg_wrapper() -> None:
+    exc = _dbapi_error_wrapping(asyncpg.exceptions.ConnectionDoesNotExistError("connection gone"))
+
+    assert database._is_stale_connection_error(exc)
+
+
+def test_concurrent_use_error_matches_raw_asyncpg_internal_client_error() -> None:
+    exc = asyncpg.exceptions.InternalClientError(
+        "cannot switch to state 15; another operation (2) is in progress"
+    )
+
+    assert database._is_concurrent_use_error(exc)
+
+
+def test_concurrent_use_error_matches_sqlalchemy_asyncpg_wrapper() -> None:
+    exc = _dbapi_error_wrapping(
+        asyncpg.exceptions.InternalClientError(
+            "cannot switch to state 15; another operation (2) is in progress"
+        )
+    )
+
+    assert database._is_concurrent_use_error(exc)
+
+
+def test_internal_client_error_without_concurrent_operation_is_not_transient() -> None:
+    exc = asyncpg.exceptions.InternalClientError("unexpected protocol state")
+
+    assert not database._is_concurrent_use_error(exc)
+
+
+def test_deadlock_error_matches_sqlalchemy_asyncpg_wrapper() -> None:
+    exc = _dbapi_error_wrapping(asyncpg.exceptions.DeadlockDetectedError("deadlock detected"))
+
+    assert database._is_deadlock_error(exc)
+
+
+def test_handle_error_marks_wrapped_concurrent_use_as_disconnect() -> None:
+    class Context:
+        original_exception = _dbapi_error_wrapping(
+            asyncpg.exceptions.InternalClientError(
+                "cannot switch to state 15; another operation (2) is in progress"
+            )
+        )
+        is_disconnect = False
+
+    context = Context()
+
+    database._mark_bad_connection_as_disconnect(context)
+
+    assert context.is_disconnect


### PR DESCRIPTION
Fixes FFM-1038.

## What changed

- Make DB transient-error classification walk SQLAlchemy/asyncpg exception chains via `orig`, `__cause__`, and `__context__`.
- Mark wrapped asyncpg concurrent-use failures as disconnects so the pool discards the dirty connection.
- Keep `InternalClientError` retry narrow: only the `another operation ... in progress` state-machine error is treated as transient.
- Add regression tests for raw asyncpg errors, SQLAlchemy adapter-wrapped errors, deadlocks, stale connections, and the `handle_error` disconnect hook.

## Root cause

The existing retry code only checked `DBAPIError.__cause__`. In SQLAlchemy 2.0.48 with asyncpg, wrapped asyncpg errors can sit at `DBAPIError.orig.__cause__`, and `InternalClientError` can also surface as the raw asyncpg exception. That means the production retry/disconnect path missed the Sentry shape and let the recurring `/tgbot/webhook` error escape.

Evidence from local reproduction:

```text
old_classifier_for_wrapped_internal_client_error= False
new_classifier_for_wrapped_internal_client_error= True
dbapi_exc.__cause__= None
dbapi_exc.orig.__cause__ type= InternalClientError
```

## Verification

- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `DATABASE_URL=postgresql+asyncpg://app:app@app_db:5432/app REDIS_URL=redis://localhost:6379 CORS_ORIGINS='["http://localhost:3000"]' CORS_HEADERS='["*"]' ENVIRONMENT=TESTING python3 -m pytest tests/test_database_transient_errors.py -q`

Result: `6 passed`.

Note: plain pytest collection in this workspace does not load `pytest.ini` env values because `pytest-env` is not installed, so the targeted command exports the required config explicitly.
