### PR TITLE
Fix false routine outcome markers

### DIFF
--- a/agents/qa-engineer/AGENTS.md
+++ b/agents/qa-engineer/AGENTS.md
@@ -196,7 +196,7 @@ checks manually.
    - **Weekly Analyst Summary** → latest summary issue/report names product changes and anomalies
    - **Daily Channel Post** → latest linked `[post:...]` issue has `outcome=published`, `telegram_message_id`, and `editorial_post_id`; draft/approval-only handoffs are YELLOW
    - **gstack Update Check** → latest outcome names the update method and does NOT have `unknown_gstack_update_path` / degraded update flags
-   - **Paperclip Update Check** → latest outcome includes version/changelog impact, and any deploy claim includes `coolify_deployment_commit` or `verified_deployed_commit` matching the intended target
+   - **Paperclip Update Check** → latest outcome includes version/changelog impact, or `health.version=not_reported` plus `coolify_deployment_commit`, latest stable/canary, and `impact=none`; any deploy claim needs `verified_deployed_commit` or equivalent finished Coolify commit matching the intended target
    - **PR Review** → latest run's payload PR number matches the linked issue title/review signal
    - **Process Health Check** → skip (that's you)
 4. If any routine has outcome-contract flags from `paperclip_routine_audit.py`

--- a/docs/agents/routine-observability.md
+++ b/docs/agents/routine-observability.md
@@ -70,7 +70,9 @@ green.
 This is not only a SHA poll, and queueing a Coolify deployment is not terminal
 success. Every run should record:
 
-- deployed Paperclip version/ref
+- deployed Paperclip version/ref when `/api/health` reports it; otherwise
+  `health.version=not_reported` is acceptable only with a verified Coolify
+  finished deployment commit
 - actual Coolify deployment commit, written as `coolify_deployment_commit` or
   `verified_deployed_commit`
 - latest stable npm version
@@ -82,7 +84,8 @@ If upstream changed, create one triage issue with the impact summary. Do not
 bury the analysis in a completed routine comment. If a deployment is attempted,
 only advance any state file and close green after Coolify reports a finished
 deployment whose commit equals the intended target; otherwise leave the run
-blocked with `unverified_paperclip_deploy`.
+blocked with `unverified_paperclip_deploy`. Channel publication markers such as
+`telegram_message_id` and `editorial_post_id` do not apply to this routine.
 
 ### PR Review
 

--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -228,29 +228,25 @@ def classify_issue(
         if "latest stable" not in lower and "changelog" not in lower:
             flags.append("sha_only_update_check")
     if (
-        (
-            "deployed paperclip update" in lower
-            or "coolify deployment queued" in lower
-            or "state file updated" in lower
-            or "deployed paperclip" in lower
-        )
-        and not any(pattern.search(text) for pattern in VERIFIED_PAPERCLIP_DEPLOY_PATTERNS)
-    ):
+        "deployed paperclip update" in lower
+        or "coolify deployment queued" in lower
+        or "state file updated" in lower
+        or "deployed paperclip" in lower
+    ) and not any(pattern.search(text) for pattern in VERIFIED_PAPERCLIP_DEPLOY_PATTERNS):
         flags.append("unverified_paperclip_deploy")
     if "gstack-derived skills" in lower and "paperclip skills runtime" in lower:
         flags.append("unknown_gstack_update_path")
     if "draft issue exists" in lower or "awaiting ceo approval" in lower:
         flags.append("draft_handoff")
-    is_publish_flow = (
-        title.startswith("[post:")
-        or "daily channel post" in title
-        or "outcome=draft_created" in lower
-        or "outcome=published" in lower
-        or "ceo approval" in lower
-    )
+    # Publication markers are a Daily Channel Post contract. Other routines
+    # often mention approvals, posts, or prior watchdog flags while summarizing
+    # their work; those must not inherit the channel-publication contract.
+    is_publish_flow = title.startswith("[post:") or "daily channel post" in title
     has_approval_signal = "approved" in lower or has_accepted_confirmation(interactions or [])
-    if is_publish_flow and has_approval_signal and not all(
-        pattern.search(text) for pattern in PUBLISHED_MARKER_PATTERNS
+    if (
+        is_publish_flow
+        and has_approval_signal
+        and not all(pattern.search(text) for pattern in PUBLISHED_MARKER_PATTERNS)
     ):
         flags.append("approved_without_publish_marker")
     # Generic stall / no-comment / zombie-run classification is intentionally

--- a/tests/scripts/test_paperclip_routine_audit.py
+++ b/tests/scripts/test_paperclip_routine_audit.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def load_audit_module():
+    path = Path(__file__).resolve().parents[2] / "scripts" / "paperclip_routine_audit.py"
+    spec = importlib.util.spec_from_file_location("paperclip_routine_audit", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+audit = load_audit_module()
+
+
+def test_pr_review_approval_comment_does_not_require_publish_markers():
+    issue = {"title": "[pr:241] Review", "description": ""}
+    comments = [
+        {
+            "body": (
+                "Done: PR #241 reviewed and merged. GitHub signal: STAFF ENGINEER REVIEW: APPROVED."
+            )
+        }
+    ]
+
+    flags, _latest = audit.classify_issue(issue, comments)
+
+    assert "approved_without_publish_marker" not in flags
+
+
+def test_process_health_summary_does_not_self_trigger_publish_marker_flag():
+    issue = {"title": "Process Health Check", "description": ""}
+    comments = [
+        {
+            "body": (
+                "Status: YELLOW. Prior flags: approved_without_publish_marker. "
+                "Referenced post FFM-1079 is awaiting CEO approval."
+            )
+        }
+    ]
+
+    flags, _latest = audit.classify_issue(issue, comments)
+
+    assert "approved_without_publish_marker" not in flags
+
+
+def test_paperclip_update_verified_by_coolify_commit_is_green():
+    issue = {"title": "Paperclip Update Check", "description": ""}
+    comments = [
+        {
+            "body": (
+                "Paperclip update check green.\n"
+                "- health.version=not_reported\n"
+                "- coolify_deployment_uuid=v8s5shyjid9n9c7l2gtghig9\n"
+                "- coolify_deployment_status=finished\n"
+                "- coolify_deployment_commit=3494e84a2920f3e2bc5f627f916da29e224086dc\n"
+                "- latest_stable=2026.428.0\n"
+                "- latest_canary=2026.508.0-canary.0\n"
+                "- stable_tag_sha=3494e84a2920f3e2bc5f627f916da29e224086dc\n"
+                "- impact=none\n"
+            )
+        }
+    ]
+
+    flags, _latest = audit.classify_issue(issue, comments)
+
+    assert flags == []
+
+
+def test_daily_channel_post_approval_still_requires_publish_markers():
+    issue = {"title": "Daily Channel Post", "description": ""}
+    comments = [{"body": "CEO approved this draft; publishing still pending."}]
+
+    flags, _latest = audit.classify_issue(issue, comments)
+
+    assert "approved_without_publish_marker" in flags


### PR DESCRIPTION
Fixes FFM-1103.

## What changed
- Restrict `approved_without_publish_marker` to actual Daily Channel Post / `[post:...]` workflows.
- Clarify that Paperclip Update Check can be green with `health.version=not_reported` when the finished Coolify deployment commit is verified.
- Add regression tests for PR Review approval fallback, Process Health self-triggering, Paperclip Update Check Coolify verification, and Daily Channel Post approval.

## Verification
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `python3 -m pytest tests/scripts/test_paperclip_routine_audit.py -q`
- `python3 scripts/paperclip_routine_audit.py --focus all` against live Paperclip data: FFM-1102, FFM-1100, and FFM-1071 now report `flags=ok`.

## QA note
Next Process Health Check should remain green for PR Review and Paperclip Update Check unless a real outcome-contract mismatch appears.