### PR TITLE
Fix: serialize Telegram webhook updates per user

### DIFF
--- a/src/tgbot/app.py
+++ b/src/tgbot/app.py
@@ -1,3 +1,5 @@
+import logging
+
 from telegram import Update
 from telegram.ext import (
     AIORateLimiter,
@@ -91,8 +93,15 @@ from src.tgbot.handlers.treasury.commands import (
     handle_show_leaderbaord,
 )
 from src.tgbot.handlers.upload import moderation, stats, upload_meme
+from src.tgbot.update_lock import acquire_update_user_lock, release_update_user_lock
 
 application: Application = None  # type: ignore
+
+
+def _get_update_user_id(update: Update) -> int | None:
+    if update.effective_user is None:
+        return None
+    return update.effective_user.id
 
 
 def add_handlers(application: Application) -> None:
@@ -504,7 +513,22 @@ async def process_event(payload: dict) -> None:
     # TODO: try await application.update_queue.put(update)
     # https://github.com/python-telegram-bot/python-telegram-bot/wiki/Webhooks#custom-solution
 
+    lock = None
     try:
+        user_id = _get_update_user_id(update)
+        if user_id is not None:
+            try:
+                # FastAPI runs webhook background tasks concurrently across Gunicorn workers.
+                # Keep one user's handler chain serialized so double taps/retries don't overlap
+                # DB-heavy reaction and next-message operations.
+                lock = await acquire_update_user_lock(user_id)
+            except Exception:  # noqa: BLE001
+                logging.warning(
+                    "Failed to acquire Telegram update lock for user %s; processing unlocked",
+                    user_id,
+                    exc_info=True,
+                )
+
         await application.process_update(update)
     except Exception as e:
         import sys
@@ -515,6 +539,11 @@ async def process_event(payload: dict) -> None:
         sys.stderr.write(f"[process_event] UNHANDLED ERROR{cb}: {e}\n")
         sys.stderr.flush()
         raise
+    finally:
+        try:
+            await release_update_user_lock(lock)
+        except Exception:  # noqa: BLE001
+            logging.warning("Failed to release Telegram update lock", exc_info=True)
 
 
 async def setup_webhook(application: Application) -> None:

--- a/src/tgbot/update_lock.py
+++ b/src/tgbot/update_lock.py
@@ -1,0 +1,39 @@
+import asyncio
+import uuid
+
+from src import redis
+
+UPDATE_USER_LOCK_TTL_SECONDS = 120
+UPDATE_USER_LOCK_POLL_SECONDS = 0.05
+_RELEASE_LOCK_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+end
+return 0
+"""
+
+
+async def acquire_update_user_lock(user_id: int) -> tuple[str, str]:
+    """Serialize webhook updates for one Telegram user across Gunicorn workers."""
+    lock_key = f"tg_update_user_lock:{user_id}"
+    token = str(uuid.uuid4())
+
+    while True:
+        acquired = await redis.redis_client.set(
+            lock_key,
+            token,
+            nx=True,
+            ex=UPDATE_USER_LOCK_TTL_SECONDS,
+        )
+        if acquired:
+            return lock_key, token
+
+        await asyncio.sleep(UPDATE_USER_LOCK_POLL_SECONDS)
+
+
+async def release_update_user_lock(lock: tuple[str, str] | None) -> None:
+    if lock is None:
+        return
+
+    lock_key, token = lock
+    await redis.redis_client.eval(_RELEASE_LOCK_SCRIPT, 1, lock_key, token)

--- a/tests/tgbot/test_process_event.py
+++ b/tests/tgbot/test_process_event.py
@@ -1,0 +1,53 @@
+import asyncio
+
+import pytest
+
+from src.tgbot import update_lock
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    async def set(self, key: str, token: str, *, nx: bool, ex: int) -> bool:
+        assert nx is True
+        assert ex == update_lock.UPDATE_USER_LOCK_TTL_SECONDS
+        if key in self.values:
+            return False
+        self.values[key] = token
+        return True
+
+    async def eval(self, script: str, numkeys: int, key: str, token: str) -> int:
+        assert script == update_lock._RELEASE_LOCK_SCRIPT
+        assert numkeys == 1
+        if self.values.get(key) != token:
+            return 0
+        self.values.pop(key, None)
+        return 1
+
+
+@pytest.mark.parametrize("user_id", [12345])
+async def test_update_lock_serializes_same_user(monkeypatch, user_id):
+    active_updates = 0
+    max_active_updates = 0
+
+    async def process_locked_update():
+        nonlocal active_updates, max_active_updates
+
+        lock = await update_lock.acquire_update_user_lock(user_id)
+        try:
+            active_updates += 1
+            max_active_updates = max(max_active_updates, active_updates)
+            await asyncio.sleep(0.01)
+            active_updates -= 1
+        finally:
+            await update_lock.release_update_user_lock(lock)
+
+    monkeypatch.setattr(update_lock.redis, "redis_client", FakeRedis())
+
+    await asyncio.gather(
+        process_locked_update(),
+        process_locked_update(),
+    )
+
+    assert max_active_updates == 1


### PR DESCRIPTION
Fixes FFM-1090.

## What changed
- Added a Redis-backed per-user lock around Telegram webhook update processing.
- Kept the lock cross-worker safe for Gunicorn and released it with token-checked Redis Lua cleanup.
- Added a focused async regression test proving two same-user updates cannot enter the critical section concurrently.

## Why
The custom FastAPI webhook processes updates in background tasks. Under duplicate Telegram callbacks/retries, two handlers for the same user can overlap across workers and run the DB-heavy reaction/next-message chain concurrently, matching the recurring asyncpg InternalClientError pattern.

## Verification
- ruff check --fix src/ tests/
- ruff format src/ tests/
- DATABASE_URL='postgresql+asyncpg://app:app@app_db:5432/app' REDIS_URL='redis://:myStrongPassword@redis:6379' CORS_ORIGINS='["http://localhost:3000"]' CORS_HEADERS='["*"]' ENVIRONMENT=TESTING SITE_DOMAIN=127.0.0.1 TELEGRAM_BOT_TOKEN='123456:ABCdefGHIjklMNOpqrSTUvwxYZ1234567890' TELEGRAM_BOT_USERNAME='test_bot' TELEGRAM_BOT_WEBHOOK_SECRET='test-secret' MEME_STORAGE_TELEGRAM_CHAT_ID='1' UPLOADED_MEMES_REVIEW_CHAT_ID='2' ADMIN_LOGS_CHAT_ID='3' python3 -m pytest tests/tgbot/test_process_event.py -q

Note: local pytest emits a warning because this host lacks the pytest-env plugin; env vars were passed explicitly.