### PR TITLE
Align Paperclip outcomes with native tools

### DIFF
--- a/agents/analyst/AGENTS.md
+++ b/agents/analyst/AGENTS.md
@@ -24,7 +24,8 @@ Monitor product health, track experiments, detect anomalies, and produce compreh
 ## Paperclip Runtime
 
 Use the native `paperclip` skill for wake context, task selection, checkout,
-structured interactions, blockers/subtasks, comments, and task completion.
+structured confirmations, blockers/subtasks, documents/attachments, concise
+comments, and task completion.
 
 For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first. Use child issues for

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -141,7 +141,7 @@ First run the outcome audit:
 
 ```bash
 source ~/.zshrc 2>/dev/null || true
-python scripts/paperclip_outcome_audit.py --days 7
+python3 scripts/paperclip_outcome_audit.py --days 7
 ```
 
 Create or update `[strategy:weekly-outcomes-YYYY-MM-DD] Weekly outcome review`

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -43,7 +43,8 @@ Review Analyst reports, think strategically about the product, manage experiment
 ## Paperclip Runtime
 
 Use the native `paperclip` skill for wake context, task selection, checkout,
-structured interactions, blockers/subtasks, comments, and task completion.
+structured confirmations, blockers/subtasks, documents/attachments, concise
+comments, and task completion.
 
 For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first. Use child issues for
@@ -54,7 +55,8 @@ delegated subtasks instead of comment-only handoffs.
 Every issue you create must start with a stable bracket slug and reuse that slug
 across recurrences:
 - `[incident:<slug>]`, `[deploy:<branch-or-pr>]`, `[report:YYYY-MM-DD]`,
-  `[post:YYYY-MM-DD-slug]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`
+  `[post:YYYY-MM-DD-slug]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`,
+  `[strategy:weekly-outcomes-YYYY-MM-DD]`
 
 Search/update an existing open issue with the same slug before creating another
 one.
@@ -77,20 +79,32 @@ your approval is only an intermediate state. The channel post is not done until
 Comms publishes it through `publish_editorial_post` and records the Telegram
 message id and editorial post id returned by that function.
 
+The authoritative approval mechanism is the structured confirmation card
+surfaced by the native `paperclip` skill (i.e. `paperclipRequestConfirmation`
+or the skill's `request_confirmation` flow keyed by the `[post:...]` slug).
+Accepting or rejecting that card is the decision; comment text is only context.
+
 For an approved post:
 1. Accept the pending structured confirmation surfaced by the native
    `paperclip` skill.
-2. Add a comment starting with `APPROVED_TO_PUBLISH`.
-3. Reassign the same issue to Comms Manager and set status back to `todo`.
+2. Reassign the same issue to Comms Manager and set status back to `todo`.
+3. Optionally add a short context comment, but do NOT rely on magic comment
+   tokens for the approval signal — the accepted confirmation card is the
+   signal.
 4. Do NOT mark the issue `done`. Only Comms Manager closes `[post:...]` issues
    after publishing and archiving.
 
 For a rejected or stale post:
 1. Reject the pending structured confirmation surfaced by the native
-   `paperclip` skill.
-2. Comment with `REJECTED` or `STALE_NEEDS_REFRESH` and the required change.
-3. Reassign the issue to Comms Manager with status `todo`.
-4. Do NOT leave the draft assigned to CEO unless you are actively reviewing it.
+   `paperclip` skill, including the required change in the rejection note.
+2. Reassign the issue to Comms Manager with status `todo`.
+3. Do NOT leave the draft assigned to CEO unless you are actively reviewing it.
+
+Legacy fallback only: very old `[post:...]` drafts created before the
+structured confirmation flow may rely on an `APPROVED_TO_PUBLISH` /
+`REJECTED` / `STALE_NEEDS_REFRESH` comment. Treat these comments as a
+back-compat signal for those legacy drafts only — for any new draft, the
+structured confirmation card is the contract.
 
 ## Every Heartbeat (daily)
 
@@ -123,7 +137,27 @@ Read `experiments/active/`. For each experiment:
 - Create a task for Comms Manager with what to announce and why it matters
 
 ### 5. Weekly Review (Mondays)
-Run `/retro` — it analyzes commit history, shipping velocity, test health, per-person contributions, and trends. Then act on its output: create tasks for systemic issues it surfaces (stale routines, missing reports, handoff friction).
+First run the outcome audit:
+
+```bash
+source ~/.zshrc 2>/dev/null || true
+python scripts/paperclip_outcome_audit.py --days 7
+```
+
+Create or update `[strategy:weekly-outcomes-YYYY-MM-DD] Weekly outcome review`
+with `decision_yield`, audit flags, active experiment decisions, shipped
+outcomes, work to stop, and one next bet. Use
+`docs/agents/outcome-ledger.md` as the contract.
+
+If the audit flags `activity_without_decisions`, `low_decision_yield`, or
+`stale_active_experiments`, close the decision gap before creating new
+non-critical execution work. During weekly review, create at most three new
+non-critical execution issues; every one must name the decision or audit flag
+that caused it.
+
+Then run `/retro` — it analyzes commit history, shipping velocity, test health,
+per-person contributions, and trends. Act on its output only after the outcome
+ledger says what to keep, kill, change, and bet on next.
 
 ### 6. Review the Backlog
 Read `TODOS.md` and the research ideas in memory. Prioritize:
@@ -141,7 +175,7 @@ Append to `experiments/log.jsonl`:
 {
   "timestamp": "ISO 8601",
   "agent": "ceo",
-  "action": "daily_review|experiment_completed|experiment_created|bug_fixed|task_created",
+  "action": "daily_review|weekly_outcome_review|experiment_completed|experiment_created|bug_fixed|task_created",
   "status": "success",
   "summary": "one-line description",
   "details": {"experiment": "name", "reason": "why", "impact": "expected impact"},
@@ -173,6 +207,8 @@ Other signals that matter:
 
 ### When NOT to start a new experiment:
 - Already 2+ active experiments (can't attribute changes)
+- Any active experiment is past its measurement date or still
+  deployment-pending after 7 days
 - No clear hypothesis (what metric will change and by how much?)
 - The fix is obvious — just do it, don't experiment
 
@@ -185,6 +221,7 @@ Other signals that matter:
 - **Read CLAUDE.md** for full project context.
 - **Read docs/analyst/README.md** for schema and metric definitions.
 - **Read experiments/README.md** for experiment lifecycle.
+- **Read docs/agents/outcome-ledger.md** for the weekly outcome review contract.
 
 ## What NOT To Do
 - Do NOT make changes without reading the Analyst's latest report first

--- a/agents/ceo/HEARTBEAT.md
+++ b/agents/ceo/HEARTBEAT.md
@@ -33,8 +33,8 @@ Close resolved issues or comment on what remains open.
 
 ## 6. Delegation
 
-- Create subtasks with `paperclipCreateIssue`. Set parent/goal fields when the
-  task belongs under an existing issue or goal.
+- Create subtasks through the native `paperclip` skill. Set parent/goal fields
+  when the task belongs under an existing issue or goal.
 - Use `paperclip-create-agent` skill when hiring new agents.
 - Assign work to the right agent for the job.
 

--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -19,10 +19,20 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 ## Paperclip Runtime
 
 Use the native `paperclip` skill for wake context, task selection, checkout,
-structured interactions, blockers/subtasks, comments, and task completion.
+structured interactions, blockers/subtasks, documents, comments, and task
+completion. Prefer the skill's MCP tools (`paperclipRequestConfirmation`,
+`paperclipCreateIssue`, `paperclipUpsertIssueDocument`,
+`paperclipAddComment`, `paperclipUpdateIssue`) over ad-hoc curl or
+free-form markdown coordination.
 
-CEO publication gates require a structured Paperclip confirmation card. For
-blocked work, set status `blocked` with a clear comment and use
+CEO publication gates MUST use a structured Paperclip confirmation card via
+`paperclipRequestConfirmation` (or the native `paperclip` skill's
+`request_confirmation` flow). The accepted/rejected card is the decision; do
+not gate publishing on free-form yes/no comments. Use a stable idempotency
+key derived from the `[post:...]` slug so reruns reuse the same card instead
+of stacking new ones.
+
+For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first.
 
 ## Issue Hygiene
@@ -168,25 +178,37 @@ The anomaly-driven daily routine in "What Triggers You" is the canonical flow.
 
 ### CEO Approval Required
 Run steps 1-6, then instead of posting directly:
-1. Create a Paperclip issue with full post text + visual PNG attached.
-   Title format: `[post:YYYY-MM-DD-slug] Brief topic` (see Issue Hygiene).
-2. Add a structured Paperclip confirmation card asking CEO to approve or reject
-   the exact draft. Use a stable idempotency key based on the `[post:...]` slug.
+1. Create the draft via `paperclipCreateIssue` with full post text + visual
+   PNG attached. Title format: `[post:YYYY-MM-DD-slug] Brief topic` (see Issue
+   Hygiene). Use `paperclipUpsertIssueDocument` for any longer-form draft body
+   so revisions are tracked.
+2. Open the approval gate with `paperclipRequestConfirmation` (or the native
+   `paperclip` skill's `request_confirmation` flow) on that issue. Use a
+   stable idempotency key derived from the `[post:...]` slug so reruns reuse
+   the same card. Do NOT ask CEO for a free-form yes/no comment as the
+   approval mechanism — the accepted/rejected card is the decision.
    Assign the draft issue to CEO for approval, but make the terminal owner
-   explicit: CEO must return it to Comms. CEO approval is not a terminal outcome.
+   explicit: CEO must return it to Comms. CEO approval is not a terminal
+   outcome.
 3. You may close the short-lived routine execution issue after the draft issue is
    created, so tomorrow's cron is not blocked. The closing comment MUST say
    `outcome=draft_created`, link the draft issue, and note that publication is
    still pending.
-4. When an approved `[post:...]` issue is assigned back to you, read
-   native Paperclip context first and verify the latest CEO decision is an
-   accepted confirmation or canonical `APPROVED_TO_PUBLISH` comment. Then publish
-   via `publish_editorial_post`, archive, log, and close that draft issue with
+4. When an approved `[post:...]` issue is assigned back to you, fetch context
+   through the native `paperclip` skill and verify the latest CEO decision is
+   an accepted structured confirmation. Then publish via
+   `publish_editorial_post`, archive, log, and close that draft issue with
    `outcome=published`, `channel`, `telegram_message_id`, `editorial_post_id`,
    and `already_posted` from the returned result object.
 5. NEVER close an approved `[post:...]` issue as done before publishing. A CEO
-   approval comment without a Telegram message id means the post is still not
-   public.
+   approval (card or otherwise) without a Telegram message id means the post
+   is still not public.
+
+Legacy fallback: a small number of pre-existing drafts may carry an
+`APPROVED_TO_PUBLISH` comment instead of an accepted confirmation card.
+Treat that comment as a valid approval signal only for those legacy drafts;
+for anything created via the current routine, require the structured
+confirmation card.
 
 If a draft is still waiting for approval or publish after 24h, treat it as stale:
 comment with `outcome=stale_draft`, either refresh the data for today's post or

--- a/agents/cto/AGENTS.md
+++ b/agents/cto/AGENTS.md
@@ -21,7 +21,8 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 ## Paperclip Runtime
 
 Use the native `paperclip` skill for wake context, task selection, checkout,
-structured interactions, blockers/subtasks, comments, and task completion.
+structured confirmations, blockers/subtasks, documents/attachments, concise
+comments, and task completion.
 
 For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first. Use child issues for

--- a/agents/qa-engineer/AGENTS.md
+++ b/agents/qa-engineer/AGENTS.md
@@ -32,7 +32,8 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 ## Paperclip Runtime
 
 Use the native `paperclip` skill for wake context, task selection, checkout,
-structured interactions, blockers/subtasks, comments, and task completion.
+structured confirmations, blockers/subtasks, documents/attachments, concise
+comments, and task completion.
 
 For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first. Use child issues for
@@ -160,28 +161,52 @@ After deterministic smoke passes, run `/qa exhaustive` for an improvised bug hun
 
 ## Process Health Check (Watchdog)
 
-When triggered by the daily watchdog routine, check that all other routines are running AND succeeding:
+When triggered by the daily watchdog routine, audit product-specific routine
+outcomes. There are two distinct layers and you should not duplicate them:
 
-1. Run the compact outcome audit first:
+- **Native Paperclip runtime signals** (Paperclip v2026.428+ productivity review,
+  liveness/watchdog recovery, stranded assignment recovery). Generic stall,
+  zombie-run, and no-comment classification belong here. Read these from the
+  Paperclip dashboard / native routine tooling — do NOT reimplement them in
+  the FFmemes audit script.
+- **FFmemes outcome-contract checks**, run via
+  `scripts/paperclip_routine_audit.py`. This is narrow and business-specific:
+  channel post publication markers, update-check content (changelog, version,
+  verified deploy commit), gstack update path, draft handoff state, and PR
+  payload mismatch.
+
+Workflow:
+
+1. Run the compact outcome audit first for FFmemes-specific contract flags:
 ```bash
 source ~/.zshrc 2>/dev/null || true
 python scripts/paperclip_routine_audit.py --focus all
 ```
 If the script is unavailable in the runtime workspace, fall back to
-native Paperclip dashboard/routine tooling, but preserve the same outcome checks
-manually.
-2. Use native Paperclip routine tooling only for freshness/status details not already shown by the script.
-3. For each routine, check BOTH **freshness** (did it run recently?) AND **health** (did it produce the expected outcome?):
-   - **Daily Analyst Report** → ran in last 28h AND `lastRun.status` is not `failed`
-   - **QA Log Scan** → ran in last 12h AND `lastRun.status` is not `failed`
-   - **Weekly CEO Review** → ran in last 14 days AND `lastRun.status` is not `failed`
-   - **Weekly Analyst Summary** → ran in last 14 days AND `lastRun.status` is not `failed`
+native Paperclip dashboard/routine tooling, but preserve the same outcome
+checks manually.
+2. Use the native Paperclip dashboard / routine tooling for freshness, run
+   status, liveness/zombie recovery, no-comment streaks, and
+   productivity-review escalations. Trust those over re-deriving stall signals
+   here.
+3. For each routine, check the FFmemes **outcome contract**:
+   - **Daily Analyst Report** → latest report issue/file exists for the expected date
+   - **QA Log Scan** → latest scan issue records concrete health evidence or "all clear"
+   - **Weekly CEO Review** → latest review includes outcome-ledger decisions, not only `/retro`
+   - **Weekly Analyst Summary** → latest summary issue/report names product changes and anomalies
    - **Daily Channel Post** → latest linked `[post:...]` issue has `outcome=published`, `telegram_message_id`, and `editorial_post_id`; draft/approval-only handoffs are YELLOW
-   - **gstack Update Check** → ran in last 48h, `lastRun.status` is not `failed`, and does NOT have `unknown_gstack_update_path` / degraded update flags
-   - **Paperclip Update Check** → ran in last 48h, includes version/changelog impact, and any deploy claim includes `coolify_deployment_commit` or `verified_deployed_commit` matching the intended target
-   - **PR Review** → event-driven, skip unless no runs in 7 days
+   - **gstack Update Check** → latest outcome names the update method and does NOT have `unknown_gstack_update_path` / degraded update flags
+   - **Paperclip Update Check** → latest outcome includes version/changelog impact, and any deploy claim includes `coolify_deployment_commit` or `verified_deployed_commit` matching the intended target
+   - **PR Review** → latest run's payload PR number matches the linked issue title/review signal
    - **Process Health Check** → skip (that's you)
-4. If any routine is STALE, FAILED, or has outcome flags from `paperclip_routine_audit.py`, create or update ONE `[maintenance:routine-outcome-health]` issue for CEO with: routine, issue id, flag, timestamp, and the exact expected outcome contract.
+4. If any routine has outcome-contract flags from `paperclip_routine_audit.py`
+   (e.g. unverified deploy, sha-only update check, draft handoff,
+   approved-without-publish-marker, PR payload mismatch), create or update ONE
+   `[maintenance:routine-outcome-health]` issue for CEO with: routine, issue
+   id, flag, timestamp, and the exact expected outcome contract. Generic
+   stale/zombie/no-comment situations should already be surfaced by the native
+   Paperclip productivity review — open a Paperclip runtime issue only if the
+   native recovery surface reports a persistent failure.
 5. If all routines are fresh and outcome-clean → log "Process health: GREEN" in your QA report.
 
 ## What NOT To Do

--- a/agents/qa-engineer/AGENTS.md
+++ b/agents/qa-engineer/AGENTS.md
@@ -180,7 +180,7 @@ Workflow:
 1. Run the compact outcome audit first for FFmemes-specific contract flags:
 ```bash
 source ~/.zshrc 2>/dev/null || true
-python scripts/paperclip_routine_audit.py --focus all
+python3 scripts/paperclip_routine_audit.py --focus all
 ```
 If the script is unavailable in the runtime workspace, fall back to
 native Paperclip dashboard/routine tooling, but preserve the same outcome

--- a/agents/release-engineer/AGENTS.md
+++ b/agents/release-engineer/AGENTS.md
@@ -20,7 +20,8 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 ## Paperclip Runtime
 
 Use the native `paperclip` skill for wake context, task selection, checkout,
-structured interactions, blockers/subtasks, comments, and task completion.
+structured confirmations, blockers/subtasks, documents/attachments, concise
+comments, and task completion.
 
 For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first. Use child issues for

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -20,7 +20,8 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 ## Paperclip Runtime
 
 Use the native `paperclip` skill for wake context, task selection, checkout,
-structured interactions, blockers/subtasks, comments, and task completion.
+structured confirmations, blockers/subtasks, documents/attachments, concise
+comments, and task completion.
 
 For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first. Use child issues for
@@ -89,7 +90,7 @@ You own the full PR → merged cycle for internal PRs. No handoffs to Release En
    **Request changes:** (do these in order — race-sensitive)
    - **First, cancel any pending auto-merge** from a prior wake on this PR: `gh pr merge <pr_number> --disable-auto --repo ffmemes/ff-backend` (no-op if no queue exists). Must come BEFORE posting the change-request signal — a queued merge can fire in the gap if a check completes mid-call, and `gh pr comment` does not block auto-merge.
    - Then post the review signal — try formal first: `gh pr review <pr_number> --request-changes --repo ffmemes/ff-backend -b "Issues found"`. On self-review-block: `gh pr comment <pr_number> --repo ffmemes/ff-backend -b "STAFF ENGINEER REVIEW: CHANGES REQUESTED — <summary>"`.
-   - **For internal authors only** (using `AUTHOR`, `HEAD_BRANCH`, and `IS_FORK` from step 1 — internal = `IS_FORK == false` AND (`AUTHOR == "ohld"` OR `HEAD_BRANCH` matches one of `agent/*`, `cto/*`, `staff-engineer/*`, `release-engineer/*`, `localize-*`, `fix/FFM-*`, `feat/agent-*`)): create a CTO follow-up via `paperclipCreateIssue` with title `[pr:NNN] address review changes` and a one-line summary. PR #174 sat 9 days because no Paperclip handoff existed. **For external authors (or any fork PR):** skip the handoff (CTO can't fix their PRs) and add `@ohld` to the comment instead so ohld can decide.
+   - **For internal authors only** (using `AUTHOR`, `HEAD_BRANCH`, and `IS_FORK` from step 1 — internal = `IS_FORK == false` AND (`AUTHOR == "ohld"` OR `HEAD_BRANCH` matches one of `agent/*`, `cto/*`, `staff-engineer/*`, `release-engineer/*`, `localize-*`, `fix/FFM-*`, `feat/agent-*`)): create a CTO child issue/subtask through the native `paperclip` skill with title `[pr:NNN] address review changes` and a one-line summary. PR #174 sat 9 days because no Paperclip handoff existed. **For external authors (or any fork PR):** skip the handoff (CTO can't fix their PRs) and add `@ohld` to the comment instead so ohld can decide.
    - Do not proceed to step 8.
 
    **External-author PRs:** `gh pr comment` alone is never a substitute for `gh pr review --approve|--request-changes` — non-ohld authors need a real review for any future rule that requires `reviewDecision`.
@@ -171,7 +172,7 @@ For internal PRs on the happy path:
 
 Other outcomes:
 - **Approved but blocked** — review clean, CI failing. Comment posted, Paperclip issue left `blocked`, no merge.
-- **Changes requested** — structural issues found. Comment-fallback `STAFF ENGINEER REVIEW: CHANGES REQUESTED` posted (or real `--request-changes` for external PRs). MANDATORY: `paperclipCreateIssue` `[pr:NNN] address review changes` for CTO. Paperclip execution issue marked `done`. Next PR update re-triggers a new review.
+- **Changes requested** — structural issues found. Comment-fallback `STAFF ENGINEER REVIEW: CHANGES REQUESTED` posted (or real `--request-changes` for external PRs). MANDATORY: create a CTO child issue/subtask through the native `paperclip` skill with `[pr:NNN] address review changes`. Paperclip execution issue marked `done`. Next PR update re-triggers a new review.
 - **External PR approved** — review posted, merge left to `ohld` manually.
 
 ## Who you hand off to
@@ -214,5 +215,5 @@ follow-up issue created.
 - Do NOT `git push` directly to `production` — merges must go through `gh pr merge --squash` on an approved PR
 - Do NOT approve PRs with known SQL injection patterns without flagging them
 - Do NOT commit secrets to git
-- Do NOT skip posting the review signal on GitHub — for ohld-authored PRs that means a `gh pr comment` prefixed `STAFF ENGINEER REVIEW: APPROVED|CHANGES REQUESTED` (since `gh pr review` self-review-blocks); for external-author PRs that means a real `gh pr review --approve|--request-changes`. `paperclipAddComment` alone never counts.
+- Do NOT skip posting the review signal on GitHub — for ohld-authored PRs that means a `gh pr comment` prefixed `STAFF ENGINEER REVIEW: APPROVED|CHANGES REQUESTED` (since `gh pr review` self-review-blocks); for external-author PRs that means a real `gh pr review --approve|--request-changes`. A Paperclip comment alone never counts.
 - Do NOT merge before the three-check preflight (approved review + green CI + internal author) passes

--- a/docs/agents/autonomy-metrics.md
+++ b/docs/agents/autonomy-metrics.md
@@ -23,6 +23,9 @@ Track these every Monday in the CEO review:
 | Child issue completion | up | parent issues completed by agent-created child tasks |
 | Routine useful outcome rate | up | `scripts/paperclip_routine_audit.py --json` |
 | Comms publish completion | up | `[post:...]` issues closed with `telegram_message_id` + `editorial_post_id` |
+| Decision yield | up | `scripts/paperclip_outcome_audit.py --days 7 --json` |
+| Stale active experiments | down | `experiments/active/*` parsed by `paperclip_outcome_audit.py` |
+| Stopped-work decisions | up | weekly `[strategy:weekly-outcomes-YYYY-MM-DD]` issue |
 
 ## CEO-Specific Check
 
@@ -38,14 +41,55 @@ If CEO is not implementing the backlog, measure the funnel instead of guessing:
    `ceo_attention_gap`.
 
 The CEO should not code. A healthy CEO creates clear child issues, uses
-`request_confirmation` for real gates, sets `blockedByIssueIds` when waiting on
-data or implementation, and closes the loop when child issues finish.
+structured confirmation cards through the native Paperclip skill for real gates,
+sets `blockedByIssueIds` when waiting on data or implementation, and closes the
+loop when child issues finish.
+
+## Outcome Review
+
+Every Monday, run:
+
+```bash
+source ~/.zshrc 2>/dev/null || true
+python scripts/paperclip_outcome_audit.py --days 7
+```
+
+The point is to catch weeks where the organization completes many issues but
+does not close product loops. Treat these flags as CEO-level blockers:
+
+- `activity_without_decisions`: 50+ completed issues and fewer than 3 decision
+  events.
+- `low_decision_yield`: decision events are less than 5% of completed issue
+  volume.
+- `execution_heavy_week`: PRs, deploys, scans, incidents, reports, and
+  maintenance dominate the week.
+- `stale_active_experiments`: an active experiment is past its measurement date,
+  is still deployment-pending after 7 days, or lacks a parseable measurement
+  date after 21 days.
+
+The weekly CEO review should create or update one
+`[strategy:weekly-outcomes-YYYY-MM-DD]` issue with:
+
+1. Product decisions closed: continue, complete, cancel, or ask Analyst for data.
+2. Work shipped to production: PR/deploy outcomes, not just reviewed PRs.
+3. Work to stop, merge, or delete: stale issues, duplicate incidents, stale
+   experiments, dead bets.
+4. Next bet: one clear priority for the coming week.
+
+If `paperclip_outcome_audit.py` emits `activity_without_decisions`,
+`low_decision_yield`, or `stale_active_experiments`, do not open new
+non-critical execution work until the outcome issue records the keep/kill/change
+decisions.
 
 ## Existing Tools
 
 - [`routine-observability.md`](routine-observability.md) defines routine outcome
   contracts.
+- [`outcome-ledger.md`](outcome-ledger.md) defines the weekly CEO outcome review
+  contract.
 - [`paperclip-simplification-2026-05-04.md`](paperclip-simplification-2026-05-04.md)
   defines the runtime simplification direction.
 - [`../../scripts/paperclip_routine_audit.py`](../../scripts/paperclip_routine_audit.py)
   gives compact routine health input.
+- [`../../scripts/paperclip_outcome_audit.py`](../../scripts/paperclip_outcome_audit.py)
+  gives compact outcome-throughput input.

--- a/docs/agents/autonomy-metrics.md
+++ b/docs/agents/autonomy-metrics.md
@@ -51,7 +51,7 @@ Every Monday, run:
 
 ```bash
 source ~/.zshrc 2>/dev/null || true
-python scripts/paperclip_outcome_audit.py --days 7
+python3 scripts/paperclip_outcome_audit.py --days 7
 ```
 
 The point is to catch weeks where the organization completes many issues but

--- a/docs/agents/outcome-ledger.md
+++ b/docs/agents/outcome-ledger.md
@@ -12,6 +12,8 @@ python3 scripts/paperclip_outcome_audit.py --days 7
 ```
 
 Use `--json` when another agent needs compact structured input.
+The helper reads `PAPERCLIP_API_URL` in Paperclip runtime and falls back to
+`PAPERCLIP_URL` for local runs.
 
 ## Weekly CEO Contract
 

--- a/docs/agents/outcome-ledger.md
+++ b/docs/agents/outcome-ledger.md
@@ -8,7 +8,7 @@ learn, what changed in the product, what should stop, and what is the next bet?
 
 ```bash
 source ~/.zshrc 2>/dev/null || true
-python scripts/paperclip_outcome_audit.py --days 7
+python3 scripts/paperclip_outcome_audit.py --days 7
 ```
 
 Use `--json` when another agent needs compact structured input.

--- a/docs/agents/outcome-ledger.md
+++ b/docs/agents/outcome-ledger.md
@@ -1,0 +1,94 @@
+# Agent Outcome Ledger
+
+Use this when the organization is producing many issues, PR reviews, reports,
+and routine comments. The goal is to force a CEO-level answer to: what did we
+learn, what changed in the product, what should stop, and what is the next bet?
+
+## First Command
+
+```bash
+source ~/.zshrc 2>/dev/null || true
+python scripts/paperclip_outcome_audit.py --days 7
+```
+
+Use `--json` when another agent needs compact structured input.
+
+## Weekly CEO Contract
+
+Every Weekly CEO Review must create or update exactly one strategy issue:
+
+`[strategy:weekly-outcomes-YYYY-MM-DD] Weekly outcome review`
+
+That issue is the source of truth for the week. It must contain:
+
+```markdown
+## Outcome audit
+- decision_yield:
+- flags:
+- issue mix:
+
+## Decisions closed
+- Continue:
+- Complete:
+- Cancel:
+- Ask Analyst:
+
+## Shipped outcomes
+- Production changes:
+- Published comms:
+- Verified deploys:
+
+## Stop list
+- Stale experiments:
+- Duplicate/merged issues:
+- Work to stop doing:
+
+## Next bet
+- Bet:
+- Owner:
+- Success metric:
+- First execution task:
+```
+
+## Gates
+
+If any of these are true, the CEO review is not green:
+
+- `activity_without_decisions`: the team closed 50+ issues but recorded fewer
+  than 3 decision events.
+- `low_decision_yield`: decision events are less than 5% of completed issue
+  volume.
+- `stale_active_experiments`: an active experiment is past its measurement date,
+  still deployment-pending after 7 days, or has no parseable measurement date
+  after 21 days.
+- More than 2 active experiments are running.
+
+When a gate is red, the CEO must close the decision gap before creating new
+non-critical CTO/QA/Comms work.
+
+## What Counts
+
+Counts as an outcome:
+
+- Experiment created, completed, cancelled, archived, or explicitly continued
+  with a reason.
+- Product decision logged in `experiments/log.jsonl`.
+- Production deploy verified.
+- Comms post actually published with `telegram_message_id` and
+  `editorial_post_id`.
+- Incident resolved with root cause and follow-up decision.
+
+Does not count as an outcome by itself:
+
+- PR reviewed.
+- Issue closed as no-op.
+- Routine execution completed.
+- Draft approved but not published.
+- Analyst report created without a CEO decision.
+
+## Task Throttle
+
+During the weekly review, create at most three new non-critical execution issues.
+Every new execution issue must name the decision or audit flag that caused it.
+Critical production incidents are exempt, but they still need stable
+`[incident:<slug>]` issue hygiene.

--- a/docs/agents/pr-review-cycle.md
+++ b/docs/agents/pr-review-cycle.md
@@ -19,8 +19,9 @@ agent infrastructure, see `paperclip-ops-runbook.md`.
      `STAFF ENGINEER REVIEW: APPROVED` comment fallback for self-review-blocked
      PRs; internal PRs are queued with `gh pr merge --squash --auto`.
    - **Hold** — real request-changes review when allowed, or a
-     `STAFF ENGINEER REVIEW: CHANGES REQUESTED` comment fallback. A CTO issue
-     is created for required fixes.
+     `STAFF ENGINEER REVIEW: CHANGES REQUESTED` comment fallback. A CTO child
+     issue/subtask is created through native Paperclip tooling for required
+     fixes.
 
 ## What "running" means
 

--- a/docs/agents/routine-observability.md
+++ b/docs/agents/routine-observability.md
@@ -19,11 +19,13 @@ Two layers, do not duplicate:
 
 ```bash
 source ~/.zshrc
-python scripts/paperclip_routine_audit.py --focus all
+python3 scripts/paperclip_routine_audit.py --focus all
 ```
 
 Use `--focus comms` for channel posting and `--focus updates` for Paperclip /
 gstack checks. Add `--json` when another agent needs compact structured input.
+The helper reads `PAPERCLIP_API_URL` in Paperclip runtime and falls back to
+`PAPERCLIP_URL` for local runs.
 
 ## Outcome Contracts
 

--- a/docs/agents/routine-observability.md
+++ b/docs/agents/routine-observability.md
@@ -1,7 +1,19 @@
 # Agent Routine Observability
 
-Use this before broad manual audits. The goal is to measure useful outcomes,
-not whether Paperclip emitted activity notifications.
+Use this before broad manual audits. The goal is to measure useful FFmemes
+**business outcomes**, not generic Paperclip liveness.
+
+Two layers, do not duplicate:
+
+- **Native Paperclip runtime** (v2026.428+) owns generic liveness, stall /
+  zombie-run detection, stranded assignment recovery, and productivity-review
+  escalation. Read those from the Paperclip dashboard / native routine
+  tooling.
+- `scripts/paperclip_routine_audit.py` (this doc) owns narrow, FFmemes-specific
+  outcome-contract checks: channel post publication markers, update-check
+  content (changelog/version/verified deploy commit), gstack update path,
+  draft handoff state, and PR payload mismatch. It does not re-derive stall
+  or no-comment signals — those belong to the native runtime.
 
 ## First Command
 
@@ -22,11 +34,13 @@ Terminal success is `outcome=published` with both:
 - `telegram_message_id`
 - `editorial_post_id`
 
-`draft_created`, `approval_pending`, accepted `request_confirmation`, and
-`APPROVED_TO_PUBLISH` are intermediate states. CEO approval must reassign the
-`[post:...]` issue to Comms Manager with status `todo`; CEO must not close the
-issue. Comms Manager is the only terminal owner and closes it after publishing
-through `publish_editorial_post()` using the returned `result.message_id` and
+`draft_created`, `approval_pending`, and an accepted `request_confirmation`
+card (the authoritative CEO approval signal) are intermediate states. Legacy
+`APPROVED_TO_PUBLISH` comments count as the same intermediate state for old
+drafts only. CEO approval must reassign the `[post:...]` issue to Comms
+Manager with status `todo`; CEO must not close the issue. Comms Manager is
+the only terminal owner and closes it after publishing through
+`publish_editorial_post()` using the returned `result.message_id` and
 `result.editorial_post_id`.
 
 If a `[post:...]` draft is older than 24 hours, refresh or skip it explicitly.
@@ -79,6 +93,23 @@ productivity-review escalation. Keep this audit focused on business outcome
 mismatches, then file a Paperclip runtime issue only if the native recovery
 surface reports a persistent failure.
 
+### Weekly CEO Review
+
+Terminal success is not "retro ran" or "new tasks created." A healthy Weekly CEO
+Review must include the outcome ledger:
+
+- `decision_yield` from `scripts/paperclip_outcome_audit.py --days 7`
+- outcome audit flags, if any
+- active experiment decisions: continue, complete, cancel, or ask Analyst
+- a stop list for stale/duplicate/merged work
+- one next bet with owner and success metric
+- a linked `[strategy:weekly-outcomes-YYYY-MM-DD]` issue
+
+If the outcome audit reports `activity_without_decisions`,
+`low_decision_yield`, or `stale_active_experiments`, the run is YELLOW until the
+strategy issue records the keep/kill/change decisions. It is RED if the CEO
+opens more non-critical execution work without resolving those flags.
+
 ## Telegram Activity Feed
 
 `@ffnerdbot` is only a low-signal activity feed. It proves that agents started
@@ -97,5 +128,8 @@ issues/comments, not from Telegram notifications.
   [`paperclip-simplification-2026-05-04.md`](paperclip-simplification-2026-05-04.md).
 - For organization-level autonomy measurement, use
   [`autonomy-metrics.md`](autonomy-metrics.md).
+- For issue-throughput versus product-learning measurement, use
+  [`outcome-ledger.md`](outcome-ledger.md) and
+  [`../../scripts/paperclip_outcome_audit.py`](../../scripts/paperclip_outcome_audit.py).
 - Treat secrets in Paperclip agent config as toxic output. Never paste values
   into comments, docs, or chat.

--- a/docs/agents/update-routine-findings-2026-05-01.md
+++ b/docs/agents/update-routine-findings-2026-05-01.md
@@ -27,7 +27,9 @@ release note from scratch. Follow-up simplification notes from May 4 live in
   explicitly fixed stale execution-run locks, which maps directly to the
   `activeRun=null` zombie PR-review pattern observed here. After prod upgrade
   verification, remove prompt-side race/recovery prose that duplicates runtime
-  behavior.
+  behavior. Historical note after the v2026.428 cleanup: local FFmemes audits
+  should not re-detect these runtime states; use the native Paperclip recovery
+  and productivity-review surfaces.
 - Productivity review service. This is the right surface for "agents are busy
   but did anything useful happen?" It should open issues for no-comment streaks,
   long-active runs, and high-churn loops.
@@ -70,11 +72,13 @@ release note from scratch. Follow-up simplification notes from May 4 live in
   before closing as useful.
 - `@ffnerdbot` is only an activity feed. It is useful to see work starting and
   stopping, but not to judge value delivered.
-- PR Review can currently misqueue work: PR #215 was coalesced into active
+- Historical PR Review finding: PR #215 was coalesced into active
   `FFM-860 [pr:214] Review`, then both `FFM-860` and the re-triggered
   `FFM-862 [pr:215] Review` showed `in_progress` + running run +
   `activeRun=null` with no review comments. Treat this as Paperclip runtime
-  zombie execution, not as a real review in progress.
+  zombie execution, not as a real review in progress. Do not add new local
+  zombie/no-comment checks for this; rely on native Paperclip recovery, and keep
+  the local routine audit limited to PR payload/output mismatches.
 
 ## Repo Changes Made
 

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -196,6 +196,18 @@ Outcome contracts live in `docs/agents/routine-observability.md`. In particular,
 `@ffnerdbot` is an activity feed only; it is not the source of truth for whether
 a routine produced a useful result.
 
+For Weekly CEO Review health, also run the outcome-throughput audit:
+
+```bash
+source ~/.zshrc
+python scripts/paperclip_outcome_audit.py --days 7
+```
+
+This distinguishes issue volume from product decisions, closed experiments,
+stopped work, and next bets. The weekly source of truth is the
+`[strategy:weekly-outcomes-YYYY-MM-DD]` issue described in
+`docs/agents/outcome-ledger.md`.
+
 | Routine | Agent | Schedule (UTC) | Trigger Type | What it does |
 |---------|-------|----------------|-------------|--------------|
 | Daily Analyst Report | Analyst | `19 6 * * *` | schedule + API | Query metrics, detect anomalies, write report |

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -200,7 +200,7 @@ For Weekly CEO Review health, also run the outcome-throughput audit:
 
 ```bash
 source ~/.zshrc
-python scripts/paperclip_outcome_audit.py --days 7
+python3 scripts/paperclip_outcome_audit.py --days 7
 ```
 
 This distinguishes issue volume from product decisions, closed experiments,

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -189,8 +189,11 @@ Paperclip JSON:
 
 ```bash
 source ~/.zshrc
-python scripts/paperclip_routine_audit.py --focus all
+python3 scripts/paperclip_routine_audit.py --focus all
 ```
+
+Audit helpers read `PAPERCLIP_API_URL` in Paperclip runtime and fall back to
+`PAPERCLIP_URL` for local MacBook runs.
 
 Outcome contracts live in `docs/agents/routine-observability.md`. In particular,
 `@ffnerdbot` is an activity feed only; it is not the source of truth for whether

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -29,6 +29,8 @@ experiments/
 Created: YYYY-MM-DD
 Status: active | completed | cancelled
 Owner: ceo | engineer | analyst
+Deployed: YYYY-MM-DD | pending
+Measure after: YYYY-MM-DD
 
 ## Hypothesis
 What we expect to happen and why.
@@ -45,6 +47,11 @@ Key metrics at experiment end (filled by CEO on completion).
 ## Conclusion
 What we learned (filled on completion).
 ```
+
+For active experiments, `Measure after:` must be a parseable `YYYY-MM-DD` once
+the deployment date is known. Avoid relative-only dates such as "14 days
+post-deploy" after code has shipped; the weekly outcome audit uses this field to
+find stale active experiments.
 
 ## Daily Report Format (reports/)
 

--- a/scripts/paperclip_outcome_audit.py
+++ b/scripts/paperclip_outcome_audit.py
@@ -5,7 +5,7 @@ This separates agent activity from product learning. It is intentionally
 compact enough to paste into a CEO weekly review without dumping raw issue JSON.
 
 Env:
-  PAPERCLIP_API_URL (preferred) or PAPERCLIP_URL (legacy/local)
+  PAPERCLIP_API_URL (preferred in Paperclip runtime) or PAPERCLIP_URL
   PAPERCLIP_API_KEY
   PAPERCLIP_COMPANY_ID (optional, defaults to FFmemes prod company)
 """
@@ -81,6 +81,13 @@ class Paperclip:
         except urllib.error.HTTPError as exc:
             body = compact_body(exc.read().decode("utf-8", errors="replace"), limit=500)
             raise RuntimeError(f"HTTP {exc.code} for {path}: {body}") from exc
+
+
+def paperclip_base_url() -> str | None:
+    base_url = os.getenv("PAPERCLIP_API_URL") or os.getenv("PAPERCLIP_URL")
+    if base_url and base_url.rstrip("/").endswith("/api"):
+        return base_url.rstrip("/")[:-4]
+    return base_url
 
 
 def compact_body(body: str, limit: int = 240) -> str:
@@ -227,11 +234,7 @@ def log_events(since: datetime, limit: int = 12) -> dict[str, Any]:
             "events": [],
             "decisions": [],
             "outcomes": [],
-            "counts": {
-                "events": 0,
-                "decisions": 0,
-                "outcomes": 0,
-            },
+            "counts": {"events": 0, "decisions": 0, "outcomes": 0},
         }
 
     for line in LOG_PATH.read_text().splitlines():
@@ -492,13 +495,10 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     args = parser.parse_args()
 
-    base_url = os.getenv("PAPERCLIP_API_URL") or os.getenv("PAPERCLIP_URL")
+    base_url = paperclip_base_url()
     api_key = os.getenv("PAPERCLIP_API_KEY")
     if not base_url or not api_key:
-        print(
-            "Set PAPERCLIP_API_URL (or legacy PAPERCLIP_URL) and PAPERCLIP_API_KEY",
-            file=sys.stderr,
-        )
+        print("Set PAPERCLIP_API_URL (or PAPERCLIP_URL) and PAPERCLIP_API_KEY", file=sys.stderr)
         return 2
 
     client = Paperclip(base_url, api_key)

--- a/scripts/paperclip_outcome_audit.py
+++ b/scripts/paperclip_outcome_audit.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Read-only audit for Paperclip outcome throughput.
+
+This separates agent activity from product learning. It is intentionally
+compact enough to paste into a CEO weekly review without dumping raw issue JSON.
+
+Env:
+  PAPERCLIP_URL
+  PAPERCLIP_API_KEY
+  PAPERCLIP_COMPANY_ID (optional, defaults to FFmemes prod company)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_COMPANY_ID = "96ee7b2e-6df2-43c8-bbe3-53e19297308a"
+ROOT = Path(__file__).resolve().parents[1]
+LOG_PATH = ROOT / "experiments" / "log.jsonl"
+ACTIVE_EXPERIMENTS_DIR = ROOT / "experiments" / "active"
+
+OPEN_STATUSES = {"backlog", "todo", "in_progress", "in_review", "blocked"}
+ALL_STATUSES = "backlog,todo,in_progress,in_review,blocked,done,cancelled"
+DECISION_ACTIONS = {
+    "experiment_created",
+    "experiment_completed",
+    "experiment_cancelled",
+    "experiment_archived",
+    "weekly_outcome_review",
+}
+OUTCOME_ACTIONS = DECISION_ACTIONS | {
+    "daily_channel_post",
+    "post_published",
+    "bug_fixed",
+}
+SENSITIVE_PATTERNS = (
+    (
+        re.compile(r"(?i)\b(bearer\s+)[a-z0-9._~+/=-]{20,}"),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(r"(https?://)[^@\s/:]+:[^@\s@]+@"),
+        r"\1[REDACTED]@",
+    ),
+    (
+        re.compile(
+            r"(?i)\b([a-z0-9_]*(?:token|secret|api_key|auth)[a-z0-9_]*\s*[:=]\s*)"
+            r"([^\s,;]+)"
+        ),
+        r"\1[REDACTED]",
+    ),
+)
+
+
+class Paperclip:
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+
+    def get(self, path: str, query: dict[str, str] | None = None) -> Any:
+        url = self.base_url + path
+        if query:
+            url += "?" + urllib.parse.urlencode(query)
+        req = urllib.request.Request(url)
+        req.add_header("Authorization", f"Bearer {self.api_key}")
+        req.add_header("User-Agent", "ffmemes-paperclip-outcome-audit/1.0")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            body = compact_body(exc.read().decode("utf-8", errors="replace"), limit=500)
+            raise RuntimeError(f"HTTP {exc.code} for {path}: {body}") from exc
+
+
+def compact_body(body: str, limit: int = 240) -> str:
+    body = " ".join(body.split())
+    for pattern, replacement in SENSITIVE_PATTERNS:
+        body = pattern.sub(replacement, body)
+    return body if len(body) <= limit else body[: limit - 1] + "..."
+
+
+def parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    match = re.search(r"\d{4}-\d{2}-\d{2}", value)
+    if not match:
+        return None
+    return date.fromisoformat(match.group(0))
+
+
+def age_days(day: date | None, today: date) -> int | None:
+    if not day:
+        return None
+    return (today - day).days
+
+
+def in_window(value: str | None, since: datetime) -> bool:
+    parsed = parse_ts(value)
+    return bool(parsed and parsed >= since)
+
+
+def list_agents(client: Paperclip, company_id: str) -> dict[str, str]:
+    agents = client.get(f"/api/companies/{company_id}/agents")
+    if not isinstance(agents, list):
+        return {}
+    return {
+        item.get("id"): (
+            item.get("name") or item.get("title") or item.get("urlKey") or item.get("id")
+        )
+        for item in agents
+        if item.get("id")
+    }
+
+
+def list_issues(client: Paperclip, company_id: str, limit: int) -> list[dict[str, Any]]:
+    issues = client.get(
+        f"/api/companies/{company_id}/issues",
+        {"status": ALL_STATUSES, "limit": str(limit)},
+    )
+    return issues if isinstance(issues, list) else []
+
+
+def bracket_slug(title: str) -> str | None:
+    match = re.match(r"\[([a-z0-9_-]+):([^\]]+)\]", title.lower())
+    return match.group(1) if match else None
+
+
+def classify_issue(issue: dict[str, Any], agents: dict[str, str]) -> str:
+    title = issue.get("title") or ""
+    lower = title.lower()
+    slug = bracket_slug(title)
+    creator = agents.get(issue.get("createdByAgentId"), "")
+    assignee = agents.get(issue.get("assigneeAgentId"), "")
+
+    if slug == "pr" or lower == "pr review" or "pr review" in lower:
+        return "pr_review"
+    if slug == "post":
+        return "comms_post"
+    if slug == "deploy":
+        return "deploy"
+    if slug == "incident":
+        return "incident"
+    if slug == "maintenance":
+        return "maintenance"
+    if slug == "report" or "analyst report" in lower or creator == "Analyst":
+        return "analyst_report"
+    if slug == "experiment" or "experiment" in lower:
+        return "experiment"
+    if slug == "scan" or creator == "QA Engineer" or assignee == "QA Engineer":
+        return "qa_scan"
+    if slug == "strategy":
+        return "strategy"
+    if creator == "CEO":
+        return "ceo_routing"
+    return "other"
+
+
+def creator_label(issue: dict[str, Any], agents: dict[str, str]) -> str:
+    agent_id = issue.get("createdByAgentId")
+    if agent_id and agent_id in agents:
+        return agents[agent_id]
+    if issue.get("createdByUserId"):
+        return "human"
+    if issue.get("originKind") == "routine_execution":
+        return "routine_execution"
+    return "unknown"
+
+
+def assignee_label(issue: dict[str, Any], agents: dict[str, str]) -> str:
+    agent_id = issue.get("assigneeAgentId")
+    if agent_id and agent_id in agents:
+        return agents[agent_id]
+    if issue.get("assigneeUserId"):
+        return "human"
+    return "unassigned"
+
+
+def parse_log_entry(line: str) -> dict[str, Any] | None:
+    try:
+        entry = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return entry if isinstance(entry, dict) else None
+
+
+def entry_contains_product_decision(entry: dict[str, Any]) -> bool:
+    action = entry.get("action")
+    if action in DECISION_ACTIONS:
+        return True
+    text = json.dumps(entry.get("details") or {}, ensure_ascii=True).lower()
+    return any(
+        marker in text
+        for marker in (
+            "product_decision",
+            "experiment_continue",
+            "experiment_blocked",
+            "experiment_archived",
+            "experiment_cancelled",
+            "next_experiment_priority",
+        )
+    )
+
+
+def log_events(since: datetime, limit: int = 12) -> dict[str, Any]:
+    events: list[dict[str, Any]] = []
+    decisions: list[dict[str, Any]] = []
+    outcomes: list[dict[str, Any]] = []
+    if not LOG_PATH.exists():
+        return {"events": [], "decisions": [], "outcomes": []}
+
+    for line in LOG_PATH.read_text().splitlines():
+        entry = parse_log_entry(line)
+        if not entry:
+            continue
+        ts = parse_ts(entry.get("timestamp"))
+        if not ts or ts < since:
+            continue
+        events.append(entry)
+        if entry_contains_product_decision(entry):
+            decisions.append(entry)
+        if entry.get("action") in OUTCOME_ACTIONS or entry_contains_product_decision(entry):
+            outcomes.append(entry)
+
+    def compact(entry: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "timestamp": entry.get("timestamp"),
+            "agent": entry.get("agent"),
+            "action": entry.get("action"),
+            "summary": compact_body(entry.get("summary") or "", limit=180),
+        }
+
+    return {
+        "events": [compact(e) for e in events[-limit:]],
+        "decisions": [compact(e) for e in decisions[-limit:]],
+        "outcomes": [compact(e) for e in outcomes[-limit:]],
+        "counts": {
+            "events": len(events),
+            "decisions": len(decisions),
+            "outcomes": len(outcomes),
+        },
+    }
+
+
+def read_field(text: str, field: str) -> str | None:
+    patterns = (
+        rf"^\*\*{re.escape(field)}:\*\*\s*(.+)$",
+        rf"^{re.escape(field)}:\s*(.+)$",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE | re.MULTILINE)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def active_experiments(today: date) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not ACTIVE_EXPERIMENTS_DIR.exists():
+        return rows
+
+    for path in sorted(ACTIVE_EXPERIMENTS_DIR.glob("*.md")):
+        text = path.read_text()
+        created_raw = read_field(text, "Created")
+        deployed_raw = read_field(text, "Deployed")
+        measure_raw = read_field(text, "Measure after")
+        created = parse_date(created_raw)
+        deployed = parse_date(deployed_raw)
+        measure_after = parse_date(measure_raw)
+        flags: list[str] = []
+
+        if measure_after and measure_after < today:
+            flags.append(f"measurement_overdue_by_{(today - measure_after).days}d")
+        if deployed_raw and "pending" in deployed_raw.lower():
+            created_age = age_days(created, today)
+            if created_age is not None and created_age > 7:
+                flags.append(f"deploy_pending_{created_age}d")
+        if created and not measure_after and (today - created).days > 21:
+            flags.append(f"no_parseable_measurement_date_{(today - created).days}d")
+
+        rows.append(
+            {
+                "file": str(path.relative_to(ROOT)),
+                "name": path.stem,
+                "created": created.isoformat() if created else None,
+                "deployed": deployed.isoformat() if deployed else deployed_raw,
+                "measureAfter": measure_after.isoformat() if measure_after else measure_raw,
+                "ageDays": age_days(created, today),
+                "flags": flags,
+            }
+        )
+    return rows
+
+
+def build_report(client: Paperclip, company_id: str, days: int, limit: int) -> dict[str, Any]:
+    generated = datetime.now(timezone.utc)
+    since = generated - timedelta(days=days)
+    agents = list_agents(client, company_id)
+    issues = list_issues(client, company_id, limit)
+
+    touched = [
+        issue
+        for issue in issues
+        if in_window(issue.get("createdAt"), since)
+        or in_window(issue.get("startedAt"), since)
+        or in_window(issue.get("completedAt"), since)
+        or in_window(issue.get("updatedAt"), since)
+    ]
+    created = [issue for issue in issues if in_window(issue.get("createdAt"), since)]
+    completed = [issue for issue in issues if in_window(issue.get("completedAt"), since)]
+    open_now = [issue for issue in issues if issue.get("status") in OPEN_STATUSES]
+
+    category_counts = Counter(classify_issue(issue, agents) for issue in touched)
+    status_counts = Counter(issue.get("status") or "unknown" for issue in touched)
+    creator_counts = Counter(creator_label(issue, agents) for issue in created)
+    assignee_counts = Counter(assignee_label(issue, agents) for issue in touched)
+    log = log_events(since)
+    experiments = active_experiments(generated.date())
+    stale_experiments = [row for row in experiments if row["flags"]]
+
+    completed_count = len(completed)
+    decision_count = log["counts"]["decisions"]
+    outcome_count = log["counts"]["outcomes"]
+    decision_yield = round(decision_count / completed_count, 3) if completed_count else None
+    outcome_yield = round(outcome_count / completed_count, 3) if completed_count else None
+    execution_categories = {
+        "pr_review",
+        "incident",
+        "deploy",
+        "qa_scan",
+        "maintenance",
+        "analyst_report",
+    }
+    execution_count = sum(category_counts[name] for name in execution_categories)
+    execution_share = round(execution_count / len(touched), 3) if touched else None
+
+    flags: list[str] = []
+    if completed_count >= 50 and decision_count < 3:
+        flags.append("activity_without_decisions")
+    if completed_count >= 10 and decision_yield is not None and decision_yield < 0.05:
+        flags.append("low_decision_yield")
+    if execution_share is not None and execution_share >= 0.7 and len(touched) >= 20:
+        flags.append("execution_heavy_week")
+    if stale_experiments:
+        flags.append("stale_active_experiments")
+    if len(experiments) > 2:
+        flags.append("too_many_active_experiments")
+
+    return {
+        "generatedAt": generated.isoformat(),
+        "companyId": company_id,
+        "window": {
+            "days": days,
+            "since": since.isoformat(),
+            "until": generated.isoformat(),
+        },
+        "issueLimit": limit,
+        "issues": {
+            "touched": len(touched),
+            "created": len(created),
+            "completed": completed_count,
+            "openNow": len(open_now),
+            "byCategory": dict(category_counts.most_common()),
+            "byStatus": dict(status_counts.most_common()),
+            "createdBy": dict(creator_counts.most_common()),
+            "assignedTo": dict(assignee_counts.most_common()),
+        },
+        "events": {
+            "decisionCount": decision_count,
+            "outcomeCount": outcome_count,
+            "decisionYield": decision_yield,
+            "outcomeYield": outcome_yield,
+            "recentDecisions": log["decisions"],
+            "recentOutcomes": log["outcomes"],
+        },
+        "activeExperiments": experiments,
+        "flags": flags,
+        "recommendedCeoActions": recommended_actions(flags),
+    }
+
+
+def recommended_actions(flags: list[str]) -> list[str]:
+    actions: list[str] = []
+    if "stale_active_experiments" in flags:
+        actions.append(
+            "Conclude, cancel, or explicitly re-date stale active experiments "
+            "before opening new bets."
+        )
+    if "activity_without_decisions" in flags or "low_decision_yield" in flags:
+        actions.append(
+            "Convert the week into decisions: one keep, one kill, one change, and one next bet."
+        )
+    if "execution_heavy_week" in flags:
+        actions.append(
+            "Throttle new execution tickets unless they trace to a named product "
+            "decision or incident threshold."
+        )
+    if "too_many_active_experiments" in flags:
+        actions.append("Reduce to at most two active experiments so attribution stays readable.")
+    if not actions:
+        actions.append(
+            "Record the top decision, shipped outcome, stopped work, and next bet "
+            "in the weekly outcome issue."
+        )
+    return actions
+
+
+def print_text(report: dict[str, Any]) -> None:
+    window = report["window"]
+    issues = report["issues"]
+    events = report["events"]
+    print(f"paperclip_outcome_audit generated_at={report['generatedAt']}")
+    print(f"window_days={window['days']} since={window['since']} until={window['until']}")
+    print()
+    print(
+        "issues "
+        f"touched={issues['touched']} created={issues['created']} "
+        f"completed={issues['completed']} open_now={issues['openNow']}"
+    )
+    print(
+        "events "
+        f"decisions={events['decisionCount']} outcomes={events['outcomeCount']} "
+        f"decision_yield={events['decisionYield']} outcome_yield={events['outcomeYield']}"
+    )
+    print()
+    print("category_mix:")
+    for category, count in issues["byCategory"].items():
+        print(f"  {category}: {count}")
+    print()
+    print("created_by:")
+    for creator, count in issues["createdBy"].items():
+        print(f"  {creator}: {count}")
+    if report["activeExperiments"]:
+        print()
+        print("active_experiments:")
+        for experiment in report["activeExperiments"]:
+            flags = ",".join(experiment["flags"]) if experiment["flags"] else "ok"
+            print(
+                f"  {experiment['name']}: created={experiment['created']} "
+                f"deployed={experiment['deployed']} measure_after={experiment['measureAfter']} "
+                f"flags={flags}"
+            )
+    if report["flags"]:
+        print()
+        print("flags:")
+        for flag in report["flags"]:
+            print(f"  {flag}")
+    if events["recentDecisions"]:
+        print()
+        print("recent_decisions:")
+        for event in events["recentDecisions"]:
+            print(f"  {event['timestamp']} {event['action']}: {event['summary']}")
+    print()
+    print("recommended_ceo_actions:")
+    for action in report["recommendedCeoActions"]:
+        print(f"  - {action}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--company-id",
+        default=os.getenv("PAPERCLIP_COMPANY_ID", DEFAULT_COMPANY_ID),
+    )
+    parser.add_argument("--days", type=int, default=7)
+    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args()
+
+    base_url = os.getenv("PAPERCLIP_URL")
+    api_key = os.getenv("PAPERCLIP_API_KEY")
+    if not base_url or not api_key:
+        print("Set PAPERCLIP_URL and PAPERCLIP_API_KEY", file=sys.stderr)
+        return 2
+
+    client = Paperclip(base_url, api_key)
+    report = build_report(client, args.company_id, args.days, args.limit)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_text(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/paperclip_outcome_audit.py
+++ b/scripts/paperclip_outcome_audit.py
@@ -5,7 +5,7 @@ This separates agent activity from product learning. It is intentionally
 compact enough to paste into a CEO weekly review without dumping raw issue JSON.
 
 Env:
-  PAPERCLIP_URL
+  PAPERCLIP_API_URL (preferred) or PAPERCLIP_URL (legacy/local)
   PAPERCLIP_API_KEY
   PAPERCLIP_COMPANY_ID (optional, defaults to FFmemes prod company)
 """
@@ -223,7 +223,16 @@ def log_events(since: datetime, limit: int = 12) -> dict[str, Any]:
     decisions: list[dict[str, Any]] = []
     outcomes: list[dict[str, Any]] = []
     if not LOG_PATH.exists():
-        return {"events": [], "decisions": [], "outcomes": []}
+        return {
+            "events": [],
+            "decisions": [],
+            "outcomes": [],
+            "counts": {
+                "events": 0,
+                "decisions": 0,
+                "outcomes": 0,
+            },
+        }
 
     for line in LOG_PATH.read_text().splitlines():
         entry = parse_log_entry(line)
@@ -483,10 +492,13 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     args = parser.parse_args()
 
-    base_url = os.getenv("PAPERCLIP_URL")
+    base_url = os.getenv("PAPERCLIP_API_URL") or os.getenv("PAPERCLIP_URL")
     api_key = os.getenv("PAPERCLIP_API_KEY")
     if not base_url or not api_key:
-        print("Set PAPERCLIP_URL and PAPERCLIP_API_KEY", file=sys.stderr)
+        print(
+            "Set PAPERCLIP_API_URL (or legacy PAPERCLIP_URL) and PAPERCLIP_API_KEY",
+            file=sys.stderr,
+        )
         return 2
 
     client = Paperclip(base_url, api_key)

--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python3
-"""Compact read-only audit for Paperclip routine outcomes.
+"""Compact read-only audit for FFmemes-specific Paperclip routine outcomes.
 
-This is intentionally narrow: it turns routine issues/comments into a small
-outcome report so agents do not spend context manually spelunking Paperclip JSON.
+This is intentionally narrow and business-focused: it turns routine
+issues/comments into a small report of FFmemes outcome-contract mismatches
+(post publication markers, update-check content, deploy verification,
+gstack update path, draft handoff state, PR payload mismatch) so agents
+do not spend context manually spelunking Paperclip JSON.
+
+Generic liveness, stall / zombie-run detection, and no-comment classification
+are intentionally NOT covered here — those are owned by Paperclip v2026.428+
+productivity review / liveness recovery in the native runtime.
 
 Env:
   PAPERCLIP_URL
@@ -38,6 +45,9 @@ PUBLISHED_MARKER_PATTERNS = (
     re.compile(r"\b(?:editorial_post_id|editorial post id)\b", re.IGNORECASE),
     re.compile(r"\b(?:telegram_message_id|telegram message id)\b", re.IGNORECASE),
 )
+INTERACTION_LIST_KEYS = ("interactions", "items", "data")
+CONFIRMATION_KIND_MARKERS = ("confirmation", "request_confirmation")
+ACCEPTED_MARKERS = {"accepted", "approved", "confirmed", "yes"}
 VERIFIED_PAPERCLIP_DEPLOY_PATTERNS = (
     re.compile(r"\bverified_deployed_commit\b", re.IGNORECASE),
     re.compile(r"\bcoolify_deployment_commit\b", re.IGNORECASE),
@@ -110,6 +120,21 @@ def issue_comments(client: Paperclip, issue_id: str) -> list[dict[str, Any]]:
     return sorted(comments, key=lambda item: item.get("createdAt") or "")
 
 
+def issue_interactions(client: Paperclip, issue_id: str) -> list[dict[str, Any]]:
+    try:
+        interactions = client.get(f"/api/issues/{issue_id}/interactions", {"limit": "100"})
+    except RuntimeError:
+        return []
+    if isinstance(interactions, list):
+        return interactions
+    if isinstance(interactions, dict):
+        for key in INTERACTION_LIST_KEYS:
+            value = interactions.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+    return []
+
+
 def get_issue(client: Paperclip, issue_id: str) -> dict[str, Any] | None:
     try:
         issue = client.get(f"/api/issues/{issue_id}")
@@ -137,7 +162,55 @@ def routine_matches(name: str, focus: str) -> bool:
     return focus.lower() in lower
 
 
-def classify_issue(issue: dict[str, Any], comments: list[dict[str, Any]]) -> tuple[list[str], str]:
+def interaction_value(interaction: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = interaction.get(key)
+        if value is not None:
+            return str(value).lower()
+    return ""
+
+
+def has_accepted_confirmation(interactions: list[dict[str, Any]]) -> bool:
+    for interaction in interactions:
+        kind = interaction_value(interaction, "kind", "type", "interactionType", "name")
+        if not any(marker in kind for marker in CONFIRMATION_KIND_MARKERS):
+            continue
+        state = interaction_value(
+            interaction,
+            "status",
+            "state",
+            "outcome",
+            "decision",
+            "response",
+            "answer",
+            "value",
+        )
+        if state in ACCEPTED_MARKERS:
+            return True
+        if interaction.get("acceptedAt") or interaction.get("confirmedAt"):
+            return True
+        result = interaction.get("result")
+        if isinstance(result, dict):
+            result_state = interaction_value(
+                result,
+                "status",
+                "state",
+                "outcome",
+                "decision",
+                "response",
+                "answer",
+                "value",
+            )
+            if result_state in ACCEPTED_MARKERS:
+                return True
+    return False
+
+
+def classify_issue(
+    issue: dict[str, Any],
+    comments: list[dict[str, Any]],
+    interactions: list[dict[str, Any]] | None = None,
+) -> tuple[list[str], str]:
     text = "\n".join([issue.get("description") or ""] + [c.get("body") or "" for c in comments])
     lower = text.lower()
     title = (issue.get("title") or "").lower()
@@ -168,14 +241,14 @@ def classify_issue(issue: dict[str, Any], comments: list[dict[str, Any]]) -> tup
         or "outcome=published" in lower
         or "ceo approval" in lower
     )
-    if (
-        is_publish_flow
-        and "approved" in lower
-        and not all(pattern.search(text) for pattern in PUBLISHED_MARKER_PATTERNS)
+    has_approval_signal = "approved" in lower or has_accepted_confirmation(interactions or [])
+    if is_publish_flow and has_approval_signal and not all(
+        pattern.search(text) for pattern in PUBLISHED_MARKER_PATTERNS
     ):
         flags.append("approved_without_publish_marker")
-    if not comments and issue.get("status") == "done":
-        flags.append("no_comments")
+    # Generic stall / no-comment / zombie-run classification is intentionally
+    # delegated to Paperclip v2026.428+ productivity review and liveness
+    # recovery; this audit only flags FFmemes business-outcome mismatches.
     latest = comments[-1].get("body", "") if comments else issue.get("description", "")
     return flags, compact_body(latest or "")
 
@@ -191,7 +264,8 @@ def referenced_post_issues(
         ref = get_issue(client, ident)
         if ref and (ref.get("title") or "").startswith("[post:"):
             ref_comments = issue_comments(client, ref["id"])
-            flags, latest = classify_issue(ref, ref_comments)
+            ref_interactions = issue_interactions(client, ref["id"])
+            flags, latest = classify_issue(ref, ref_comments, ref_interactions)
             found.append(
                 {
                     "identifier": ref.get("identifier"),
@@ -223,7 +297,8 @@ def audit_routines(client: Paperclip, company_id: str, focus: str) -> list[dict[
         issue_id = run.get("linkedIssueId")
         issue = get_issue(client, issue_id) if issue_id else None
         comments = issue_comments(client, issue_id) if issue_id else []
-        flags, latest = classify_issue(issue or {}, comments)
+        interactions = issue_interactions(client, issue_id) if issue_id else []
+        flags, latest = classify_issue(issue or {}, comments, interactions)
         payload_pr = str(((run.get("triggerPayload") or {}).get("pr_number")) or "")
         issue_title = (
             ((run.get("linkedIssue") or {}).get("title")) or (issue or {}).get("title") or ""
@@ -257,7 +332,8 @@ def stale_post_drafts(client: Paperclip, company_id: str) -> list[dict[str, Any]
         if not title.startswith("[post:"):
             continue
         comments = issue_comments(client, issue["id"])
-        flags, latest = classify_issue(issue, comments)
+        interactions = issue_interactions(client, issue["id"])
+        flags, latest = classify_issue(issue, comments, interactions)
         if flags or issue.get("status") != "done":
             rows.append(
                 {

--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -12,7 +12,7 @@ are intentionally NOT covered here — those are owned by Paperclip v2026.428+
 productivity review / liveness recovery in the native runtime.
 
 Env:
-  PAPERCLIP_URL
+  PAPERCLIP_API_URL (preferred in Paperclip runtime) or PAPERCLIP_URL
   PAPERCLIP_API_KEY
   PAPERCLIP_COMPANY_ID (optional, defaults to FFmemes prod company)
 """
@@ -90,6 +90,13 @@ class Paperclip:
         except urllib.error.HTTPError as exc:
             body = compact_body(exc.read().decode("utf-8", errors="replace"), limit=500)
             raise RuntimeError(f"HTTP {exc.code} for {path}: {body}") from exc
+
+
+def paperclip_base_url() -> str | None:
+    base_url = os.getenv("PAPERCLIP_API_URL") or os.getenv("PAPERCLIP_URL")
+    if base_url and base_url.rstrip("/").endswith("/api"):
+        return base_url.rstrip("/")[:-4]
+    return base_url
 
 
 def parse_ts(value: str | None) -> datetime | None:
@@ -384,10 +391,10 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     args = parser.parse_args()
 
-    base_url = os.getenv("PAPERCLIP_URL")
+    base_url = paperclip_base_url()
     api_key = os.getenv("PAPERCLIP_API_KEY")
     if not base_url or not api_key:
-        print("Set PAPERCLIP_URL and PAPERCLIP_API_KEY", file=sys.stderr)
+        print("Set PAPERCLIP_API_URL (or PAPERCLIP_URL) and PAPERCLIP_API_KEY", file=sys.stderr)
         return 2
 
     client = Paperclip(base_url, api_key)


### PR DESCRIPTION
## Summary

- move agent prompts toward native Paperclip v2026.428 coordination: structured confirmations, child issues/subtasks, documents/attachments, concise comments, and native completion
- make Comms/CEO publication approval use accepted structured confirmation cards as the authoritative gate; keep magic comments only as legacy fallback for old drafts
- narrow `paperclip_routine_audit.py` to FFmemes outcome-contract checks and delegate generic liveness/stall/zombie/no-comment checks to native Paperclip productivity/recovery
- add a CEO weekly outcome ledger and `paperclip_outcome_audit.py` so weekly reviews measure decisions, shipped outcomes, stale experiments, and next bets instead of raw issue volume

## Verification

- Claude Code implementation pass completed
- Subagent inspection before edits: prompt/audit cleanup recommendations
- Subagent verification after edits: no blockers
- Claude Code read-only verification after edits: no blockers
- `python -m py_compile scripts/paperclip_routine_audit.py scripts/paperclip_outcome_audit.py`
- `git diff --check`
- live smoke with Paperclip env loaded:
  - `python scripts/paperclip_routine_audit.py --focus all --json`
  - `python scripts/paperclip_outcome_audit.py --days 7 --limit 500 --json`
- local unit smoke for `classify_issue()` accepted structured confirmation, publish markers, and no-comment behavior

## Notes for reviewer

Paperclip stable is still v2026.428.0. This PR does not upgrade runtime; it adopts built-in v428 coordination/recovery surfaces and removes local duplicate liveness semantics from the routine audit.
