### PR TITLE
Experiment: mature recently_liked blender A/B

### DIFF
--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -14,7 +14,68 @@ from src.recommendations.candidates import (
 from src.recommendations.utils import exclude_meme_ids_sql_filter
 from src.storage.schemas import MemeData
 from src.tgbot.constants import UserType
+from src.tgbot.service import assign_experiment, get_experiment_variant
 from src.tgbot.user_info import get_user_info
+
+RECENTLY_LIKED_BLENDER_EXPERIMENT_ID = "recently_liked_blender_mature_v1"
+RECENTLY_LIKED_BLENDER_CONTROL = "control"
+RECENTLY_LIKED_BLENDER_TREATMENT = "treatment"
+
+MATURE_BLENDER_CONTROL_WEIGHTS = {
+    "best_uploaded_memes": 0.3,
+    "like_spread_and_recent_memes": 0.3,
+    "lr_smoothed": 0.4,
+    "recently_liked": 0.2,
+    "goat": 0.1,
+    "es_ranked": 0.1,
+}
+MATURE_BLENDER_TREATMENT_WEIGHTS = {
+    "best_uploaded_memes": 0.3,
+    "like_spread_and_recent_memes": 0.25,
+    "lr_smoothed": 0.35,
+    "recently_liked": 0.3,
+    "goat": 0.1,
+    "es_ranked": 0.1,
+}
+
+
+async def get_or_assign_recently_liked_blender_variant(user_id: int) -> str:
+    variant = await get_experiment_variant(user_id, RECENTLY_LIKED_BLENDER_EXPERIMENT_ID)
+    if variant is not None:
+        return variant
+
+    proposed = (
+        RECENTLY_LIKED_BLENDER_TREATMENT if user_id % 2 == 0 else RECENTLY_LIKED_BLENDER_CONTROL
+    )
+    inserted = await assign_experiment(
+        user_id,
+        RECENTLY_LIKED_BLENDER_EXPERIMENT_ID,
+        proposed,
+    )
+    if inserted:
+        return proposed
+
+    return (
+        await get_experiment_variant(user_id, RECENTLY_LIKED_BLENDER_EXPERIMENT_ID)
+        or RECENTLY_LIKED_BLENDER_CONTROL
+    )
+
+
+async def get_recently_liked_blender_weights(user_id: int) -> dict[str, float]:
+    try:
+        variant = await get_or_assign_recently_liked_blender_variant(user_id)
+    except Exception:
+        logging.warning(
+            "recently_liked blender assignment failed for user %d",
+            user_id,
+            exc_info=True,
+        )
+        return dict(MATURE_BLENDER_CONTROL_WEIGHTS)
+
+    if variant == RECENTLY_LIKED_BLENDER_TREATMENT:
+        return dict(MATURE_BLENDER_TREATMENT_WEIGHTS)
+
+    return dict(MATURE_BLENDER_CONTROL_WEIGHTS)
 
 
 async def get_next_meme_for_user(user_id: int) -> MemeData | None:
@@ -216,14 +277,7 @@ async def generate_recommendations(
             return blend(candidates_dict, weights, fixed_pos, limit, random_seed)
 
         # >=100
-        weights = {
-            "best_uploaded_memes": 0.3,
-            "like_spread_and_recent_memes": 0.3,
-            "lr_smoothed": 0.4,
-            "recently_liked": 0.2,
-            "goat": 0.1,
-            "es_ranked": 0.1,
-        }
+        weights = await get_recently_liked_blender_weights(user_id)
 
         candidates_dict = await retriever.get_candidates_dict(
             weights.keys(), user_id, limit, exclude_mem_ids=meme_ids_in_queue

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -4,7 +4,16 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from src.recommendations.candidates import CandidatesRetriever
-from src.recommendations.meme_queue import generate_recommendations
+from src.recommendations.meme_queue import (
+    MATURE_BLENDER_CONTROL_WEIGHTS,
+    MATURE_BLENDER_TREATMENT_WEIGHTS,
+    RECENTLY_LIKED_BLENDER_CONTROL,
+    RECENTLY_LIKED_BLENDER_EXPERIMENT_ID,
+    RECENTLY_LIKED_BLENDER_TREATMENT,
+    generate_recommendations,
+    get_or_assign_recently_liked_blender_variant,
+    get_recently_liked_blender_weights,
+)
 
 TEST_USER_ID = 99999
 
@@ -288,12 +297,205 @@ async def test_generate_above_100():
             "es_ranked": es_ranked,
         }
 
-    candidates = await generate_recommendations(
-        TEST_USER_ID, 10, 200, TestRetriever(), random_seed=102
-    )
+    with patch(
+        "src.recommendations.meme_queue.get_or_assign_recently_liked_blender_variant",
+        new_callable=AsyncMock,
+        return_value=RECENTLY_LIKED_BLENDER_CONTROL,
+    ):
+        candidates = await generate_recommendations(
+            TEST_USER_ID, 10, 200, TestRetriever(), random_seed=102
+        )
     assert len(candidates) == 10
     # lr_smoothed is pinned at position 0
     assert candidates[0]["id"] in [7, 8, 9, 10]
+
+
+@pytest.mark.asyncio
+async def test_generate_above_100_treatment_uses_recently_liked_weights():
+    captured_weights = None
+
+    async def best_uploaded_memes(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 1}]
+
+    async def like_spread_and_recent_memes(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 2}]
+
+    async def get_lr_smoothed(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 3}]
+
+    async def get_recently_liked(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 4}]
+
+    async def goat(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 5}]
+
+    async def es_ranked(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 6}]
+
+    def capture_blend(candidates_dict, weights_dict, fixed_pos=None, limit=0, random_seed=None):
+        nonlocal captured_weights
+        captured_weights = weights_dict
+        return [{"id": 4, "recommended_by": "recently_liked"}]
+
+    class TestRetriever(CandidatesRetriever):
+        engine_map = {
+            "best_uploaded_memes": best_uploaded_memes,
+            "like_spread_and_recent_memes": like_spread_and_recent_memes,
+            "lr_smoothed": get_lr_smoothed,
+            "recently_liked": get_recently_liked,
+            "goat": goat,
+            "es_ranked": es_ranked,
+        }
+
+    with (
+        patch(
+            "src.recommendations.meme_queue.get_or_assign_recently_liked_blender_variant",
+            new_callable=AsyncMock,
+            return_value=RECENTLY_LIKED_BLENDER_TREATMENT,
+        ) as assign_variant,
+        patch("src.recommendations.meme_queue.blend", side_effect=capture_blend),
+    ):
+        candidates = await generate_recommendations(
+            TEST_USER_ID, 10, 200, TestRetriever(), random_seed=102
+        )
+
+    assert candidates == [{"id": 4, "recommended_by": "recently_liked"}]
+    assert captured_weights == MATURE_BLENDER_TREATMENT_WEIGHTS
+    assign_variant.assert_awaited_once_with(TEST_USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_assignment_is_mature_only():
+    async def empty(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return []
+
+    class TestRetriever(CandidatesRetriever):
+        engine_map = {
+            "best_uploaded_memes": empty,
+            "like_spread_and_recent_memes": empty,
+            "lr_smoothed": empty,
+            "recently_liked": empty,
+            "goat": empty,
+            "es_ranked": empty,
+            "cold_start_explore": empty,
+            "cold_start_adapt": empty,
+        }
+
+    with patch(
+        "src.recommendations.meme_queue.get_or_assign_recently_liked_blender_variant",
+        new_callable=AsyncMock,
+        return_value=RECENTLY_LIKED_BLENDER_TREATMENT,
+    ) as assign_variant:
+        await generate_recommendations(TEST_USER_ID, 10, 29, TestRetriever())
+        await generate_recommendations(TEST_USER_ID, 10, 99, TestRetriever())
+
+    assign_variant.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_existing_recently_liked_blender_assignment_wins():
+    with patch(
+        "src.recommendations.meme_queue.get_experiment_variant",
+        new_callable=AsyncMock,
+        return_value=RECENTLY_LIKED_BLENDER_TREATMENT,
+    ) as get_variant:
+        variant = await get_or_assign_recently_liked_blender_variant(101)
+
+    assert variant == RECENTLY_LIKED_BLENDER_TREATMENT
+    get_variant.assert_awaited_once_with(101, RECENTLY_LIKED_BLENDER_EXPERIMENT_ID)
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_even_user_gets_treatment():
+    with (
+        patch(
+            "src.recommendations.meme_queue.get_experiment_variant",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "src.recommendations.meme_queue.assign_experiment",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as assign,
+    ):
+        variant = await get_or_assign_recently_liked_blender_variant(100)
+
+    assert variant == RECENTLY_LIKED_BLENDER_TREATMENT
+    assign.assert_awaited_once_with(
+        100,
+        RECENTLY_LIKED_BLENDER_EXPERIMENT_ID,
+        RECENTLY_LIKED_BLENDER_TREATMENT,
+    )
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_odd_user_gets_control():
+    with (
+        patch(
+            "src.recommendations.meme_queue.get_experiment_variant",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "src.recommendations.meme_queue.assign_experiment",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as assign,
+    ):
+        variant = await get_or_assign_recently_liked_blender_variant(101)
+
+    assert variant == RECENTLY_LIKED_BLENDER_CONTROL
+    assign.assert_awaited_once_with(
+        101,
+        RECENTLY_LIKED_BLENDER_EXPERIMENT_ID,
+        RECENTLY_LIKED_BLENDER_CONTROL,
+    )
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_race_rereads_winning_assignment():
+    with (
+        patch(
+            "src.recommendations.meme_queue.get_experiment_variant",
+            new_callable=AsyncMock,
+            side_effect=[None, RECENTLY_LIKED_BLENDER_CONTROL],
+        ),
+        patch(
+            "src.recommendations.meme_queue.assign_experiment",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        variant = await get_or_assign_recently_liked_blender_variant(100)
+
+    assert variant == RECENTLY_LIKED_BLENDER_CONTROL
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_weights_fall_back_to_control_on_assignment_error():
+    with patch(
+        "src.recommendations.meme_queue.get_or_assign_recently_liked_blender_variant",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("assignment unavailable"),
+    ):
+        weights = await get_recently_liked_blender_weights(100)
+
+    assert weights == MATURE_BLENDER_CONTROL_WEIGHTS
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_treatment_increases_recently_liked_weight():
+    with patch(
+        "src.recommendations.meme_queue.get_or_assign_recently_liked_blender_variant",
+        new_callable=AsyncMock,
+        return_value=RECENTLY_LIKED_BLENDER_TREATMENT,
+    ):
+        weights = await get_recently_liked_blender_weights(100)
+
+    assert weights == MATURE_BLENDER_TREATMENT_WEIGHTS
+    assert weights["recently_liked"] > MATURE_BLENDER_CONTROL_WEIGHTS["recently_liked"]
+    assert weights["lr_smoothed"] < MATURE_BLENDER_CONTROL_WEIGHTS["lr_smoothed"]
 
 
 @pytest.mark.asyncio
@@ -311,12 +513,17 @@ async def test_generate_empty_above_100():
             "es_ranked": empty,
         }
 
-    # All engines empty → empty result
-    candidates = await generate_recommendations(TEST_USER_ID, 10, 200, TestRetriever())
-    assert len(candidates) == 0
+    with patch(
+        "src.recommendations.meme_queue.get_or_assign_recently_liked_blender_variant",
+        new_callable=AsyncMock,
+        return_value=RECENTLY_LIKED_BLENDER_CONTROL,
+    ):
+        # All engines empty → empty result
+        candidates = await generate_recommendations(TEST_USER_ID, 10, 200, TestRetriever())
+        assert len(candidates) == 0
 
-    # Same for high meme count — no fallback engine anymore
-    candidates = await generate_recommendations(TEST_USER_ID, 10, 1200, TestRetriever())
+        # Same for high meme count — no fallback engine anymore
+        candidates = await generate_recommendations(TEST_USER_ID, 10, 1200, TestRetriever())
     assert len(candidates) == 0
 
 


### PR DESCRIPTION
## Summary
- Adds mature-user-only A/B assignment for recently_liked blender weights using experiment_assignment.
- Keeps control at current mature weights and shifts treatment recently_liked from 0.2 to 0.3 by reducing lr_smoothed and like_spread.
- Leaves cold-start and growing-user routing unchanged; experiment assignment falls back to control on assignment errors.

## Measurement
- Experiment id: recently_liked_blender_mature_v1
- Cohort lives in experiment_assignment; engine exposure remains in user_meme_reaction.recommended_by for Analyst joins.

## Tests
- ruff check --fix src/ tests/
- ruff format src/ tests/
- env DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/postgres REDIS_URL=redis://localhost:6379/0 CORS_ORIGINS='["*"]' CORS_HEADERS='["*"]' python3 -m pytest tests/recommendations/test_meme_queue.py -q

Fixes FFM-1049.