### PR TITLE
Fix Comms visual publishing without moderator staging

### DIFF
--- a/agents/.paperclip.yaml
+++ b/agents/.paperclip.yaml
@@ -91,6 +91,9 @@ agents:
         FFMEMES_PROD_TELEGRAM_BOT_TOKEN:
           kind: "secret"
           requirement: "required"
+        OPENAI_API_KEY:
+          kind: "secret"
+          requirement: "optional"
 
   cto:
     role: "cto"

--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -47,8 +47,8 @@ You may create only execution tickets from the comms workflow. Strategic or
 planning tickets belong to CEO.
 
 Do NOT file Paperclip issues titled `test`, `debug`, or `v2`. Test notification
-rendering by sending to yourself or to the moderator chat, not by creating
-backlog clutter.
+rendering locally or as a Paperclip attachment, not by posting stray images
+into the moderator chat.
 
 ## Target Cadence
 
@@ -154,12 +154,18 @@ about our infra find this exciting to read?" If the answer is "maybe" or
 requires context, regenerate.
 
 ### Step 6 — Visual
-Use `src/comms/visuals.py` primitives ONLY. Do not write raw matplotlib.
+For exact data, use `src/comms/visuals.py` primitives ONLY. Do not write raw matplotlib.
 - 1 number → `stat_slide(title, value, subtitle)`
 - 2-20 time-series points → `line_chart(x, y, title, accent_x=...)`
 - 2-10 categorical bars → `bar_chart(labels, values, title, highlight_idx=...)`
 - > 20 points → bucket or sample down first
 - Pie charts, 3D, dual-axis → banned
+
+These primitives return PNG bytes. Pass them directly as `photo_bytes=png` to
+`publish_editorial_post`. For illustrative/editorial art, use
+`src.comms.image_generation.generate_editorial_image()` with a precise prompt
+built by `build_editorial_image_prompt(...)`, then pass
+`photo_bytes=image.image_bytes`.
 
 See `docs/comms/brand-guide.md` for the full decision tree and constraints.
 
@@ -274,12 +280,15 @@ See full brand guide: `docs/comms/brand-guide.md`
 5. **Stat cards** — for daily pulse (big number + context)
 
 When generating charts/images, verify the result looks good by feeding it back through the browse skill.
+Never send editorial visuals to the moderator chat just to get a Telegram `file_id`.
 
 ### Image Review Before Posting (MANDATORY)
 
 Before attaching ANY image to a channel post, you MUST:
 
-1. **Download and visually inspect** the image — use the Telegram Bot API to get the file, then view it:
+1. **Visually inspect** the image. For Telegram `file_id` memes, download via
+   the Telegram Bot API first; for local/generated images, inspect the local
+   PNG directly.
 ```bash
 # Get file path
 FILE_PATH=$(curl -s "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/getFile?file_id=<file_id>" | python3 -c "import json,sys; print(json.load(sys.stdin)['result']['file_path'])")
@@ -291,6 +300,8 @@ curl -s "https://api.telegram.org/file/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/${F
 2. **Check against content policy** (see below) — reject if it violates any rule
 3. **Always caption the image** in the post text — explain what the image is and why it's there (e.g., "вот этот мем собрал больше всего лайков от новичков"). Never attach an image without context.
 4. **If the image fails review** — pick the next candidate or use a chart/stat card instead
+5. **Do not stage editorial images in the moderator chat** for testing or
+   `file_id` extraction. Use `photo_bytes` for local/generated visuals.
 
 ### Content Policy for Public Posts
 
@@ -386,7 +397,7 @@ try:
         channel="ffmemes",               # "ffmemes" build-in-public, "ru" @fastfoodmemes, "en" @fast_food_memes
         category="C",                    # A/B/C/D/E/F — see "Content Categories"
         entity_id="dau_delta_2026_04_24",# stable slug for the specific anomaly/topic
-        photo_file_id=telegram_file_id,  # OR photo_url — always include a visual
+        photo_bytes=png,                 # OR photo_file_id / photo_url — always include a visual
         topic_slug="dau-delta-anomaly",
         button_text=None, button_url=None,  # optional inline button
     )
@@ -558,7 +569,9 @@ curl -s -X POST "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/
 - Do NOT bold more than 2-3 spans per post — it stops being emphasis
 - Do NOT write raw matplotlib — use `src/comms/visuals.py` primitives only
 - Do NOT post without CEO approval
-- Do NOT post images without downloading and visually inspecting them first
+- Do NOT post images without visually inspecting them first
+- Do NOT send editorial visuals to the moderator chat for staging, testing, or
+  `file_id` extraction
 - Do NOT post political, NSFW, or controversial memes — EVER
 - Do NOT attach images without explaining what they are in the post text
 - Do NOT share internal metrics that could be embarrassing (exact revenue, costs)

--- a/agents/comms-manager/capabilities.md
+++ b/agents/comms-manager/capabilities.md
@@ -15,7 +15,7 @@ try:
         channel="ffmemes",               # "ffmemes" build-in-public, "ru" @fastfoodmemes, "en" @fast_food_memes
         category="C",                    # A–F, see AGENTS.md
         entity_id="dau_drop_2026_04_26", # stable slug for this anomaly
-        photo_file_id=tg_file_id,        # or photo_url=
+        photo_bytes=png,                 # or photo_file_id= / photo_url=
         topic_slug="dau-drop",
     )
 except EditorialValidationError as e:
@@ -23,7 +23,7 @@ except EditorialValidationError as e:
     ...
 ```
 
-Raw `curl`, `sendPhoto`, `sendMessage`, or `bot.send_*` to a public channel produce broken posts. They're fine for the moderator chat (`-1001305866294`) — see AGENTS.md.
+Raw `curl`, `sendPhoto`, `sendMessage`, or `bot.send_*` to a public channel produce broken posts. Generated/local visuals should go directly through `photo_bytes`; do not send them to the moderator chat just to get a Telegram `file_id`.
 
 ## Operating
 

--- a/agents/comms-manager/routines/daily-channel-post.description.md
+++ b/agents/comms-manager/routines/daily-channel-post.description.md
@@ -7,6 +7,7 @@ Run the workflow in `agents/comms-manager/AGENTS.md` ("What Triggers You", steps
 Things that trip people up:
 
 - Post via `src.comms.publishing.publish_editorial_post()`. Single sanctioned path. Raw curl, sendPhoto, or sendMessage to the channel splits the post into photo-without-caption + text — we shipped that once.
+- For generated/local visuals, pass `photo_bytes=png` directly. Do not post the image to the moderator chat for staging or `file_id` extraction.
 - Step 0 — read `experiments/reports/channel-stats-YYYY-MM-DD.md` for yesterday's performance.
 - Step 1 — pick the strongest `Chart-worthy: yes` finding from `experiments/reports/anomalies-YYYY-MM-DD.md`.
 - Step 7 — archive to `docs/comms/published/YYYY-MM-DD-slug.md` and close this issue with a one-liner pointing at the archive.

--- a/docs/comms/brand-guide.md
+++ b/docs/comms/brand-guide.md
@@ -118,6 +118,12 @@ png = line_chart(dates, values, title="DAU 7d", accent_x=today)
 png = bar_chart(labels, values, title="Top sources", highlight_idx=0, horizontal=True)
 ```
 
+Publish generated chart bytes directly:
+
+```python
+await publish_editorial_post(..., photo_bytes=png)
+```
+
 **Design constraints (hard rules, violated = reject the image):**
 
 - **Max 3 numbers per image.** If you can't fit the story in 3 numbers, the story is too complicated for one post.
@@ -132,7 +138,12 @@ png = bar_chart(labels, values, title="Top sources", highlight_idx=0, horizontal
 - **Text density.** Titles ≤ 6 words. Axis labels only when the unit isn't obvious.
 - **Background.** Dark (`#1A1A2E`) for stat_slide; light (`#F5F5F5`) for charts. Don't mix.
 
-If an idea needs something beyond these primitives, flag it to CTO — don't improvise raw matplotlib.
+If an idea needs exact numbers beyond these primitives, flag it to CTO — don't improvise raw matplotlib.
+
+For non-data editorial art, use `src.comms.image_generation.build_editorial_image_prompt(...)`
+and `generate_editorial_image(...)` with a precise visual brief, then publish via
+`photo_bytes=image.image_bytes`. Do not stage generated visuals in the moderator
+chat to obtain Telegram `file_id`.
 
 ### 4. Diagrams
 For engineering/architecture posts.

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -340,7 +340,7 @@ These are encrypted in Paperclip DB and injected as env vars during agent runs:
 | `SENTRY_AUTH_TOKEN` | CTO, QA | Sentry CLI authentication (read-only project scope) |
 | `PREFECT_API_URL` | CTO, QA | Prefect API endpoint (`https://prefect.swanrate.com/api`) |
 | `PREFECT_AUTH_STRING` | CTO, QA | Prefect API Basic auth credentials |
-| `OPENAI_API_KEY` | All (Codex), Telegram plugin (Whisper) | OpenAI API for Codex + voice transcription |
+| `OPENAI_API_KEY` | All (Codex), Comms optional image generation, Telegram plugin (Whisper) | OpenAI API for Codex, GPT Image visuals, and voice transcription |
 | `TEST_DATABASE_URL` | CTO | Test/staging DB for safe experiments |
 | `TELEGRAM_BOT_TOKEN` | Telegram plugin | @ffnerdbot token (NOT @ffmemesbot!) |
 

--- a/src/comms/image_generation.py
+++ b/src/comms/image_generation.py
@@ -1,0 +1,131 @@
+"""OpenAI image generation helpers for Comms editorial visuals.
+
+This module is intentionally small: Comms builds an explicit prompt, receives
+image bytes, visually reviews them, and passes the bytes directly to
+`publish_editorial_post(photo_bytes=...)`. No Telegram moderator-chat staging
+is needed to obtain a file_id.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Any
+
+from openai import AsyncOpenAI
+
+from src.config import settings
+
+DEFAULT_IMAGE_MODEL = "gpt-image-2"
+DEFAULT_IMAGE_SIZE = "1536x1024"
+DEFAULT_IMAGE_QUALITY = "medium"
+DEFAULT_OUTPUT_FORMAT = "png"
+
+
+@dataclass(frozen=True)
+class GeneratedEditorialImage:
+    image_bytes: bytes
+    prompt: str
+    revised_prompt: str | None
+    model: str
+    size: str
+    quality: str
+    output_format: str
+
+
+def build_editorial_image_prompt(
+    *,
+    post_text: str,
+    visual_brief: str,
+    composition: str,
+    mood: str = "curious, sharp, optimistic",
+    include_text: bool = False,
+) -> str:
+    """Build a precise, repeatable prompt for Telegram post visuals.
+
+    Use AI-generated imagery for illustrative/editorial visuals. For exact
+    numbers, charts, UI labels, or text-heavy layouts, use `src.comms.visuals`
+    instead; image models can still miss precise typography.
+    """
+    text_rule = (
+        "Do not include readable text, numbers, UI labels, watermarks, or logos."
+        if not include_text
+        else "Readable text is allowed only where explicitly described in the brief."
+    )
+    return "\n".join(
+        [
+            "Create a polished editorial image for a Russian Telegram channel post.",
+            f"Post context: {post_text.strip()}",
+            f"Visual brief: {visual_brief.strip()}",
+            f"Composition: {composition.strip()}",
+            f"Mood: {mood.strip()}",
+            "Style: premium product/editorial illustration, clean shapes, "
+            "crisp lighting, high contrast, not stock-photo-like.",
+            "Brand palette: warm orange #FF6B35 as a single accent, "
+            "deep navy #1A1A2E, soft light neutral #F5F5F5, "
+            "restrained green #4CAF50 only for positive signal.",
+            "Format: landscape 3:2, Telegram-friendly crop, "
+            "clear focal point in the center third, readable at phone size.",
+            text_rule,
+            "Content safety: apolitical, SFW, non-offensive, "
+            "no real public figures, no brand logos unless explicitly requested.",
+        ]
+    )
+
+
+async def generate_editorial_image(
+    prompt: str,
+    *,
+    client: Any | None = None,
+    model: str = DEFAULT_IMAGE_MODEL,
+    size: str = DEFAULT_IMAGE_SIZE,
+    quality: str = DEFAULT_IMAGE_QUALITY,
+    output_format: str = DEFAULT_OUTPUT_FORMAT,
+) -> GeneratedEditorialImage:
+    """Generate a Comms visual with the OpenAI Images API.
+
+    Returns raw bytes so callers can publish with
+    `publish_editorial_post(photo_bytes=image.image_bytes)`.
+    """
+    if client is None:
+        if not settings.OPENAI_API_KEY:
+            raise RuntimeError("OPENAI_API_KEY is required to generate editorial images.")
+        client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
+
+    response = await client.images.generate(
+        model=model,
+        prompt=prompt,
+        size=size,
+        quality=quality,
+        output_format=output_format,
+        n=1,
+    )
+    data = getattr(response, "data", None) or []
+    if not data:
+        raise RuntimeError("OpenAI image generation returned no images.")
+
+    first = data[0]
+    image_b64 = getattr(first, "b64_json", None)
+    if not image_b64:
+        raise RuntimeError("OpenAI image generation returned no base64 image data.")
+
+    return GeneratedEditorialImage(
+        image_bytes=base64.b64decode(image_b64),
+        prompt=prompt,
+        revised_prompt=getattr(first, "revised_prompt", None),
+        model=model,
+        size=size,
+        quality=quality,
+        output_format=output_format,
+    )
+
+
+__all__ = [
+    "DEFAULT_IMAGE_MODEL",
+    "DEFAULT_IMAGE_QUALITY",
+    "DEFAULT_IMAGE_SIZE",
+    "DEFAULT_OUTPUT_FORMAT",
+    "GeneratedEditorialImage",
+    "build_editorial_image_prompt",
+    "generate_editorial_image",
+]

--- a/src/comms/publishing.py
+++ b/src/comms/publishing.py
@@ -19,6 +19,9 @@ Invariants enforced here (not in prompt):
   after send returns. A retry that races with a previous in-flight call
   loses the ON CONFLICT and refuses to double-post; a retry after the
   previous call succeeded short-circuits via the existing-row fast path.
+- Local/generated images can be passed as raw PNG/JPEG bytes. This avoids
+  staging a generated visual in the moderator chat just to obtain a Telegram
+  file_id.
 """
 
 from __future__ import annotations
@@ -295,6 +298,29 @@ def compute_draft_hash(
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:32]
 
 
+def media_key(
+    photo_file_id: str | None = None,
+    photo_url: str | None = None,
+    photo_bytes: bytes | None = None,
+) -> str | None:
+    """Stable identity for the attached visual.
+
+    `photo_file_id` and `photo_url` keep their historical raw string identity
+    so old idempotency hashes remain stable. Raw bytes use a content hash
+    because Telegram will not assign a reusable file_id until after upload.
+    """
+    provided = [value is not None for value in (photo_file_id, photo_url, photo_bytes)]
+    if sum(provided) > 1:
+        raise EditorialValidationError(
+            ["Pass exactly one visual source: photo_file_id, photo_url, or photo_bytes."]
+        )
+    if photo_bytes is not None:
+        if not photo_bytes:
+            raise EditorialValidationError(["photo_bytes must not be empty."])
+        return "bytes:" + hashlib.sha256(photo_bytes).hexdigest()
+    return photo_file_id or photo_url
+
+
 async def _recent_rotation_keys(
     channel: str, limit: int = 14
 ) -> list[tuple[str | None, str | None]]:
@@ -314,6 +340,7 @@ async def publish_editorial_post(
     entity_id: str,
     photo_file_id: str | None = None,
     photo_url: str | None = None,
+    photo_bytes: bytes | None = None,
     button_text: str | None = None,
     button_url: str | None = None,
     topic_slug: str | None = None,
@@ -329,7 +356,11 @@ async def publish_editorial_post(
         )
 
     normalized_text = normalize_blockquote(text)
-    photo_key = photo_file_id or photo_url
+    photo_key = media_key(
+        photo_file_id=photo_file_id,
+        photo_url=photo_url,
+        photo_bytes=photo_bytes,
+    )
     has_media = bool(photo_key)
 
     draft_hash = compute_draft_hash(
@@ -409,6 +440,7 @@ async def publish_editorial_post(
         channel=channel,
         photo_file_id=photo_file_id,
         photo_url=photo_url,
+        photo_bytes=photo_bytes,
         button_text=button_text,
         button_url=button_url,
     )
@@ -458,6 +490,7 @@ __all__ = [
     "compute_draft_hash",
     "execute",
     "mark_tracked_message_ids",
+    "media_key",
     "normalize_blockquote",
     "publish_editorial_post",
     "validate_post_draft",

--- a/src/flows/crossposting/editorial.py
+++ b/src/flows/crossposting/editorial.py
@@ -38,6 +38,7 @@ async def post_editorial_to_channel(
     channel: str = "ru",
     photo_url: str | None = None,
     photo_file_id: str | None = None,
+    photo_bytes: bytes | None = None,
     button_text: str | None = None,
     button_url: str | None = None,
 ):
@@ -50,6 +51,7 @@ async def post_editorial_to_channel(
             "ffmemes" (@ffmemes — RU build-in-public / product / process).
         photo_url: URL to a photo to attach.
         photo_file_id: Telegram file_id of a photo to attach.
+        photo_bytes: Raw image bytes for generated/local visuals.
         button_text: Optional inline button label.
         button_url: Optional inline button URL.
     """
@@ -68,15 +70,28 @@ async def post_editorial_to_channel(
             [[InlineKeyboardButton(text=button_text, url=button_url)]]
         )
 
-    photo = photo_file_id or photo_url
+    media_sources = [photo_file_id is not None, photo_url is not None, photo_bytes is not None]
+    if sum(media_sources) > 1:
+        raise ValueError("Pass exactly one of photo_file_id, photo_url, or photo_bytes")
 
-    if photo:
+    if photo_file_id is not None:
+        photo = photo_file_id
+    elif photo_url is not None:
+        photo = photo_url
+    else:
+        photo = photo_bytes
+
+    if photo is not None:
+        send_kwargs = {}
+        if photo_bytes is not None and photo is photo_bytes:
+            send_kwargs["filename"] = "editorial.png"
         msg = await bot.send_photo(
             chat_id=chat_id,
             photo=photo,
             caption=text,
             parse_mode=ParseMode.HTML,
             reply_markup=reply_markup,
+            **send_kwargs,
         )
         logger.info(f"Posted editorial photo to {channel} channel: msg_id={msg.message_id}")
     else:

--- a/tests/comms/test_image_generation.py
+++ b/tests/comms/test_image_generation.py
@@ -1,0 +1,70 @@
+import base64
+from types import SimpleNamespace
+
+import pytest
+
+from src.comms.image_generation import (
+    DEFAULT_IMAGE_MODEL,
+    build_editorial_image_prompt,
+    generate_editorial_image,
+)
+
+
+class _FakeImages:
+    def __init__(self):
+        self.kwargs = None
+
+    async def generate(self, **kwargs):
+        self.kwargs = kwargs
+        return SimpleNamespace(
+            data=[
+                SimpleNamespace(
+                    b64_json=base64.b64encode(b"png-bytes").decode("ascii"),
+                    revised_prompt="revised prompt",
+                )
+            ]
+        )
+
+
+class _FakeClient:
+    def __init__(self):
+        self.images = _FakeImages()
+
+
+def test_build_editorial_image_prompt_is_precise_and_brand_safe():
+    prompt = build_editorial_image_prompt(
+        post_text="Интересное: пользователи стали дольше сидеть в боте.",
+        visual_brief="One glowing feed card pulls attention while background cards fade.",
+        composition="Centered phone-like feed stack, one warm orange signal line.",
+    )
+
+    assert "Post context:" in prompt
+    assert "Visual brief:" in prompt
+    assert "#FF6B35" in prompt
+    assert "Do not include readable text" in prompt
+    assert "apolitical" in prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_editorial_image_returns_bytes_and_uses_gpt_image_2():
+    client = _FakeClient()
+    image = await generate_editorial_image("make image", client=client)
+
+    assert image.image_bytes == b"png-bytes"
+    assert image.revised_prompt == "revised prompt"
+    assert image.model == DEFAULT_IMAGE_MODEL
+    assert client.images.kwargs["model"] == "gpt-image-2"
+    assert client.images.kwargs["output_format"] == "png"
+    assert client.images.kwargs["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_editorial_image_rejects_empty_response():
+    class EmptyImages:
+        async def generate(self, **kwargs):
+            return SimpleNamespace(data=[])
+
+    client = SimpleNamespace(images=EmptyImages())
+
+    with pytest.raises(RuntimeError, match="no images"):
+        await generate_editorial_image("make image", client=client)

--- a/tests/comms/test_publishing.py
+++ b/tests/comms/test_publishing.py
@@ -10,7 +10,9 @@ from src.comms.publishing import (
     ALLOWED_CHANNELS,
     ALLOWED_HTML_TAGS,
     TELEGRAM_CAPTION_MAX,
+    EditorialValidationError,
     compute_draft_hash,
+    media_key,
     normalize_blockquote,
     validate_post_draft,
 )
@@ -286,6 +288,30 @@ def test_compute_draft_hash_includes_button():
     assert with_button != compute_draft_hash(
         "ru", "hello", "f1", "C", "e1", button_text="Поехали", button_url="https://t.me/x"
     )
+
+
+# ── Media identity ────────────────────────────────────────────────────────
+
+
+def test_media_key_keeps_file_id_identity_stable():
+    assert media_key(photo_file_id="telegram_file_id") == "telegram_file_id"
+
+
+def test_media_key_hashes_raw_bytes():
+    key = media_key(photo_bytes=b"png-bytes")
+    assert key.startswith("bytes:")
+    assert key == media_key(photo_bytes=b"png-bytes")
+    assert key != media_key(photo_bytes=b"other-png-bytes")
+
+
+def test_media_key_rejects_multiple_sources():
+    with pytest.raises(EditorialValidationError):
+        media_key(photo_file_id="telegram_file_id", photo_bytes=b"png")
+
+
+def test_media_key_rejects_empty_bytes():
+    with pytest.raises(EditorialValidationError):
+        media_key(photo_bytes=b"")
 
 
 # ── Channel routing ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- allow Comms editorial posts to publish local/generated images via raw photo bytes
- add a GPT Image helper that returns bytes for direct publishing
- update Comms instructions so generated visuals are never staged in the moderator chat for file_id extraction

## Tests
- ruff check src tests
- ruff format --check src tests
- pytest tests/comms -q

Claude check: skipped because local Claude CLI has no auth configured in this environment.