### PR TITLE
Fix: address PR 245 audit review findings

### DIFF
--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -25,7 +25,12 @@ import os
 import re
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
 try:
     from paperclip_contracts import (

--- a/scripts/redaction_audit.py
+++ b/scripts/redaction_audit.py
@@ -24,6 +24,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
+from urllib.parse import unquote, urlsplit
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -47,6 +48,22 @@ PLACEHOLDER_TOKENS = {
     "@localhost",
     "@db:",
     "@app_db:",
+}
+
+DB_CREDENTIAL_PLACEHOLDER_TOKENS = {
+    "changeme",
+    "redacted",
+    "<password>",
+    "<token>",
+    "<secret>",
+    "example",
+    "xxxxxxxx",
+    "mystrongpassword",
+}
+
+DB_CREDENTIAL_PLACEHOLDER_PAIRS = {
+    ("app", "app"),
+    ("postgres", "postgres"),
 }
 
 
@@ -202,6 +219,24 @@ def is_placeholder(match_text: str) -> bool:
     return False
 
 
+def is_db_url_placeholder(match_text: str) -> bool:
+    parsed = urlsplit(match_text)
+    username = unquote(parsed.username or "")
+    password = unquote(parsed.password or "")
+    if not username or not password:
+        return False
+
+    lowered_pair = (username.lower(), password.lower())
+    if lowered_pair in DB_CREDENTIAL_PLACEHOLDER_PAIRS:
+        return True
+
+    credential_text = f"{username}:{password}".lower()
+    for token in DB_CREDENTIAL_PLACEHOLDER_TOKENS:
+        if token in credential_text:
+            return True
+    return False
+
+
 def list_tracked_files() -> list[str]:
     result = subprocess.run(
         ["git", "ls-files"],
@@ -238,9 +273,13 @@ def scan_file(rel_path: str) -> list[Finding]:
     for pattern in PATTERNS:
         for match in pattern.regex.finditer(text):
             matched = match.group(0)
-            if is_placeholder_file and is_placeholder(matched):
+            if pattern.name == "db_url_with_password":
+                is_placeholder_match = is_db_url_placeholder(matched)
+            else:
+                is_placeholder_match = is_placeholder(matched)
+            if is_placeholder_file and is_placeholder_match:
                 continue
-            if is_placeholder(matched):
+            if is_placeholder_match:
                 # heuristic for non-env files too: if the value clearly
                 # contains a placeholder marker, skip.
                 continue

--- a/tests/scripts/test_paperclip_routine_audit.py
+++ b/tests/scripts/test_paperclip_routine_audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 
@@ -9,7 +10,13 @@ def load_audit_module():
     spec = importlib.util.spec_from_file_location("paperclip_routine_audit", path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    original_sys_path = list(sys.path)
+    blocked_paths = {path.parent, path.parents[1]}
+    sys.path[:] = [item for item in sys.path if Path(item or ".").resolve() not in blocked_paths]
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path[:] = original_sys_path
     return module
 
 

--- a/tests/test_redaction_audit.py
+++ b/tests/test_redaction_audit.py
@@ -85,6 +85,14 @@ def test_postgres_url_with_password_flagged(tmp_path: Path) -> None:
     assert any(f.pattern == "db_url_with_password" for f in findings)
 
 
+def test_postgres_url_with_real_password_on_db_host_flagged(tmp_path: Path) -> None:
+    findings = _scan_file(
+        tmp_path,
+        "DATABASE_URL=postgresql://prod_user:HotPassword2026@db:5432/app",
+    )
+    assert any(f.pattern == "db_url_with_password" for f in findings)
+
+
 def test_postgres_placeholders_clean(tmp_path: Path) -> None:
     findings = _scan_file(
         tmp_path,


### PR DESCRIPTION
## Summary

Fixes FFM-1115 follow-up findings from PR #245:

- Makes `scripts/paperclip_routine_audit.py` self-contained when imported via `importlib` by adding its own `scripts/` directory to `sys.path` before sibling imports.
- Strengthens `tests/scripts/test_paperclip_routine_audit.py` so it strips ambient repo/script paths before loading the module, covering the import-order failure mode.
- Narrows `scripts/redaction_audit.py` DB URL placeholder suppression to placeholder credentials instead of suppressing every URL whose host is `db` / `app_db` / `localhost`.
- Adds a regression test for `postgresql://prod_user:HotPassword2026@db:5432/app`.

## Root Cause

The routine audit import depended on ambient `sys.path` state when imported through `importlib`, which made the test environment/order matter.

The redaction audit used one pattern-agnostic placeholder check for every finding type. Host placeholder tokens such as `@db:` were enough to suppress a full Postgres URL even when the username/password were real literals.

## Validation

- `python3 -m pytest tests/scripts/test_paperclip_routine_audit.py -q` -> 4 passed
- `python3 -m pytest tests/test_redaction_audit.py -q` -> 15 passed
- `python3 -m pytest tests/scripts/test_paperclip_routine_audit.py tests/test_redaction_audit.py -q` -> 19 passed
- `python3 scripts/redaction_audit.py` -> clean, 412 tracked files scanned
- `ruff check --fix src/ tests/ scripts/paperclip_routine_audit.py scripts/redaction_audit.py`
- `ruff format src/ tests/ scripts/paperclip_routine_audit.py scripts/redaction_audit.py`
- `git diff --check`

Attempted `python3 -m pytest tests/ -x -q`, but this local environment stops during collection before these tests because required settings are missing: `REDIS_URL`, `CORS_ORIGINS`, and `CORS_HEADERS`.
