### PR TITLE
fix: reject empty comms media inputs

### DIFF
--- a/src/comms/publishing.py
+++ b/src/comms/publishing.py
@@ -314,6 +314,10 @@ def media_key(
         raise EditorialValidationError(
             ["Pass exactly one visual source: photo_file_id, photo_url, or photo_bytes."]
         )
+    if photo_file_id is not None and not photo_file_id.strip():
+        raise EditorialValidationError(["photo_file_id must not be empty."])
+    if photo_url is not None and not photo_url.strip():
+        raise EditorialValidationError(["photo_url must not be empty."])
     if photo_bytes is not None:
         if not photo_bytes:
             raise EditorialValidationError(["photo_bytes must not be empty."])

--- a/src/flows/crossposting/editorial.py
+++ b/src/flows/crossposting/editorial.py
@@ -73,6 +73,12 @@ async def post_editorial_to_channel(
     media_sources = [photo_file_id is not None, photo_url is not None, photo_bytes is not None]
     if sum(media_sources) > 1:
         raise ValueError("Pass exactly one of photo_file_id, photo_url, or photo_bytes")
+    if photo_file_id is not None and not photo_file_id.strip():
+        raise ValueError("photo_file_id must not be empty")
+    if photo_url is not None and not photo_url.strip():
+        raise ValueError("photo_url must not be empty")
+    if photo_bytes is not None and not photo_bytes:
+        raise ValueError("photo_bytes must not be empty")
 
     if photo_file_id is not None:
         photo = photo_file_id

--- a/tests/comms/test_editorial_flow.py
+++ b/tests/comms/test_editorial_flow.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.flows.crossposting import editorial
+
+
+class _FailingBot:
+    async def send_photo(self, **_kwargs):
+        raise AssertionError("send_photo must not be called for invalid media input")
+
+
+class _Logger:
+    def info(self, *_args, **_kwargs):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"photo_file_id": ""}, "photo_file_id must not be empty"),
+        ({"photo_url": "   "}, "photo_url must not be empty"),
+        ({"photo_bytes": b""}, "photo_bytes must not be empty"),
+    ],
+)
+async def test_post_editorial_rejects_empty_media_before_sending(monkeypatch, kwargs, message):
+    monkeypatch.setattr(editorial, "bot", _FailingBot())
+    monkeypatch.setattr(editorial, "get_run_logger", lambda: _Logger())
+
+    with pytest.raises(ValueError, match=message):
+        await editorial.post_editorial_to_channel.fn(
+            text="<b>ok</b>",
+            channel="ffmemes",
+            **kwargs,
+        )
+
+
+@pytest.mark.asyncio
+async def test_post_editorial_sends_raw_bytes_with_filename(monkeypatch):
+    calls = []
+
+    class Bot:
+        async def send_photo(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(message_id=123)
+
+    monkeypatch.setattr(editorial, "bot", Bot())
+    monkeypatch.setattr(editorial, "get_run_logger", lambda: _Logger())
+
+    message_id = await editorial.post_editorial_to_channel.fn(
+        text="<b>ok</b>",
+        channel="ffmemes",
+        photo_bytes=b"\x89PNG\r\n\x1a\n",
+    )
+
+    assert message_id == 123
+    assert calls[0]["photo"] == b"\x89PNG\r\n\x1a\n"
+    assert calls[0]["filename"] == "editorial.png"

--- a/tests/comms/test_publishing.py
+++ b/tests/comms/test_publishing.py
@@ -314,6 +314,22 @@ def test_media_key_rejects_empty_bytes():
         media_key(photo_bytes=b"")
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "field"),
+    [
+        ({"photo_file_id": ""}, "photo_file_id"),
+        ({"photo_file_id": "   "}, "photo_file_id"),
+        ({"photo_url": ""}, "photo_url"),
+        ({"photo_url": "   "}, "photo_url"),
+    ],
+)
+def test_media_key_rejects_blank_string_sources(kwargs, field):
+    with pytest.raises(EditorialValidationError) as excinfo:
+        media_key(**kwargs)
+
+    assert field in str(excinfo.value)
+
+
 # ── Channel routing ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Follow-up to #243 after independent Codex/Claude review.\n\nWhat changed:\n- Reject blank photo_file_id/photo_url in media_key before draft_hash claim.\n- Reject empty media inputs in post_editorial_to_channel before Telegram send.\n- Add tests for blank media validation and raw photo_bytes forwarding with filename.\n\nVerification:\n- ruff format --check src tests\n- ruff check src tests\n- pytest tests/comms -q (76 passed)\n\nNotes:\n- Codex/Claude both questioned gpt-image-2 based on stale SDK/type metadata. I verified via OpenAI Models API that the configured key can access gpt-image-2, so this PR leaves the intended image model unchanged.