### PR TITLE
Implement recently_liked blender v2 experiment

### DIFF
--- a/alembic/versions/2026-05-09_recently_liked_blender_v2.py
+++ b/alembic/versions/2026-05-09_recently_liked_blender_v2.py
@@ -1,0 +1,144 @@
+"""recently liked blender v2 assignment metadata
+
+Revision ID: 1a2b3c4d5e6f
+Revises: 24cd1a8bd9b8
+Create Date: 2026-05-09 10:45:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "1a2b3c4d5e6f"
+down_revision = "24cd1a8bd9b8"
+branch_labels = None
+depends_on = None
+
+
+EXPERIMENT_ID = "recently_liked_blender_v2"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "experiment_assignment",
+        sa.Column(
+            "assignment_metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+            CREATE VIEW v_recently_liked_blender_v2_assignment AS
+            SELECT
+                ea.user_id,
+                ea.variant,
+                ea.assigned_at,
+                (ea.assignment_metadata->>'lr_quartile')::int AS lr_quartile,
+                (ea.assignment_metadata->>'likes_7d')::int AS likes_7d,
+                (ea.assignment_metadata->>'reactions_7d')::int AS reactions_7d,
+                (ea.assignment_metadata->>'lr_7d')::float AS lr_7d,
+                COALESCE(
+                    (ea.assignment_metadata->>'high_volume_skipper')::boolean,
+                    false
+                ) AS high_volume_skipper,
+                ea.assignment_metadata->>'excluded_reason' AS excluded_reason,
+                ea.assignment_metadata->'assigned_weights' AS assigned_weights,
+                (ea.assignment_metadata->>'sample_gate_per_variant')::int
+                    AS sample_gate_per_variant,
+                ea.assignment_metadata->'day3_guardrail' AS day3_guardrail
+            FROM experiment_assignment ea
+            WHERE ea.experiment_id = '{EXPERIMENT_ID}'
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+            CREATE VIEW v_recently_liked_blender_v2_sample_gate AS
+            SELECT
+                variant,
+                COUNT(*) AS assigned_users,
+                COUNT(*) >= 1000 AS sample_gate_met
+            FROM experiment_assignment
+            WHERE experiment_id = '{EXPERIMENT_ID}'
+                AND variant IN ('control', 'treatment')
+            GROUP BY variant
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+            CREATE VIEW v_recently_liked_blender_v2_engine_metrics AS
+            WITH assignment AS (
+                SELECT user_id, variant, assigned_at
+                FROM experiment_assignment
+                WHERE experiment_id = '{EXPERIMENT_ID}'
+                    AND variant IN ('control', 'treatment')
+            ),
+            reactions AS (
+                SELECT
+                    a.variant,
+                    r.user_id,
+                    r.meme_id,
+                    r.recommended_by,
+                    r.reaction_id,
+                    r.sent_at,
+                    r.reacted_at,
+                    LEAD(r.sent_at) OVER (
+                        PARTITION BY r.user_id
+                        ORDER BY r.sent_at
+                    ) AS next_sent_at
+                FROM assignment a
+                INNER JOIN user_meme_reaction r
+                    ON r.user_id = a.user_id
+                    AND r.sent_at >= a.assigned_at
+                WHERE r.recommended_by IS NOT NULL
+            )
+            SELECT
+                variant,
+                recommended_by,
+                COUNT(*) AS total_sent,
+                COUNT(reaction_id) AS total_reactions,
+                COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+                ROUND(
+                    100.0 * COUNT(*) FILTER (WHERE reaction_id = 1)
+                    / NULLIF(COUNT(reaction_id), 0),
+                    1
+                ) AS like_rate_pct,
+                ROUND(
+                    100.0 * COUNT(*)
+                    / NULLIF(SUM(COUNT(*)) OVER (PARTITION BY variant), 0),
+                    1
+                ) AS allocation_pct,
+                COUNT(*) FILTER (
+                    WHERE next_sent_at IS NOT NULL
+                        AND next_sent_at - sent_at <= INTERVAL '30 minutes'
+                ) AS continuation_events,
+                ROUND(
+                    100.0 * COUNT(*) FILTER (
+                        WHERE next_sent_at IS NOT NULL
+                            AND next_sent_at - sent_at <= INTERVAL '30 minutes'
+                    ) / NULLIF(COUNT(*), 0),
+                    1
+                ) AS continuation_rate_pct
+            FROM reactions
+            GROUP BY variant, recommended_by
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP VIEW IF EXISTS v_recently_liked_blender_v2_engine_metrics"))
+    op.execute(sa.text("DROP VIEW IF EXISTS v_recently_liked_blender_v2_sample_gate"))
+    op.execute(sa.text("DROP VIEW IF EXISTS v_recently_liked_blender_v2_assignment"))
+    op.drop_column("experiment_assignment", "assignment_metadata")

--- a/experiments/active/2026-05-09-recently-liked-blender-v2.md
+++ b/experiments/active/2026-05-09-recently-liked-blender-v2.md
@@ -1,0 +1,64 @@
+# Experiment: recently_liked Blender V2
+Created: 2026-05-09
+Status: active - implementation delegated
+Owner: ceo
+Measure after: after each variant reaches at least 1,000 assigned mature users
+
+## Hypothesis
+
+The `recently_liked` engine is still under-allocated for mature users. The first mature-user blender A/B was rolled back after a severe LR guardrail breach, but post-rollback analysis shows the engine itself has 98.0% session continuation at its natural allocation, second only to `uploaded_meme` and above `lr_smoothed` at 95.3%.
+
+The v1 failure is therefore treated as an experiment-design failure, not proof that `recently_liked` is harmful. If assignment is stratified by each user's recent like-rate behavior and high-volume skippers are balanced or excluded, increasing `recently_liked` allocation for mature users should improve median session depth without breaching LR or freshness guardrails.
+
+## Changes Made
+
+- 2026-05-09 CEO decision from [FFM-1093](/FFM/issues/FFM-1093): open a redesigned v2 A/B instead of immediately re-enabling the v1 weights.
+- CTO implementation delegated in Paperclip to build LR-stratified assignment, high-volume-skipper handling, and explicit sample gates before the experiment can be read.
+- Analyst measurement delegated in Paperclip and blocked on deployment.
+
+## Metrics Before
+
+| Metric | Value |
+|--------|-------|
+| Session length median | 19.5 |
+| WAU | 594 |
+| MAU | 1,091 |
+| DAU | 249 |
+| ok_pct | 94% |
+| Reactions 24h | 20,957 partial 10h |
+| `recently_liked` continuation | 98.0% |
+| `lr_smoothed` continuation | 95.3% |
+| V1 final LR delta | treatment 30.3% vs control 44.3% (-14.0pp) |
+| V1 final median session depth delta | treatment 15.0 vs control 17.5 (-2.5 memes) |
+| V1 high-volume skipper imbalance | 34 treatment vs 15 control (2.3x) |
+
+## Design Requirements
+
+- Mature users only; keep cold-start routing out of scope.
+- Assign users within 7d personal-like-rate quartiles at enrollment time.
+- Exclude users with 7d LR <20% and >50 reactions, or explicitly balance them across variants if exclusion is not technically practical.
+- Do not read winner/loser results until each variant has at least 1,000 assigned users.
+- Track per-variant LR, median session depth, per-user median LR, high-volume-skipper counts, engine allocation mix, and per-engine continuation.
+- Add a Day-3 guardrail checkpoint, but treat the minimum sample gate as the primary read rule.
+
+## Success Criteria
+
+- Treatment median session depth improves by at least 5% versus control after the sample gate is met.
+- Treatment LR is no worse than 2pp below control.
+- High-volume skipper composition differs by no more than 1.3x between arms.
+- Per-engine diagnostics do not show broad treatment-arm underperformance across unaffected engines.
+
+## Failure Criteria
+
+- LR guardrail drops more than 4pp below control at Day 3 and cohort diagnostics do not clearly exonerate treatment.
+- Treatment median session depth remains below control after the sample gate is met.
+- Assignment stratification cannot be verified before rollout.
+- V2 cannot reach 1,000 users per variant in a reasonable window without overexposing the same high-volume users.
+
+## Metrics After
+
+Pending deployment and measurement.
+
+## Conclusion
+
+Pending. V2 exists to test the engine under a corrected experiment design, not to relitigate v1's confounded result.

--- a/src/database.py
+++ b/src/database.py
@@ -723,6 +723,12 @@ experiment_assignment = Table(
     Column("experiment_id", String(100), nullable=False),
     Column("user_id", BigInteger, ForeignKey("user.id", ondelete="CASCADE"), nullable=False),
     Column("variant", String(50), nullable=False),  # 'control', 'treatment', etc.
+    Column(
+        "assignment_metadata",
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    ),
     Column("assigned_at", DateTime, server_default=func.now(), nullable=False),
     UniqueConstraint("experiment_id", "user_id", name="uq_experiment_assignment"),
 )

--- a/src/recommendations/blender_experiments.py
+++ b/src/recommendations/blender_experiments.py
@@ -1,0 +1,192 @@
+import hashlib
+import logging
+from typing import Any
+
+from sqlalchemy import text
+
+from src.database import fetch_one
+from src.tgbot.service import (
+    assign_experiment,
+    get_experiment_assignment,
+    get_experiment_variant,
+)
+
+logger = logging.getLogger(__name__)
+
+RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID = "recently_liked_blender_v2"
+RECENTLY_LIKED_BLENDER_V2_CONTROL = "control"
+RECENTLY_LIKED_BLENDER_V2_TREATMENT = "treatment"
+RECENTLY_LIKED_BLENDER_V2_EXCLUDED = "excluded_high_volume_skipper"
+RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT = 1000
+RECENTLY_LIKED_BLENDER_V2_MATURE_MIN_MEMES_SENT = 100
+RECENTLY_LIKED_BLENDER_V2_SKIPPER_MIN_REACTIONS_7D = 50
+RECENTLY_LIKED_BLENDER_V2_SKIPPER_MAX_LR_7D = 0.20
+
+MATURE_BLENDER_CONTROL_WEIGHTS = {
+    "best_uploaded_memes": 0.3,
+    "like_spread_and_recent_memes": 0.3,
+    "lr_smoothed": 0.4,
+    "recently_liked": 0.2,
+    "goat": 0.1,
+    "es_ranked": 0.1,
+}
+MATURE_BLENDER_TREATMENT_WEIGHTS = {
+    "best_uploaded_memes": 0.3,
+    "like_spread_and_recent_memes": 0.25,
+    "lr_smoothed": 0.35,
+    "recently_liked": 0.3,
+    "goat": 0.1,
+    "es_ranked": 0.1,
+}
+
+
+def _variant_for_quartile(user_id: int, lr_quartile: int) -> str:
+    key = f"{RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID}:{lr_quartile}:{user_id}"
+    bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 2
+    if bucket == 0:
+        return RECENTLY_LIKED_BLENDER_V2_CONTROL
+    return RECENTLY_LIKED_BLENDER_V2_TREATMENT
+
+
+def _weights_for_variant(variant: str) -> dict[str, float]:
+    if variant == RECENTLY_LIKED_BLENDER_V2_TREATMENT:
+        return dict(MATURE_BLENDER_TREATMENT_WEIGHTS)
+    return dict(MATURE_BLENDER_CONTROL_WEIGHTS)
+
+
+async def get_recent_7d_lr_assignment_metrics(user_id: int) -> dict[str, Any]:
+    """Return enrollment-time 7d LR metrics and mature-user LR quartile."""
+    query = text(
+        """
+        WITH recent_reactions AS MATERIALIZED (
+            SELECT
+                umr.user_id,
+                COUNT(*) FILTER (WHERE umr.reaction_id IN (1, 2)) AS reactions_7d,
+                COUNT(*) FILTER (WHERE umr.reaction_id = 1) AS likes_7d
+            FROM user_meme_reaction umr
+            INNER JOIN user_stats us ON us.user_id = umr.user_id
+            WHERE umr.reacted_at >= NOW() - INTERVAL '7 days'
+                AND umr.reaction_id IN (1, 2)
+                AND us.nmemes_sent >= :mature_min_memes_sent
+            GROUP BY umr.user_id
+        ),
+        ranked AS (
+            SELECT
+                user_id,
+                reactions_7d,
+                likes_7d,
+                likes_7d::float / NULLIF(reactions_7d, 0) AS lr_7d,
+                NTILE(4) OVER (
+                    ORDER BY likes_7d::float / NULLIF(reactions_7d, 0)
+                ) AS lr_quartile
+            FROM recent_reactions
+        )
+        SELECT
+            COALESCE(r.likes_7d, 0) AS likes_7d,
+            COALESCE(r.reactions_7d, 0) AS reactions_7d,
+            COALESCE(r.lr_7d, 0.0) AS lr_7d,
+            COALESCE(r.lr_quartile, 1) AS lr_quartile
+        FROM (SELECT CAST(:user_id AS bigint) AS user_id) target
+        LEFT JOIN ranked r ON r.user_id = target.user_id
+        """
+    )
+    row = await fetch_one(
+        query,
+        {
+            "user_id": user_id,
+            "mature_min_memes_sent": RECENTLY_LIKED_BLENDER_V2_MATURE_MIN_MEMES_SENT,
+        },
+    )
+    if row is None:
+        return {
+            "likes_7d": 0,
+            "reactions_7d": 0,
+            "lr_7d": 0.0,
+            "lr_quartile": 1,
+        }
+    return {
+        "likes_7d": int(row["likes_7d"] or 0),
+        "reactions_7d": int(row["reactions_7d"] or 0),
+        "lr_7d": float(row["lr_7d"] or 0.0),
+        "lr_quartile": int(row["lr_quartile"] or 1),
+    }
+
+
+def build_recently_liked_blender_v2_assignment(
+    user_id: int,
+    metrics: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    lr_7d = float(metrics["lr_7d"])
+    reactions_7d = int(metrics["reactions_7d"])
+    lr_quartile = int(metrics["lr_quartile"])
+    high_volume_skipper = (
+        reactions_7d > RECENTLY_LIKED_BLENDER_V2_SKIPPER_MIN_REACTIONS_7D
+        and lr_7d < RECENTLY_LIKED_BLENDER_V2_SKIPPER_MAX_LR_7D
+    )
+
+    if high_volume_skipper:
+        variant = RECENTLY_LIKED_BLENDER_V2_EXCLUDED
+        excluded_reason = "lr_7d_below_20pct_and_reactions_7d_above_50"
+    else:
+        variant = _variant_for_quartile(user_id, lr_quartile)
+        excluded_reason = None
+
+    assignment_metadata = {
+        "assignment_strategy": "sha256(experiment_id:lr_quartile:user_id)%2",
+        "lr_quartile": lr_quartile,
+        "likes_7d": int(metrics["likes_7d"]),
+        "reactions_7d": reactions_7d,
+        "lr_7d": round(lr_7d, 6),
+        "high_volume_skipper": high_volume_skipper,
+        "excluded_reason": excluded_reason,
+        "sample_gate_per_variant": RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT,
+        "day3_guardrail": {
+            "checkpoint": "rollout_time_plus_3_days",
+            "failure_lr_delta_pp": -4,
+            "primary_read_rule": "sample_gate_per_variant",
+        },
+        "assigned_weights": _weights_for_variant(variant),
+    }
+    return variant, assignment_metadata
+
+
+async def get_or_assign_recently_liked_blender_v2_variant(user_id: int) -> str:
+    assignment = await get_experiment_assignment(
+        user_id,
+        RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID,
+    )
+    if assignment is not None:
+        return assignment["variant"]
+
+    metrics = await get_recent_7d_lr_assignment_metrics(user_id)
+    proposed_variant, assignment_metadata = build_recently_liked_blender_v2_assignment(
+        user_id,
+        metrics,
+    )
+    inserted = await assign_experiment(
+        user_id,
+        RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID,
+        proposed_variant,
+        assignment_metadata,
+    )
+    if inserted:
+        return proposed_variant
+
+    return (
+        await get_experiment_variant(user_id, RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID)
+        or RECENTLY_LIKED_BLENDER_V2_CONTROL
+    )
+
+
+async def get_recently_liked_blender_v2_weights(user_id: int) -> dict[str, float]:
+    try:
+        variant = await get_or_assign_recently_liked_blender_v2_variant(user_id)
+    except Exception:
+        logger.warning(
+            "recently_liked blender v2 assignment failed for user %d",
+            user_id,
+            exc_info=True,
+        )
+        return dict(MATURE_BLENDER_CONTROL_WEIGHTS)
+
+    return _weights_for_variant(variant)

--- a/src/recommendations/blender_experiments.py
+++ b/src/recommendations/blender_experiments.py
@@ -33,7 +33,6 @@ RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_KEY = (
 )
 RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_TTL_SECONDS = 15 * 60
 RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_SECONDS = 30
-RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES = (0.25, 0.5, 0.75)
 
 MATURE_BLENDER_CONTROL_WEIGHTS = {
     "best_uploaded_memes": 0.3,
@@ -67,9 +66,9 @@ def _weights_for_variant(variant: str) -> dict[str, float]:
     return dict(MATURE_BLENDER_CONTROL_WEIGHTS)
 
 
-def _coerce_lr_quartile_boundaries(raw_boundaries: Any) -> tuple[float, float, float]:
+def _coerce_lr_quartile_boundaries(raw_boundaries: Any) -> tuple[float, float, float] | None:
     if raw_boundaries is None:
-        return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+        return None
 
     if isinstance(raw_boundaries, str):
         raw_boundaries = raw_boundaries.strip("{}").split(",")
@@ -81,14 +80,14 @@ def _coerce_lr_quartile_boundaries(raw_boundaries: Any) -> tuple[float, float, f
             "invalid recently_liked blender v2 LR quartile boundaries: %r",
             raw_boundaries,
         )
-        return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+        return None
 
     if len(boundaries) != 3 or any(value != value for value in boundaries):
         logger.warning(
             "invalid recently_liked blender v2 LR quartile boundaries: %r",
             raw_boundaries,
         )
-        return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+        return None
 
     return tuple(max(0.0, min(1.0, value)) for value in boundaries)
 
@@ -152,7 +151,7 @@ async def _release_lr_quartile_boundaries_lock(token: str) -> None:
         )
 
 
-async def _calculate_recent_7d_lr_quartile_boundaries() -> tuple[float, float, float]:
+async def _calculate_recent_7d_lr_quartile_boundaries() -> tuple[float, float, float] | None:
     query = text(
         """
         WITH recent_user_lr AS (
@@ -180,12 +179,13 @@ async def _calculate_recent_7d_lr_quartile_boundaries() -> tuple[float, float, f
     return _coerce_lr_quartile_boundaries(row["lr_boundaries"] if row else None)
 
 
-async def get_recent_7d_lr_quartile_boundaries() -> tuple[float, float, float]:
+async def get_recent_7d_lr_quartile_boundaries() -> tuple[float, float, float] | None:
     """Return cached mature-user 7d LR quartile cut points.
 
     Assignment is on the user-facing queue path, so only the lock holder performs
     the global mature-user aggregate. Other workers wait briefly for the cache,
-    then use deterministic default cut points rather than stampeding the DB.
+    then skip enrollment until real cut points are cached rather than
+    stampeding the DB or assigning users against fallback boundaries.
     """
     cached = await _get_cached_lr_quartile_boundaries()
     if cached is not None:
@@ -204,12 +204,13 @@ async def get_recent_7d_lr_quartile_boundaries() -> tuple[float, float, float]:
             "recently_liked blender v2 LR quartile boundary lock failed",
             exc_info=True,
         )
-        return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+        return None
 
     if acquired:
         try:
             boundaries = await _calculate_recent_7d_lr_quartile_boundaries()
-            await _cache_lr_quartile_boundaries(boundaries)
+            if boundaries is not None:
+                await _cache_lr_quartile_boundaries(boundaries)
             return boundaries
         finally:
             await _release_lr_quartile_boundaries_lock(token)
@@ -221,12 +222,15 @@ async def get_recent_7d_lr_quartile_boundaries() -> tuple[float, float, float]:
             return cached
 
     logger.warning("recently_liked blender v2 LR quartile boundaries still uncached after waiting")
-    return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+    return None
 
 
-async def get_recent_7d_lr_assignment_metrics(user_id: int) -> dict[str, Any]:
+async def get_recent_7d_lr_assignment_metrics(user_id: int) -> dict[str, Any] | None:
     """Return enrollment-time 7d LR metrics and mature-user LR quartile."""
     boundaries = await get_recent_7d_lr_quartile_boundaries()
+    if boundaries is None:
+        return None
+
     query = text(
         """
         SELECT
@@ -312,6 +316,9 @@ async def get_or_assign_recently_liked_blender_v2_variant(user_id: int) -> str:
         return assignment["variant"]
 
     metrics = await get_recent_7d_lr_assignment_metrics(user_id)
+    if metrics is None:
+        return RECENTLY_LIKED_BLENDER_V2_CONTROL
+
     proposed_variant, assignment_metadata = build_recently_liked_blender_v2_assignment(
         user_id,
         metrics,

--- a/src/recommendations/blender_experiments.py
+++ b/src/recommendations/blender_experiments.py
@@ -1,10 +1,14 @@
 import hashlib
 import logging
+import uuid
+from asyncio import sleep
 from typing import Any
 
+import orjson
 from sqlalchemy import text
 
 from src.database import fetch_one
+from src.redis import redis_client
 from src.tgbot.service import (
     assign_experiment,
     get_experiment_assignment,
@@ -21,6 +25,15 @@ RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT = 1000
 RECENTLY_LIKED_BLENDER_V2_MATURE_MIN_MEMES_SENT = 100
 RECENTLY_LIKED_BLENDER_V2_SKIPPER_MIN_REACTIONS_7D = 50
 RECENTLY_LIKED_BLENDER_V2_SKIPPER_MAX_LR_7D = 0.20
+RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_CACHE_KEY = (
+    "recently_liked_blender_v2:lr_quartile_boundaries"
+)
+RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_KEY = (
+    "recently_liked_blender_v2:lr_quartile_boundaries:lock"
+)
+RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_TTL_SECONDS = 15 * 60
+RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_SECONDS = 30
+RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES = (0.25, 0.5, 0.75)
 
 MATURE_BLENDER_CONTROL_WEIGHTS = {
     "best_uploaded_memes": 0.3,
@@ -54,61 +67,197 @@ def _weights_for_variant(variant: str) -> dict[str, float]:
     return dict(MATURE_BLENDER_CONTROL_WEIGHTS)
 
 
-async def get_recent_7d_lr_assignment_metrics(user_id: int) -> dict[str, Any]:
-    """Return enrollment-time 7d LR metrics and mature-user LR quartile."""
+def _coerce_lr_quartile_boundaries(raw_boundaries: Any) -> tuple[float, float, float]:
+    if raw_boundaries is None:
+        return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+
+    if isinstance(raw_boundaries, str):
+        raw_boundaries = raw_boundaries.strip("{}").split(",")
+
+    try:
+        boundaries = tuple(float(value) for value in raw_boundaries)
+    except (TypeError, ValueError):
+        logger.warning(
+            "invalid recently_liked blender v2 LR quartile boundaries: %r",
+            raw_boundaries,
+        )
+        return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+
+    if len(boundaries) != 3 or any(value != value for value in boundaries):
+        logger.warning(
+            "invalid recently_liked blender v2 LR quartile boundaries: %r",
+            raw_boundaries,
+        )
+        return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+
+    return tuple(max(0.0, min(1.0, value)) for value in boundaries)
+
+
+def _lr_quartile_from_boundaries(lr_7d: float, boundaries: tuple[float, float, float]) -> int:
+    if lr_7d <= boundaries[0]:
+        return 1
+    if lr_7d <= boundaries[1]:
+        return 2
+    if lr_7d <= boundaries[2]:
+        return 3
+    return 4
+
+
+async def _get_cached_lr_quartile_boundaries() -> tuple[float, float, float] | None:
+    try:
+        cached = await redis_client.get(RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_CACHE_KEY)
+    except Exception:
+        logger.warning(
+            "recently_liked blender v2 LR quartile boundary cache read failed",
+            exc_info=True,
+        )
+        return None
+
+    if not cached:
+        return None
+
+    try:
+        return _coerce_lr_quartile_boundaries(orjson.loads(cached))
+    except orjson.JSONDecodeError:
+        logger.warning(
+            "recently_liked blender v2 LR quartile boundary cache payload is invalid",
+            exc_info=True,
+        )
+        return None
+
+
+async def _cache_lr_quartile_boundaries(boundaries: tuple[float, float, float]) -> None:
+    try:
+        await redis_client.set(
+            RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_CACHE_KEY,
+            orjson.dumps(boundaries),
+            ex=RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_TTL_SECONDS,
+        )
+    except Exception:
+        logger.warning(
+            "recently_liked blender v2 LR quartile boundary cache write failed",
+            exc_info=True,
+        )
+
+
+async def _release_lr_quartile_boundaries_lock(token: str) -> None:
+    try:
+        current = await redis_client.get(RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_KEY)
+        if current == token:
+            await redis_client.delete(RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_KEY)
+    except Exception:
+        logger.warning(
+            "recently_liked blender v2 LR quartile boundary lock release failed",
+            exc_info=True,
+        )
+
+
+async def _calculate_recent_7d_lr_quartile_boundaries() -> tuple[float, float, float]:
     query = text(
         """
-        WITH recent_reactions AS MATERIALIZED (
+        WITH recent_user_lr AS (
             SELECT
-                umr.user_id,
-                COUNT(*) FILTER (WHERE umr.reaction_id IN (1, 2)) AS reactions_7d,
-                COUNT(*) FILTER (WHERE umr.reaction_id = 1) AS likes_7d
+                COUNT(*) FILTER (WHERE umr.reaction_id = 1)::float
+                    / NULLIF(COUNT(*), 0) AS lr_7d
             FROM user_meme_reaction umr
             INNER JOIN user_stats us ON us.user_id = umr.user_id
             WHERE umr.reacted_at >= NOW() - INTERVAL '7 days'
                 AND umr.reaction_id IN (1, 2)
                 AND us.nmemes_sent >= :mature_min_memes_sent
             GROUP BY umr.user_id
-        ),
-        ranked AS (
-            SELECT
-                user_id,
-                reactions_7d,
-                likes_7d,
-                likes_7d::float / NULLIF(reactions_7d, 0) AS lr_7d,
-                NTILE(4) OVER (
-                    ORDER BY likes_7d::float / NULLIF(reactions_7d, 0)
-                ) AS lr_quartile
-            FROM recent_reactions
+            HAVING COUNT(*) > 0
         )
         SELECT
-            COALESCE(r.likes_7d, 0) AS likes_7d,
-            COALESCE(r.reactions_7d, 0) AS reactions_7d,
-            COALESCE(r.lr_7d, 0.0) AS lr_7d,
-            COALESCE(r.lr_quartile, 1) AS lr_quartile
-        FROM (SELECT CAST(:user_id AS bigint) AS user_id) target
-        LEFT JOIN ranked r ON r.user_id = target.user_id
+            PERCENTILE_CONT(ARRAY[0.25, 0.5, 0.75])
+                WITHIN GROUP (ORDER BY lr_7d) AS lr_boundaries
+        FROM recent_user_lr
         """
     )
     row = await fetch_one(
         query,
-        {
-            "user_id": user_id,
-            "mature_min_memes_sent": RECENTLY_LIKED_BLENDER_V2_MATURE_MIN_MEMES_SENT,
-        },
+        {"mature_min_memes_sent": RECENTLY_LIKED_BLENDER_V2_MATURE_MIN_MEMES_SENT},
     )
+    return _coerce_lr_quartile_boundaries(row["lr_boundaries"] if row else None)
+
+
+async def get_recent_7d_lr_quartile_boundaries() -> tuple[float, float, float]:
+    """Return cached mature-user 7d LR quartile cut points.
+
+    Assignment is on the user-facing queue path, so only the lock holder performs
+    the global mature-user aggregate. Other workers wait briefly for the cache,
+    then use deterministic default cut points rather than stampeding the DB.
+    """
+    cached = await _get_cached_lr_quartile_boundaries()
+    if cached is not None:
+        return cached
+
+    token = str(uuid.uuid4())
+    try:
+        acquired = await redis_client.set(
+            RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_KEY,
+            token,
+            nx=True,
+            ex=RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_SECONDS,
+        )
+    except Exception:
+        logger.warning(
+            "recently_liked blender v2 LR quartile boundary lock failed",
+            exc_info=True,
+        )
+        return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+
+    if acquired:
+        try:
+            boundaries = await _calculate_recent_7d_lr_quartile_boundaries()
+            await _cache_lr_quartile_boundaries(boundaries)
+            return boundaries
+        finally:
+            await _release_lr_quartile_boundaries_lock(token)
+
+    for _ in range(10):
+        await sleep(0.1)
+        cached = await _get_cached_lr_quartile_boundaries()
+        if cached is not None:
+            return cached
+
+    logger.warning("recently_liked blender v2 LR quartile boundaries still uncached after waiting")
+    return RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+
+
+async def get_recent_7d_lr_assignment_metrics(user_id: int) -> dict[str, Any]:
+    """Return enrollment-time 7d LR metrics and mature-user LR quartile."""
+    boundaries = await get_recent_7d_lr_quartile_boundaries()
+    query = text(
+        """
+        SELECT
+            COUNT(*) FILTER (WHERE umr.reaction_id = 1) AS likes_7d,
+            COUNT(*) AS reactions_7d,
+            COALESCE(
+                COUNT(*) FILTER (WHERE umr.reaction_id = 1)::float / NULLIF(COUNT(*), 0),
+                0.0
+            ) AS lr_7d
+        FROM user_meme_reaction umr
+        WHERE umr.user_id = :user_id
+            AND umr.reacted_at >= NOW() - INTERVAL '7 days'
+            AND umr.reaction_id IN (1, 2)
+        """
+    )
+    row = await fetch_one(query, {"user_id": user_id})
     if row is None:
         return {
             "likes_7d": 0,
             "reactions_7d": 0,
             "lr_7d": 0.0,
             "lr_quartile": 1,
+            "lr_quartile_boundaries": list(boundaries),
         }
+    lr_7d = float(row["lr_7d"] or 0.0)
     return {
         "likes_7d": int(row["likes_7d"] or 0),
         "reactions_7d": int(row["reactions_7d"] or 0),
-        "lr_7d": float(row["lr_7d"] or 0.0),
-        "lr_quartile": int(row["lr_quartile"] or 1),
+        "lr_7d": lr_7d,
+        "lr_quartile": _lr_quartile_from_boundaries(lr_7d, boundaries),
+        "lr_quartile_boundaries": list(boundaries),
     }
 
 
@@ -147,6 +296,10 @@ def build_recently_liked_blender_v2_assignment(
         },
         "assigned_weights": _weights_for_variant(variant),
     }
+    if "lr_quartile_boundaries" in metrics:
+        assignment_metadata["lr_quartile_boundaries"] = [
+            round(float(boundary), 6) for boundary in metrics["lr_quartile_boundaries"]
+        ]
     return variant, assignment_metadata
 
 

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -8,6 +8,10 @@ from sqlalchemy import text
 from src import redis
 from src.database import fetch_all
 from src.recommendations.blender import blend
+from src.recommendations.blender_experiments import (
+    MATURE_BLENDER_CONTROL_WEIGHTS,
+    get_recently_liked_blender_v2_weights,
+)
 from src.recommendations.candidates import (
     CandidatesRetriever,
 )
@@ -135,7 +139,7 @@ async def generate_recommendations(
 
         return await fetch_all(text(query), params)
 
-    async def get_candidates(user_id, limit):
+    async def get_candidates(user_id, limit, use_recently_liked_blender_v2: bool = True):
         """Route to the right engine mix based on user maturity.
 
         Cold start (<30 memes) uses 3-phase adaptive approach:
@@ -215,15 +219,13 @@ async def generate_recommendations(
             fixed_pos = {0: "lr_smoothed"}
             return blend(candidates_dict, weights, fixed_pos, limit, random_seed)
 
-        # >=100
-        weights = {
-            "best_uploaded_memes": 0.3,
-            "like_spread_and_recent_memes": 0.3,
-            "lr_smoothed": 0.4,
-            "recently_liked": 0.2,
-            "goat": 0.1,
-            "es_ranked": 0.1,
-        }
+        # >=100. Regular mature users enter the LR-stratified recently_liked
+        # blender v2 A/B. Moderator/admin traffic keeps baseline weights because
+        # their low_sent_pool quota would confound the experiment read.
+        if use_recently_liked_blender_v2:
+            weights = await get_recently_liked_blender_v2_weights(user_id)
+        else:
+            weights = dict(MATURE_BLENDER_CONTROL_WEIGHTS)
 
         candidates_dict = await retriever.get_candidates_dict(
             weights.keys(), user_id, limit, exclude_mem_ids=meme_ids_in_queue
@@ -260,7 +262,11 @@ async def generate_recommendations(
 
         remaining_limit = max(0, limit - len(candidates))
         if remaining_limit > 0:
-            extra_candidates = await get_candidates(user_id, remaining_limit)
+            extra_candidates = await get_candidates(
+                user_id,
+                remaining_limit,
+                use_recently_liked_blender_v2=False,
+            )
             candidates.extend(extra_candidates)
 
         # Last resort: if both pools are empty, fetch ANY unseen meme

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -613,17 +613,31 @@ async def unsnooze_memes_of_meme_source(meme_source_id: int) -> int:
 # === Experiment Assignment ===
 
 
-async def get_experiment_variant(user_id: int, experiment_id: str) -> str | None:
-    """Get a user's experiment variant. Returns None if not assigned."""
-    query = select(experiment_assignment.c.variant).where(
+async def get_experiment_assignment(user_id: int, experiment_id: str) -> dict[str, Any] | None:
+    """Get a user's experiment assignment row. Returns None if not assigned."""
+    query = select(
+        experiment_assignment.c.variant,
+        experiment_assignment.c.assignment_metadata,
+        experiment_assignment.c.assigned_at,
+    ).where(
         experiment_assignment.c.experiment_id == experiment_id,
         experiment_assignment.c.user_id == user_id,
     )
-    row = await fetch_one(query)
+    return await fetch_one(query)
+
+
+async def get_experiment_variant(user_id: int, experiment_id: str) -> str | None:
+    """Get a user's experiment variant. Returns None if not assigned."""
+    row = await get_experiment_assignment(user_id, experiment_id)
     return row["variant"] if row else None
 
 
-async def assign_experiment(user_id: int, experiment_id: str, variant: str) -> bool:
+async def assign_experiment(
+    user_id: int,
+    experiment_id: str,
+    variant: str,
+    assignment_metadata: dict[str, Any] | None = None,
+) -> bool:
     """Assign a user to an experiment variant. Idempotent (ON CONFLICT DO NOTHING).
 
     Returns True when this call inserted a new assignment row, False when a
@@ -636,6 +650,7 @@ async def assign_experiment(user_id: int, experiment_id: str, variant: str) -> b
             experiment_id=experiment_id,
             user_id=user_id,
             variant=variant,
+            assignment_metadata=assignment_metadata or {},
         )
         .on_conflict_do_nothing(
             index_elements=["experiment_id", "user_id"],

--- a/tests/recommendations/test_blender_experiments.py
+++ b/tests/recommendations/test_blender_experiments.py
@@ -1,0 +1,140 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.recommendations.blender_experiments import (
+    MATURE_BLENDER_CONTROL_WEIGHTS,
+    MATURE_BLENDER_TREATMENT_WEIGHTS,
+    RECENTLY_LIKED_BLENDER_V2_CONTROL,
+    RECENTLY_LIKED_BLENDER_V2_EXCLUDED,
+    RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID,
+    RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT,
+    RECENTLY_LIKED_BLENDER_V2_TREATMENT,
+    build_recently_liked_blender_v2_assignment,
+    get_or_assign_recently_liked_blender_v2_variant,
+    get_recently_liked_blender_v2_weights,
+)
+
+
+def test_assignment_excludes_high_volume_low_lr_skipper():
+    variant, metadata = build_recently_liked_blender_v2_assignment(
+        101,
+        {
+            "likes_7d": 9,
+            "reactions_7d": 51,
+            "lr_7d": 9 / 51,
+            "lr_quartile": 1,
+        },
+    )
+
+    assert variant == RECENTLY_LIKED_BLENDER_V2_EXCLUDED
+    assert metadata["high_volume_skipper"] is True
+    assert metadata["excluded_reason"] == "lr_7d_below_20pct_and_reactions_7d_above_50"
+    assert metadata["assigned_weights"] == MATURE_BLENDER_CONTROL_WEIGHTS
+
+
+def test_assignment_persists_stratification_metadata_for_eligible_user():
+    variant, metadata = build_recently_liked_blender_v2_assignment(
+        202,
+        {
+            "likes_7d": 20,
+            "reactions_7d": 60,
+            "lr_7d": 1 / 3,
+            "lr_quartile": 2,
+        },
+    )
+
+    assert variant in {RECENTLY_LIKED_BLENDER_V2_CONTROL, RECENTLY_LIKED_BLENDER_V2_TREATMENT}
+    assert metadata["lr_quartile"] == 2
+    assert metadata["reactions_7d"] == 60
+    assert metadata["high_volume_skipper"] is False
+    assert metadata["sample_gate_per_variant"] == RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT
+    assert metadata["day3_guardrail"]["primary_read_rule"] == "sample_gate_per_variant"
+
+
+def test_assignment_is_stable_within_lr_quartile():
+    metrics = {
+        "likes_7d": 20,
+        "reactions_7d": 60,
+        "lr_7d": 1 / 3,
+        "lr_quartile": 3,
+    }
+
+    first, first_metadata = build_recently_liked_blender_v2_assignment(303, metrics)
+    second, second_metadata = build_recently_liked_blender_v2_assignment(303, metrics)
+
+    assert first == second
+    assert first_metadata == second_metadata
+
+
+@pytest.mark.asyncio
+async def test_existing_recently_liked_blender_v2_assignment_wins():
+    with patch(
+        "src.recommendations.blender_experiments.get_experiment_assignment",
+        new_callable=AsyncMock,
+        return_value={"variant": RECENTLY_LIKED_BLENDER_V2_TREATMENT},
+    ) as get_assignment:
+        variant = await get_or_assign_recently_liked_blender_v2_variant(101)
+
+    assert variant == RECENTLY_LIKED_BLENDER_V2_TREATMENT
+    get_assignment.assert_awaited_once_with(101, RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID)
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_v2_race_rereads_winning_assignment():
+    with (
+        patch(
+            "src.recommendations.blender_experiments.get_experiment_assignment",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "src.recommendations.blender_experiments.get_recent_7d_lr_assignment_metrics",
+            new_callable=AsyncMock,
+            return_value={
+                "likes_7d": 20,
+                "reactions_7d": 60,
+                "lr_7d": 1 / 3,
+                "lr_quartile": 2,
+            },
+        ),
+        patch(
+            "src.recommendations.blender_experiments.assign_experiment",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "src.recommendations.blender_experiments.get_experiment_variant",
+            new_callable=AsyncMock,
+            return_value=RECENTLY_LIKED_BLENDER_V2_CONTROL,
+        ),
+    ):
+        variant = await get_or_assign_recently_liked_blender_v2_variant(202)
+
+    assert variant == RECENTLY_LIKED_BLENDER_V2_CONTROL
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_v2_weights_fall_back_to_control_on_assignment_error():
+    with patch(
+        "src.recommendations.blender_experiments.get_or_assign_recently_liked_blender_v2_variant",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("assignment unavailable"),
+    ):
+        weights = await get_recently_liked_blender_v2_weights(100)
+
+    assert weights == MATURE_BLENDER_CONTROL_WEIGHTS
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_v2_treatment_increases_recently_liked_weight():
+    with patch(
+        "src.recommendations.blender_experiments.get_or_assign_recently_liked_blender_v2_variant",
+        new_callable=AsyncMock,
+        return_value=RECENTLY_LIKED_BLENDER_V2_TREATMENT,
+    ):
+        weights = await get_recently_liked_blender_v2_weights(100)
+
+    assert weights == MATURE_BLENDER_TREATMENT_WEIGHTS
+    assert weights["recently_liked"] > MATURE_BLENDER_CONTROL_WEIGHTS["recently_liked"]
+    assert weights["lr_smoothed"] < MATURE_BLENDER_CONTROL_WEIGHTS["lr_smoothed"]

--- a/tests/recommendations/test_blender_experiments.py
+++ b/tests/recommendations/test_blender_experiments.py
@@ -6,12 +6,16 @@ from src.recommendations.blender_experiments import (
     MATURE_BLENDER_CONTROL_WEIGHTS,
     MATURE_BLENDER_TREATMENT_WEIGHTS,
     RECENTLY_LIKED_BLENDER_V2_CONTROL,
+    RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES,
     RECENTLY_LIKED_BLENDER_V2_EXCLUDED,
     RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID,
     RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT,
     RECENTLY_LIKED_BLENDER_V2_TREATMENT,
+    _lr_quartile_from_boundaries,
     build_recently_liked_blender_v2_assignment,
     get_or_assign_recently_liked_blender_v2_variant,
+    get_recent_7d_lr_assignment_metrics,
+    get_recent_7d_lr_quartile_boundaries,
     get_recently_liked_blender_v2_weights,
 )
 
@@ -65,6 +69,73 @@ def test_assignment_is_stable_within_lr_quartile():
 
     assert first == second
     assert first_metadata == second_metadata
+
+
+def test_lr_quartile_uses_cached_boundaries():
+    boundaries = (0.2, 0.5, 0.8)
+
+    assert _lr_quartile_from_boundaries(0.2, boundaries) == 1
+    assert _lr_quartile_from_boundaries(0.21, boundaries) == 2
+    assert _lr_quartile_from_boundaries(0.51, boundaries) == 3
+    assert _lr_quartile_from_boundaries(0.81, boundaries) == 4
+
+
+@pytest.mark.asyncio
+async def test_lr_assignment_metrics_only_fetch_current_user_reactions():
+    with (
+        patch(
+            "src.recommendations.blender_experiments.get_recent_7d_lr_quartile_boundaries",
+            new_callable=AsyncMock,
+            return_value=(0.2, 0.5, 0.8),
+        ) as get_boundaries,
+        patch(
+            "src.recommendations.blender_experiments.fetch_one",
+            new_callable=AsyncMock,
+            return_value={"likes_7d": 35, "reactions_7d": 100, "lr_7d": 0.35},
+        ) as fetch_metrics,
+    ):
+        metrics = await get_recent_7d_lr_assignment_metrics(101)
+
+    get_boundaries.assert_awaited_once()
+    fetch_metrics.assert_awaited_once()
+    query_text = str(fetch_metrics.await_args.args[0])
+    assert "NTILE" not in query_text
+    assert "GROUP BY umr.user_id" not in query_text
+    assert metrics == {
+        "likes_7d": 35,
+        "reactions_7d": 100,
+        "lr_7d": 0.35,
+        "lr_quartile": 2,
+        "lr_quartile_boundaries": [0.2, 0.5, 0.8],
+    }
+
+
+@pytest.mark.asyncio
+async def test_lr_quartile_boundaries_do_not_recompute_without_cache_lock():
+    with (
+        patch(
+            "src.recommendations.blender_experiments._get_cached_lr_quartile_boundaries",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "src.recommendations.blender_experiments.redis_client.set",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "src.recommendations.blender_experiments.sleep",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.recommendations.blender_experiments._calculate_recent_7d_lr_quartile_boundaries",
+            new_callable=AsyncMock,
+        ) as calculate_boundaries,
+    ):
+        boundaries = await get_recent_7d_lr_quartile_boundaries()
+
+    assert boundaries == RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+    calculate_boundaries.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/recommendations/test_blender_experiments.py
+++ b/tests/recommendations/test_blender_experiments.py
@@ -6,7 +6,6 @@ from src.recommendations.blender_experiments import (
     MATURE_BLENDER_CONTROL_WEIGHTS,
     MATURE_BLENDER_TREATMENT_WEIGHTS,
     RECENTLY_LIKED_BLENDER_V2_CONTROL,
-    RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES,
     RECENTLY_LIKED_BLENDER_V2_EXCLUDED,
     RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID,
     RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT,
@@ -134,7 +133,7 @@ async def test_lr_quartile_boundaries_do_not_recompute_without_cache_lock():
     ):
         boundaries = await get_recent_7d_lr_quartile_boundaries()
 
-    assert boundaries == RECENTLY_LIKED_BLENDER_V2_DEFAULT_QUARTILE_BOUNDARIES
+    assert boundaries is None
     calculate_boundaries.assert_not_awaited()
 
 
@@ -183,6 +182,35 @@ async def test_recently_liked_blender_v2_race_rereads_winning_assignment():
         variant = await get_or_assign_recently_liked_blender_v2_variant(202)
 
     assert variant == RECENTLY_LIKED_BLENDER_V2_CONTROL
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_v2_defers_assignment_without_real_boundaries():
+    with (
+        patch(
+            "src.recommendations.blender_experiments.get_experiment_assignment",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "src.recommendations.blender_experiments.get_recent_7d_lr_assignment_metrics",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "src.recommendations.blender_experiments.assign_experiment",
+            new_callable=AsyncMock,
+        ) as assign,
+        patch(
+            "src.recommendations.blender_experiments.get_experiment_variant",
+            new_callable=AsyncMock,
+        ) as get_variant,
+    ):
+        variant = await get_or_assign_recently_liked_blender_v2_variant(202)
+
+    assert variant == RECENTLY_LIKED_BLENDER_V2_CONTROL
+    assign.assert_not_awaited()
+    get_variant.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -3,6 +3,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src.recommendations.blender_experiments import (
+    MATURE_BLENDER_CONTROL_WEIGHTS,
+    MATURE_BLENDER_TREATMENT_WEIGHTS,
+)
 from src.recommendations.candidates import CandidatesRetriever
 from src.recommendations.meme_queue import generate_recommendations
 
@@ -299,8 +303,11 @@ async def test_generate_above_100():
 
     with (
         patch("src.recommendations.meme_queue.blend", side_effect=capture_blend),
-        patch("src.tgbot.service.get_experiment_variant", new_callable=AsyncMock) as get_variant,
-        patch("src.tgbot.service.assign_experiment", new_callable=AsyncMock) as assign,
+        patch(
+            "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+            new_callable=AsyncMock,
+            return_value=MATURE_BLENDER_CONTROL_WEIGHTS,
+        ) as get_weights,
     ):
         candidates = await generate_recommendations(
             TEST_USER_ID, 10, 200, TestRetriever(), random_seed=102
@@ -309,16 +316,125 @@ async def test_generate_above_100():
     assert len(candidates) == 10
     # lr_smoothed is pinned at position 0
     assert candidates[0]["id"] in [7, 8, 9, 10]
-    assert captured_weights == {
-        "best_uploaded_memes": 0.3,
-        "like_spread_and_recent_memes": 0.3,
-        "lr_smoothed": 0.4,
-        "recently_liked": 0.2,
-        "goat": 0.1,
-        "es_ranked": 0.1,
-    }
-    get_variant.assert_not_awaited()
-    assign.assert_not_awaited()
+    assert captured_weights == MATURE_BLENDER_CONTROL_WEIGHTS
+    get_weights.assert_awaited_once_with(TEST_USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_generate_above_100_treatment_uses_recently_liked_weights():
+    captured_weights = None
+
+    async def one_candidate(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 4, "recommended_by": "recently_liked"}]
+
+    class TestRetriever(CandidatesRetriever):
+        engine_map = {
+            "best_uploaded_memes": one_candidate,
+            "like_spread_and_recent_memes": one_candidate,
+            "lr_smoothed": one_candidate,
+            "recently_liked": one_candidate,
+            "goat": one_candidate,
+            "es_ranked": one_candidate,
+        }
+
+    def capture_blend(candidates_dict, weights_dict, fixed_pos=None, limit=0, random_seed=None):
+        nonlocal captured_weights
+        captured_weights = weights_dict
+        return [{"id": 4, "recommended_by": "recently_liked"}]
+
+    with (
+        patch(
+            "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+            new_callable=AsyncMock,
+            return_value=MATURE_BLENDER_TREATMENT_WEIGHTS,
+        ) as get_weights,
+        patch("src.recommendations.meme_queue.blend", side_effect=capture_blend),
+    ):
+        candidates = await generate_recommendations(
+            TEST_USER_ID, 10, 200, TestRetriever(), random_seed=102
+        )
+
+    assert candidates == [{"id": 4, "recommended_by": "recently_liked"}]
+    assert captured_weights == MATURE_BLENDER_TREATMENT_WEIGHTS
+    assert captured_weights["recently_liked"] > MATURE_BLENDER_CONTROL_WEIGHTS["recently_liked"]
+    get_weights.assert_awaited_once_with(TEST_USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_v2_assignment_is_mature_only():
+    async def empty(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return []
+
+    class TestRetriever(CandidatesRetriever):
+        engine_map = {
+            "best_uploaded_memes": empty,
+            "like_spread_and_recent_memes": empty,
+            "lr_smoothed": empty,
+            "recently_liked": empty,
+            "goat": empty,
+            "es_ranked": empty,
+            "cold_start_explore": empty,
+            "cold_start_adapt": empty,
+        }
+
+    with patch(
+        "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+        new_callable=AsyncMock,
+        return_value=MATURE_BLENDER_TREATMENT_WEIGHTS,
+    ) as get_weights:
+        await generate_recommendations(TEST_USER_ID, 10, 29, TestRetriever())
+        await generate_recommendations(TEST_USER_ID, 10, 99, TestRetriever())
+
+    get_weights.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_v2_skips_moderator_assignment():
+    async def one_candidate(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 4, "recommended_by": "recently_liked"}]
+
+    class TestRetriever(CandidatesRetriever):
+        engine_map = {
+            "best_uploaded_memes": one_candidate,
+            "like_spread_and_recent_memes": one_candidate,
+            "lr_smoothed": one_candidate,
+            "recently_liked": one_candidate,
+            "goat": one_candidate,
+            "es_ranked": one_candidate,
+        }
+
+    captured_weights = None
+
+    def capture_blend(candidates_dict, weights_dict, fixed_pos=None, limit=0, random_seed=None):
+        nonlocal captured_weights
+        captured_weights = weights_dict
+        return [{"id": 4, "recommended_by": "recently_liked"}]
+
+    with (
+        patch(
+            "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+            new_callable=AsyncMock,
+            return_value=MATURE_BLENDER_TREATMENT_WEIGHTS,
+        ) as get_weights,
+        patch(
+            "src.recommendations.meme_queue.get_user_info",
+            new_callable=AsyncMock,
+            return_value={"nmemes_sent": 200, "type": "moderator"},
+        ),
+        patch(
+            "src.recommendations.meme_queue.fetch_all",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("src.recommendations.meme_queue.blend", side_effect=capture_blend),
+    ):
+        candidates = await generate_recommendations(
+            TEST_USER_ID, 1, 200, TestRetriever(), random_seed=102
+        )
+
+    assert candidates == [{"id": 4, "recommended_by": "recently_liked"}]
+    assert captured_weights == MATURE_BLENDER_CONTROL_WEIGHTS
+    get_weights.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -336,12 +452,17 @@ async def test_generate_empty_above_100():
             "es_ranked": empty,
         }
 
-    # All engines empty → empty result
-    candidates = await generate_recommendations(TEST_USER_ID, 10, 200, TestRetriever())
-    assert len(candidates) == 0
+    with patch(
+        "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+        new_callable=AsyncMock,
+        return_value=MATURE_BLENDER_CONTROL_WEIGHTS,
+    ):
+        # All engines empty → empty result
+        candidates = await generate_recommendations(TEST_USER_ID, 10, 200, TestRetriever())
+        assert len(candidates) == 0
 
-    # Same for high meme count — no fallback engine anymore
-    candidates = await generate_recommendations(TEST_USER_ID, 10, 1200, TestRetriever())
+        # Same for high meme count — no fallback engine anymore
+        candidates = await generate_recommendations(TEST_USER_ID, 10, 1200, TestRetriever())
     assert len(candidates) == 0
 
 

--- a/tests/test_experiment_assignment.py
+++ b/tests/test_experiment_assignment.py
@@ -5,7 +5,7 @@ from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert
 
 from src.database import engine, experiment_assignment, user
-from src.tgbot.service import assign_experiment, get_experiment_variant
+from src.tgbot.service import assign_experiment, get_experiment_assignment, get_experiment_variant
 
 
 @pytest.fixture(autouse=True)
@@ -30,6 +30,21 @@ async def test_assign_and_get_variant():
     await assign_experiment(90001, "test_experiment", "treatment")
     variant = await get_experiment_variant(90001, "test_experiment")
     assert variant == "treatment"
+
+
+@pytest.mark.asyncio
+async def test_assign_and_get_assignment_metadata():
+    """Experiment assignments can store audit metadata for measurement."""
+    async with engine.begin() as conn:
+        await _create_test_user(conn, 90008)
+
+    metadata = {"lr_quartile": 2, "high_volume_skipper": False}
+    await assign_experiment(90008, "test_experiment", "treatment", metadata)
+    assignment = await get_experiment_assignment(90008, "test_experiment")
+
+    assert assignment is not None
+    assert assignment["variant"] == "treatment"
+    assert assignment["assignment_metadata"] == metadata
 
 
 @pytest.mark.asyncio
@@ -97,3 +112,31 @@ async def test_v_experiment_results_view_exists():
         assert "like_rate_pct" in columns
         assert "median_session_length" in columns
         assert "users_who_uploaded" in columns
+
+
+@pytest.mark.asyncio
+async def test_recently_liked_blender_v2_measurement_views_exist():
+    """The recently_liked v2 measurement views expose Analyst query hooks."""
+    async with engine.begin() as conn:
+        assignment = await conn.execute(
+            text("SELECT * FROM v_recently_liked_blender_v2_assignment LIMIT 1")
+        )
+        assignment_columns = list(assignment.keys())
+        assert "lr_quartile" in assignment_columns
+        assert "high_volume_skipper" in assignment_columns
+        assert "assigned_weights" in assignment_columns
+
+        sample_gate = await conn.execute(
+            text("SELECT * FROM v_recently_liked_blender_v2_sample_gate LIMIT 1")
+        )
+        sample_gate_columns = list(sample_gate.keys())
+        assert "assigned_users" in sample_gate_columns
+        assert "sample_gate_met" in sample_gate_columns
+
+        engine_metrics = await conn.execute(
+            text("SELECT * FROM v_recently_liked_blender_v2_engine_metrics LIMIT 1")
+        )
+        engine_columns = list(engine_metrics.keys())
+        assert "recommended_by" in engine_columns
+        assert "allocation_pct" in engine_columns
+        assert "continuation_rate_pct" in engine_columns


### PR DESCRIPTION
Fixes FFM-1094.

## What changed
- Adds `recently_liked_blender_v2` for regular mature users only (`nmemes_sent >= 100`).
- Assigns users by stable hash within enrollment-time 7d personal LR quartile.
- Excludes high-volume low-LR skippers (`reactions_7d > 50` and `lr_7d < 20%`) into an auditable `excluded_high_volume_skipper` variant with baseline weights.
- Persists assignment metadata in `experiment_assignment.assignment_metadata`: LR quartile, 7d LR inputs, high-volume-skipper flag, sample gate, Day-3 guardrail metadata, and assigned weights.
- Adds Analyst query hooks:
  - `v_recently_liked_blender_v2_assignment`
  - `v_recently_liked_blender_v2_sample_gate`
  - `v_recently_liked_blender_v2_engine_metrics`
- Keeps moderator/admin extra candidates on baseline mature weights so low-sent quota traffic does not confound the A/B.

## Experiment details
- Experiment id: `recently_liked_blender_v2`
- Control mature weights: existing production mature blend.
- Treatment mature weights: `recently_liked` 0.30, `lr_smoothed` 0.35, `like_spread_and_recent_memes` 0.25, other mature weights unchanged.
- Primary read rule: each control/treatment arm reaches at least 1,000 assigned users.
- Day-3 guardrail metadata is persisted for Analyst checkpointing; sample gate remains primary.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `ruff check src/ tests/ && ruff format --check src/ tests/`
- `python3 -m compileall -q src tests alembic/versions/2026-05-09_recently_liked_blender_v2.py`
- Alembic single-head scan: `Single alembic head: 1a2b3c4d5e6f`
- `python3 -m pytest tests/recommendations/test_blender_experiments.py tests/recommendations/test_meme_queue.py -q` with CI-equivalent required env vars: 20 passed.

DB-backed test note: `tests/test_experiment_assignment.py` could not run in this local workspace because Docker is not installed and no Postgres is listening on `localhost:5432`. The test file was updated for the new views and should run in CI where Postgres is provisioned.
