### PR TITLE
feat(admin): non-interactive CLI for source moderation (FFM-1154)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,17 @@ desired skills.
 
 **IMPORTANT: Read `docs/broadcasts.md` before sending any broadcast.** Use `send_broadcast()` from `src/broadcasts/service.py` with a unique `broadcast_id` for dedup. Never run inline ad-hoc broadcast code. Language detection uses `user_language` table (bot preference), NOT `user_tg.language_code` (Telegram app language).
 
+## Source moderation (agent-driven)
+
+`scripts/admin/advance_source.py` is the non-interactive CLI for
+advancing `meme_source` rows through moderation states. Use it from a
+CTO/QA heartbeat instead of waiting for Daniil to drive the Telegram
+bot UI. Shares business logic with the bot moderator handler via
+`src/storage/moderation.py::advance_meme_source` — same snooze/unsnooze
+cascades, same audit trail under `meme_source.data.moderation_log`.
+
+See `docs/source-moderation-cli.md` for usage and verification queries.
+
 ## Known Issues
 
 - SQL string interpolation in `candidates.py` -- needs parameterization (injection risk)

--- a/docs/source-moderation-cli.md
+++ b/docs/source-moderation-cli.md
@@ -1,0 +1,108 @@
+# Source moderation CLI (agent-driven)
+
+`scripts/admin/advance_source.py` advances a `meme_source` row through
+moderation states (`in_moderation` → `parsing_enabled`, snooze, unsnooze,
+language assignment) without driving the Telegram moderator UI.
+
+## When to use
+
+The moderator UI in `@ffmemesbot` requires a real Telegram identity, so
+agent runtimes (CTO, QA) cannot promote sources discovered by
+`/discoveredsources`. This CLI gives them a server-side path that calls
+the same business logic as the bot — see
+`src/storage/moderation.py::advance_meme_source`.
+
+Typical triggers:
+- Source candidates surge in the discovery queue and Daniil hasn't had
+  time to review (FFM-1153/FFM-1114). CTO heartbeat clears the
+  promoted-but-stuck rows.
+- QA needs to re-enable a source after a regression test.
+- Auto-snooze fires on a source that was misclassified; the CTO
+  un-snoozes it after fixing the parser.
+
+## How it runs
+
+The CLI shares the prod DB env vars by running inside the `app`
+container:
+
+```bash
+docker compose exec app python -m scripts.admin.advance_source \
+    --id <meme_source_id> \
+    --language ru \
+    --status parsing_enabled \
+    --moderator-id agent:cto
+```
+
+Flags:
+- `--id` (required): `meme_source.id`.
+- `--language`: ISO code (`ru`, `en`, …). Set on first promotion or to
+  re-classify.
+- `--status`: one of `in_moderation`, `parsing_enabled`,
+  `parsing_disabled`, `snoozed`. Skip to leave unchanged.
+- `--moderator-id` (required): stable identifier of the caller. Use
+  `agent:<role>` (e.g. `agent:cto`) so the audit trail can distinguish
+  human moderators (numeric Telegram user_id) from agents.
+- `--no-trigger-parse`: skip the platform parser kick-off after a flip
+  to `parsing_enabled`. Default behavior is to trigger parsing for TG
+  and VK sources (matches the bot moderator path).
+- `--show`: read-only — dump the current row as JSON and exit.
+
+The CLI prints a JSON result with `before_*`, `after_*`, snoozed /
+unsnoozed counts, and whether parsing was triggered.
+
+## Audit trail
+
+Every status or language change appends an entry to
+`meme_source.data.moderation_log`:
+
+```json
+{
+  "moderation_log": [
+    {
+      "moderator": "agent:cto",
+      "ts": "2026-05-10T21:30:00.000000",
+      "changed": {
+        "language_code": {"from": null, "to": "ru"},
+        "status": {"from": "in_moderation", "to": "parsing_enabled"}
+      }
+    }
+  ],
+  "last_moderated_by": "agent:cto"
+}
+```
+
+The Telegram moderator UI also writes to the same field with the
+human's numeric user_id, so the trail is unified.
+
+## Verification post-promotion
+
+After flipping a source to `parsing_enabled`, parsing has been
+triggered inline. Expected timing:
+
+1. Within ~30s: `meme_raw_telegram` rows for the new source appear.
+2. Within the next pipeline run (≤15 min): `meme(meme_source_id=…)`
+   rows transition `created → ok`.
+
+Quick sanity query (run via `psql $ANALYST_DATABASE_URL`):
+
+```sql
+SELECT
+  ms.id,
+  ms.url,
+  ms.status,
+  (SELECT count(*) FROM meme_raw_telegram WHERE meme_source_id = ms.id) AS raw_posts,
+  (SELECT count(*) FROM meme WHERE meme_source_id = ms.id) AS memes_total,
+  (SELECT count(*) FROM meme WHERE meme_source_id = ms.id AND status = 'ok') AS memes_ok
+FROM meme_source ms
+WHERE ms.id = ANY(ARRAY[21848, 21849]);
+```
+
+## Failure modes
+
+- `error: not_found` — wrong id, or a candidate row was never promoted
+  to `meme_source`. Check `meme_source_candidate.promoted_meme_source_id`.
+- `error: bad_request` — invalid status string or no fields supplied.
+- Parser errors (TG flood-wait, IG rate-limit) propagate as
+  exceptions. The DB transition has already committed — the source
+  row is marked `parsing_enabled` and the next scheduled parse run
+  picks it up.

--- a/scripts/admin/advance_source.py
+++ b/scripts/admin/advance_source.py
@@ -1,0 +1,155 @@
+"""Non-interactive CLI to advance a `meme_source` through moderation.
+
+Use case: agent runtimes (CTO, QA) need to clear sources stuck in
+`in_moderation` without driving the Telegram bot UI as a real user. The
+bot moderator path requires a human Telegram identity; this CLI does not.
+
+Run from inside the prod app container so it shares the same DB env vars
+as the FastAPI service:
+
+    docker compose exec app python -m scripts.admin.advance_source \\
+        --id 21848 --language ru --status parsing_enabled \\
+        --moderator-id agent:cto
+
+Acceptance for FFM-1154: clears sources 21848 (nourlnews) and 21849
+(kozakrichala) at language=ru, status=parsing_enabled, then post raw
+post / total meme / ok meme counts back to FFM-1114.
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from src.storage.constants import MemeSourceStatus
+from src.storage.moderation import (
+    MemeSourceNotFoundError,
+    advance_meme_source,
+    get_source,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.admin.advance_source",
+        description=("Advance a meme_source through moderation states (language and/or status)."),
+    )
+    parser.add_argument(
+        "--id",
+        dest="meme_source_id",
+        type=int,
+        required=True,
+        help="meme_source.id to advance.",
+    )
+    parser.add_argument(
+        "--language",
+        dest="language_code",
+        type=str,
+        default=None,
+        help="ISO language code (e.g. ru, en). Skips if omitted.",
+    )
+    parser.add_argument(
+        "--status",
+        dest="status",
+        type=str,
+        default=None,
+        choices=[s.value for s in MemeSourceStatus],
+        help=("New status. Use parsing_enabled to clear in_moderation. Skips if omitted."),
+    )
+    parser.add_argument(
+        "--moderator-id",
+        dest="moderator_id",
+        type=str,
+        required=True,
+        help=(
+            "Stable identifier for who/what is moderating "
+            "(e.g. 'agent:cto'). Persisted to the audit trail."
+        ),
+    )
+    parser.add_argument(
+        "--no-trigger-parse",
+        dest="trigger_parse",
+        action="store_false",
+        default=True,
+        help=("Skip kicking off the platform parser after flipping status to parsing_enabled."),
+    )
+    parser.add_argument(
+        "--show",
+        dest="show_only",
+        action="store_true",
+        help="Just print the current source row and exit (no writes).",
+    )
+    return parser
+
+
+def _serialize(value: Any) -> Any:
+    """Coerce DB rows / datetime to JSON-friendly primitives."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, list):
+        return [_serialize(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _serialize(v) for k, v in value.items()}
+    return str(value)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if args.show_only:
+        src = await get_source(args.meme_source_id)
+        if src is None:
+            print(json.dumps({"ok": False, "error": "not_found", "id": args.meme_source_id}))
+            return 1
+        print(json.dumps({"ok": True, "source": _serialize(dict(src))}, indent=2))
+        return 0
+
+    if args.language_code is None and args.status is None:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": "no_change_requested",
+                    "hint": "pass --language and/or --status",
+                }
+            )
+        )
+        return 2
+
+    try:
+        result = await advance_meme_source(
+            args.meme_source_id,
+            moderator_id=args.moderator_id,
+            language_code=args.language_code,
+            status=args.status,
+            trigger_parse=args.trigger_parse,
+        )
+    except MemeSourceNotFoundError as e:
+        print(json.dumps({"ok": False, "error": "not_found", "message": str(e)}))
+        return 1
+    except ValueError as e:
+        print(json.dumps({"ok": False, "error": "bad_request", "message": str(e)}))
+        return 2
+
+    payload = {
+        "ok": True,
+        "id": args.meme_source_id,
+        "before_status": result["before_status"],
+        "before_language_code": result["before_language_code"],
+        "after_status": result["source"]["status"],
+        "after_language_code": result["source"]["language_code"],
+        "snoozed_count": result["snoozed_count"],
+        "unsnoozed_count": result["unsnoozed_count"],
+        "parsed": result["parsed"],
+        "moderator_id": args.moderator_id,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/storage/moderation.py
+++ b/src/storage/moderation.py
@@ -1,0 +1,179 @@
+"""Shared moderation transitions for `meme_source`.
+
+Both the Telegram moderator UI (`src/tgbot/handlers/moderator/meme_source.py`)
+and the admin CLI (`scripts/admin/advance_source.py`) call into
+`advance_meme_source` so the snooze/unsnooze rules and audit trail can never
+drift between the two paths.
+
+Side-effects deliberately excluded from this module:
+- TG admin-channel notifications (`src.tgbot.logs.log`) — caller-specific.
+- UI rendering (keyboards, send_message) — caller-specific.
+
+Side-effects this module owns:
+- Snooze/unsnooze cascades on `meme.status` for the affected source.
+- Audit log appended to `meme_source.data['moderation_log']`, plus a
+  `last_moderated_by` field. `data` is JSONB so this is a structured trail
+  rather than a free-form log line, which lets future tooling (analyst
+  queries, re-deciding stuck sources) read who moved which source when.
+- Triggering the platform parser when a source flips to `parsing_enabled`.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from src.database import execute, fetch_one, meme, meme_source
+from src.storage.constants import MemeSourceStatus, MemeSourceType, MemeStatus
+
+
+class MemeSourceNotFoundError(LookupError):
+    pass
+
+
+async def get_source(meme_source_id: int) -> dict[str, Any] | None:
+    return await fetch_one(meme_source.select().where(meme_source.c.id == meme_source_id))
+
+
+async def _snooze_memes(meme_source_id: int) -> int:
+    result = await execute(
+        meme.update()
+        .where(meme.c.meme_source_id == meme_source_id)
+        .where(meme.c.status == MemeStatus.OK)
+        .values(status=MemeStatus.SNOOZED)
+    )
+    return result.rowcount
+
+
+async def _unsnooze_memes(meme_source_id: int) -> int:
+    result = await execute(
+        meme.update()
+        .where(meme.c.meme_source_id == meme_source_id)
+        .where(meme.c.status == MemeStatus.SNOOZED)
+        .values(status=MemeStatus.OK)
+    )
+    return result.rowcount
+
+
+def _audit_entry(moderator_id: str, changed: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "moderator": moderator_id,
+        "ts": datetime.utcnow().isoformat(),
+        "changed": changed,
+    }
+
+
+async def advance_meme_source(
+    meme_source_id: int,
+    moderator_id: str,
+    *,
+    language_code: str | None = None,
+    status: str | None = None,
+    trigger_parse: bool = True,
+) -> dict[str, Any]:
+    """Apply one moderation step to `meme_source(id=meme_source_id)`.
+
+    Args:
+      meme_source_id: target meme_source row id.
+      moderator_id: stable identifier of the moderator (Telegram user_id as
+        string, or agent id like `agent:cto`). Persisted to the audit trail
+        so we can tell apart human and agent moderation events.
+      language_code: optional new `language_code`; pass None to leave it.
+      status: optional new `meme_source.status`; pass None to leave it.
+        Must be a `MemeSourceStatus` value if provided.
+      trigger_parse: whether to kick off the platform parser when status
+        flips to `parsing_enabled`. CLI/bot both default this to True.
+
+    Returns dict with:
+      - `source`: updated row (post-transition).
+      - `before_status`, `before_language_code`: values prior to update.
+      - `snoozed_count`, `unsnoozed_count`: rows touched on `meme`.
+      - `parsed`: whether parsing was triggered for the source.
+
+    Raises:
+      MemeSourceNotFoundError: source id does not exist.
+      ValueError: invalid status, or no fields supplied.
+    """
+    if status is None and language_code is None:
+        raise ValueError("at least one of status or language_code must be provided")
+
+    if status is not None:
+        try:
+            status_enum: MemeSourceStatus | None = MemeSourceStatus(status)
+        except ValueError as e:
+            valid = [s.value for s in MemeSourceStatus]
+            raise ValueError(f"invalid status {status!r}; valid: {valid}") from e
+    else:
+        status_enum = None
+
+    src = await get_source(meme_source_id)
+    if src is None:
+        raise MemeSourceNotFoundError(f"meme_source(id={meme_source_id}) not found")
+
+    before_status = src["status"]
+    before_language_code = src["language_code"]
+
+    snoozed_count = 0
+    unsnoozed_count = 0
+
+    # Match the bot moderator path (`handle_meme_source_change_status`):
+    # unsnooze the source's memes when leaving SNOOZED for PARSING_ENABLED;
+    # snooze the source's OK memes whenever entering SNOOZED. Updating meme
+    # rows before the source row keeps state consistent if either fails.
+    if (
+        status_enum is MemeSourceStatus.PARSING_ENABLED
+        and before_status == MemeSourceStatus.SNOOZED.value
+    ):
+        unsnoozed_count = await _unsnooze_memes(meme_source_id)
+    elif status_enum is MemeSourceStatus.SNOOZED:
+        snoozed_count = await _snooze_memes(meme_source_id)
+
+    changed: dict[str, Any] = {}
+    values: dict[str, Any] = {"updated_at": datetime.utcnow()}
+    if language_code is not None and language_code != before_language_code:
+        values["language_code"] = language_code
+        changed["language_code"] = {"from": before_language_code, "to": language_code}
+    if status_enum is not None and status_enum.value != before_status:
+        values["status"] = status_enum.value
+        changed["status"] = {"from": before_status, "to": status_enum.value}
+
+    if changed:
+        existing_data = dict(src.get("data") or {})
+        log_entries = list(existing_data.get("moderation_log") or [])
+        log_entries.append(_audit_entry(moderator_id, changed))
+        existing_data["moderation_log"] = log_entries
+        existing_data["last_moderated_by"] = moderator_id
+        values["data"] = existing_data
+
+    updated = await fetch_one(
+        meme_source.update()
+        .where(meme_source.c.id == meme_source_id)
+        .values(**values)
+        .returning(meme_source)
+    )
+
+    parsed_triggered = False
+    if (
+        trigger_parse
+        and status_enum is MemeSourceStatus.PARSING_ENABLED
+        and updated["status"] == MemeSourceStatus.PARSING_ENABLED.value
+    ):
+        # Imported lazily so test code that exercises advance_meme_source
+        # without prefect/parser deps does not pay the import cost.
+        if updated["type"] == MemeSourceType.TELEGRAM.value:
+            from src.flows.parsers.tg import parse_telegram_source
+
+            await parse_telegram_source(meme_source_id, updated["url"])
+            parsed_triggered = True
+        elif updated["type"] == MemeSourceType.VK.value:
+            from src.flows.parsers.vk import parse_vk_source
+
+            await parse_vk_source(meme_source_id, updated["url"])
+            parsed_triggered = True
+
+    return {
+        "source": updated,
+        "before_status": before_status,
+        "before_language_code": before_language_code,
+        "snoozed_count": snoozed_count,
+        "unsnoozed_count": unsnoozed_count,
+        "parsed": parsed_triggered,
+    }

--- a/src/tgbot/handlers/moderator/meme_source.py
+++ b/src/tgbot/handlers/moderator/meme_source.py
@@ -7,6 +7,10 @@ from src.flows.parsers.tg import parse_telegram_source
 from src.flows.parsers.vk import parse_vk_source
 from src.storage.constants import MemeSourceStatus, MemeSourceType
 from src.storage.etl import normalize_telegram_channel_url
+from src.storage.moderation import (
+    MemeSourceNotFoundError,
+    advance_meme_source,
+)
 from src.tgbot.constants import UserType
 from src.tgbot.logs import log
 from src.tgbot.senders.keyboards import (
@@ -15,12 +19,8 @@ from src.tgbot.senders.keyboards import (
 )
 from src.tgbot.senders.utils import send_or_edit
 from src.tgbot.service import (
-    get_meme_source_by_id,
     get_meme_source_stats_by_id,
     get_or_create_meme_source,
-    snooze_memes_of_meme_source,
-    unsnooze_memes_of_meme_source,
-    update_meme_source,
 )
 from src.tgbot.user_info import get_user_info
 
@@ -75,8 +75,14 @@ async def handle_meme_source_language_selection(
     args = update.callback_query.data.split(":")
     meme_source_id, lang_code = int(args[1]), args[3]
 
-    meme_source = await update_meme_source(meme_source_id, language_code=lang_code)
-    if meme_source is None:
+    try:
+        result = await advance_meme_source(
+            meme_source_id,
+            moderator_id=str(user_id),
+            language_code=lang_code,
+            trigger_parse=False,
+        )
+    except MemeSourceNotFoundError:
         await update.callback_query.answer("Meme source not found")
         return
 
@@ -86,7 +92,7 @@ async def handle_meme_source_language_selection(
     )
 
     await update.callback_query.answer(f"Meme source lang is {lang_code} now")
-    await meme_source_admin_pipeline(meme_source, update)
+    await meme_source_admin_pipeline(result["source"], update)
 
 
 async def handle_meme_source_change_status(
@@ -101,21 +107,26 @@ async def handle_meme_source_change_status(
     args = update.callback_query.data.split(":")
     meme_source_id, status = int(args[1]), args[3]
 
-    meme_source = await get_meme_source_by_id(meme_source_id)
-    if (
-        meme_source["status"] == MemeSourceStatus.SNOOZED
-        and status == MemeSourceStatus.PARSING_ENABLED
-    ):
-        # unsnooze memes
-        nmemes_updated = await unsnooze_memes_of_meme_source(meme_source_id)
-        await update.effective_chat.send_message(
-            f"Unsnoozed {nmemes_updated} memes of {meme_source_id}"
+    try:
+        # `trigger_parse=False` keeps parse-after-UI ordering: we want the
+        # moderator to see the keyboard refresh before we await the parser.
+        result = await advance_meme_source(
+            meme_source_id,
+            moderator_id=str(user_id),
+            status=status,
+            trigger_parse=False,
         )
-
-    meme_source = await update_meme_source(meme_source_id, status=status)
-    if meme_source is None:
+    except MemeSourceNotFoundError:
         await update.callback_query.answer(f"Meme source {meme_source_id} not found")
         return
+    except ValueError as e:
+        await update.callback_query.answer(str(e)[:180])
+        return
+
+    if result["unsnoozed_count"]:
+        await update.effective_chat.send_message(
+            f"Unsnoozed {result['unsnoozed_count']} memes of {meme_source_id}"
+        )
 
     await log(
         f"ℹ️ MemeSource ${meme_source_id}: set_status={status} (by {user_id})",
@@ -123,8 +134,9 @@ async def handle_meme_source_change_status(
     )
 
     await update.callback_query.answer(f"Meme source status is {status} now")
-    await meme_source_admin_pipeline(meme_source, update)
+    await meme_source_admin_pipeline(result["source"], update)
 
+    meme_source = result["source"]
     if status == MemeSourceStatus.PARSING_ENABLED:  # trigger parsing
         # TODO: async
         if meme_source["type"] == MemeSourceType.VK:
@@ -132,11 +144,9 @@ async def handle_meme_source_change_status(
         elif meme_source["type"] == MemeSourceType.TELEGRAM:
             await parse_telegram_source(meme_source_id, meme_source["url"])
 
-    if status == MemeSourceStatus.SNOOZED:
-        # set memes of a source status to snoozed
-        nmemes_updated = await snooze_memes_of_meme_source(meme_source["id"])
+    if result["snoozed_count"]:
         await update.effective_chat.send_message(
-            f"Snoozed {nmemes_updated} memes of {meme_source_id}"
+            f"Snoozed {result['snoozed_count']} memes of {meme_source_id}"
         )
 
 

--- a/tests/scripts/test_advance_source_cli.py
+++ b/tests/scripts/test_advance_source_cli.py
@@ -1,0 +1,175 @@
+"""Argparse-only sanity tests for the admin source CLI (FFM-1154).
+
+The DB-touching path is covered by `tests/storage/test_moderation.py`.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from scripts.admin import advance_source as cli
+
+
+def test_parser_accepts_status_and_language():
+    parser = cli._build_parser()
+    args = parser.parse_args(
+        [
+            "--id",
+            "21848",
+            "--language",
+            "ru",
+            "--status",
+            "parsing_enabled",
+            "--moderator-id",
+            "agent:cto",
+        ]
+    )
+    assert args.meme_source_id == 21848
+    assert args.language_code == "ru"
+    assert args.status == "parsing_enabled"
+    assert args.moderator_id == "agent:cto"
+    assert args.trigger_parse is True
+
+
+def test_parser_no_trigger_parse_flag():
+    parser = cli._build_parser()
+    args = parser.parse_args(
+        [
+            "--id",
+            "1",
+            "--status",
+            "snoozed",
+            "--moderator-id",
+            "x",
+            "--no-trigger-parse",
+        ]
+    )
+    assert args.trigger_parse is False
+
+
+def test_parser_rejects_unknown_status():
+    parser = cli._build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "--id",
+                "1",
+                "--status",
+                "bogus",
+                "--moderator-id",
+                "x",
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_passes_args_to_service_and_emits_json(capsys):
+    fake_source = {
+        "status": "parsing_enabled",
+        "language_code": "ru",
+    }
+    fake_result = {
+        "source": fake_source,
+        "before_status": "in_moderation",
+        "before_language_code": None,
+        "snoozed_count": 0,
+        "unsnoozed_count": 0,
+        "parsed": True,
+    }
+    args = cli._build_parser().parse_args(
+        [
+            "--id",
+            "21848",
+            "--language",
+            "ru",
+            "--status",
+            "parsing_enabled",
+            "--moderator-id",
+            "agent:cto",
+        ]
+    )
+    with patch.object(
+        cli, "advance_meme_source", new=AsyncMock(return_value=fake_result)
+    ) as mock_advance:
+        rc = await cli._run(args)
+
+    assert rc == 0
+    mock_advance.assert_awaited_once_with(
+        21848,
+        moderator_id="agent:cto",
+        language_code="ru",
+        status="parsing_enabled",
+        trigger_parse=True,
+    )
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["after_status"] == "parsing_enabled"
+    assert out["before_status"] == "in_moderation"
+    assert out["moderator_id"] == "agent:cto"
+
+
+@pytest.mark.asyncio
+async def test_run_returns_error_on_missing_source(capsys):
+    from src.storage.moderation import MemeSourceNotFoundError
+
+    args = cli._build_parser().parse_args(
+        [
+            "--id",
+            "999999",
+            "--status",
+            "parsing_enabled",
+            "--moderator-id",
+            "agent:cto",
+        ]
+    )
+    with patch.object(
+        cli,
+        "advance_meme_source",
+        new=AsyncMock(side_effect=MemeSourceNotFoundError("not found")),
+    ):
+        rc = await cli._run(args)
+
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"ok": False, "error": "not_found", "message": "not found"}
+
+
+@pytest.mark.asyncio
+async def test_run_returns_error_when_no_change_requested(capsys):
+    args = cli._build_parser().parse_args(
+        [
+            "--id",
+            "21848",
+            "--moderator-id",
+            "agent:cto",
+        ]
+    )
+    rc = await cli._run(args)
+    assert rc == 2
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert out["error"] == "no_change_requested"
+
+
+@pytest.mark.asyncio
+async def test_run_show_only_prints_source(capsys):
+    args = cli._build_parser().parse_args(
+        [
+            "--id",
+            "21848",
+            "--moderator-id",
+            "agent:cto",
+            "--show",
+        ]
+    )
+    with patch.object(
+        cli,
+        "get_source",
+        new=AsyncMock(return_value={"id": 21848, "status": "in_moderation"}),
+    ):
+        rc = await cli._run(args)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["source"]["id"] == 21848

--- a/tests/storage/test_moderation.py
+++ b/tests/storage/test_moderation.py
@@ -1,0 +1,257 @@
+"""Integration tests for `src.storage.moderation.advance_meme_source`.
+
+Covers the shared moderation transition used by both the Telegram
+moderator UI and the admin CLI (FFM-1154).
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from src.database import engine, fetch_one, meme
+from src.storage.constants import MemeSourceStatus, MemeStatus
+from src.storage.moderation import (
+    MemeSourceNotFoundError,
+    advance_meme_source,
+)
+from tests.factories import (
+    TEST_ID_START,
+    cleanup_test_data,
+    create_meme,
+    create_meme_source,
+)
+
+SOURCE_ID = TEST_ID_START + 700
+MEME_ID_OK = TEST_ID_START + 1700
+MEME_ID_SNOOZED = TEST_ID_START + 1701
+
+
+@pytest_asyncio.fixture()
+async def conn():
+    async with engine.connect() as conn:
+        yield conn
+        await cleanup_test_data(conn)
+
+
+@pytest.mark.asyncio
+async def test_set_language_records_audit_trail(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=SOURCE_ID,
+        status=MemeSourceStatus.IN_MODERATION.value,
+        language_code=None,
+    )
+    await conn.commit()
+
+    result = await advance_meme_source(
+        SOURCE_ID,
+        moderator_id="agent:cto",
+        language_code="ru",
+        trigger_parse=False,
+    )
+
+    assert result["before_language_code"] is None
+    assert result["source"]["language_code"] == "ru"
+    assert result["source"]["status"] == MemeSourceStatus.IN_MODERATION.value
+    assert result["snoozed_count"] == 0
+    assert result["unsnoozed_count"] == 0
+    assert result["parsed"] is False
+
+    log = result["source"]["data"]["moderation_log"]
+    assert len(log) == 1
+    assert log[0]["moderator"] == "agent:cto"
+    assert log[0]["changed"]["language_code"] == {"from": None, "to": "ru"}
+    assert result["source"]["data"]["last_moderated_by"] == "agent:cto"
+
+
+@pytest.mark.asyncio
+async def test_advance_to_parsing_enabled_logs_status(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=SOURCE_ID,
+        status=MemeSourceStatus.IN_MODERATION.value,
+        language_code="ru",
+    )
+    await conn.commit()
+
+    result = await advance_meme_source(
+        SOURCE_ID,
+        moderator_id="agent:cto",
+        status=MemeSourceStatus.PARSING_ENABLED.value,
+        trigger_parse=False,
+    )
+
+    assert result["before_status"] == MemeSourceStatus.IN_MODERATION.value
+    assert result["source"]["status"] == MemeSourceStatus.PARSING_ENABLED.value
+
+    log = result["source"]["data"]["moderation_log"]
+    assert len(log) == 1
+    assert log[0]["changed"]["status"] == {
+        "from": MemeSourceStatus.IN_MODERATION.value,
+        "to": MemeSourceStatus.PARSING_ENABLED.value,
+    }
+
+
+@pytest.mark.asyncio
+async def test_unsnooze_on_snoozed_to_parsing_enabled(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=SOURCE_ID,
+        status=MemeSourceStatus.SNOOZED.value,
+        language_code="ru",
+    )
+    # One snoozed meme (will be unsnoozed) + one OK meme (must stay OK so
+    # we know the cascade only touches snoozed rows for this source).
+    await create_meme(
+        conn,
+        id=MEME_ID_SNOOZED,
+        meme_source_id=SOURCE_ID,
+        status=MemeStatus.SNOOZED.value,
+    )
+    await create_meme(
+        conn,
+        id=MEME_ID_OK,
+        meme_source_id=SOURCE_ID,
+        status=MemeStatus.OK.value,
+    )
+    await conn.commit()
+
+    result = await advance_meme_source(
+        SOURCE_ID,
+        moderator_id="agent:cto",
+        status=MemeSourceStatus.PARSING_ENABLED.value,
+        trigger_parse=False,
+    )
+
+    assert result["unsnoozed_count"] == 1
+    assert result["snoozed_count"] == 0
+
+    snoozed_row = await fetch_one(meme.select().where(meme.c.id == MEME_ID_SNOOZED))
+    ok_row = await fetch_one(meme.select().where(meme.c.id == MEME_ID_OK))
+    assert snoozed_row["status"] == MemeStatus.OK.value
+    assert ok_row["status"] == MemeStatus.OK.value
+
+
+@pytest.mark.asyncio
+async def test_snooze_cascades_ok_memes_to_snoozed(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=SOURCE_ID,
+        status=MemeSourceStatus.PARSING_ENABLED.value,
+        language_code="ru",
+    )
+    await create_meme(
+        conn,
+        id=MEME_ID_OK,
+        meme_source_id=SOURCE_ID,
+        status=MemeStatus.OK.value,
+    )
+    await conn.commit()
+
+    result = await advance_meme_source(
+        SOURCE_ID,
+        moderator_id="42",
+        status=MemeSourceStatus.SNOOZED.value,
+        trigger_parse=False,
+    )
+
+    assert result["snoozed_count"] == 1
+    assert result["unsnoozed_count"] == 0
+
+    row = await fetch_one(meme.select().where(meme.c.id == MEME_ID_OK))
+    assert row["status"] == MemeStatus.SNOOZED.value
+
+
+@pytest.mark.asyncio
+async def test_audit_log_appends_across_calls(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=SOURCE_ID,
+        status=MemeSourceStatus.IN_MODERATION.value,
+        language_code=None,
+    )
+    await conn.commit()
+
+    await advance_meme_source(
+        SOURCE_ID,
+        moderator_id="agent:qa",
+        language_code="ru",
+        trigger_parse=False,
+    )
+    second = await advance_meme_source(
+        SOURCE_ID,
+        moderator_id="agent:cto",
+        status=MemeSourceStatus.PARSING_ENABLED.value,
+        trigger_parse=False,
+    )
+
+    log = second["source"]["data"]["moderation_log"]
+    assert len(log) == 2
+    assert log[0]["moderator"] == "agent:qa"
+    assert log[1]["moderator"] == "agent:cto"
+    assert second["source"]["data"]["last_moderated_by"] == "agent:cto"
+
+
+@pytest.mark.asyncio
+async def test_no_op_change_does_not_append_log(conn: AsyncConnection):
+    """If the requested values match current state, no audit entry is added."""
+    await create_meme_source(
+        conn,
+        id=SOURCE_ID,
+        status=MemeSourceStatus.PARSING_ENABLED.value,
+        language_code="ru",
+    )
+    await conn.commit()
+
+    result = await advance_meme_source(
+        SOURCE_ID,
+        moderator_id="agent:cto",
+        language_code="ru",
+        status=MemeSourceStatus.PARSING_ENABLED.value,
+        trigger_parse=False,
+    )
+
+    data = result["source"]["data"] or {}
+    assert data.get("moderation_log") is None or data.get("moderation_log") == []
+
+
+@pytest.mark.asyncio
+async def test_missing_source_raises(conn: AsyncConnection):
+    # No row was created for this id; cleanup fixture doesn't matter.
+    await conn.commit()
+    with pytest.raises(MemeSourceNotFoundError):
+        await advance_meme_source(
+            TEST_ID_START + 9999,
+            moderator_id="agent:cto",
+            status=MemeSourceStatus.PARSING_ENABLED.value,
+            trigger_parse=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_status_raises_value_error(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=SOURCE_ID,
+        status=MemeSourceStatus.IN_MODERATION.value,
+    )
+    await conn.commit()
+    with pytest.raises(ValueError):
+        await advance_meme_source(
+            SOURCE_ID,
+            moderator_id="agent:cto",
+            status="not_a_real_status",
+            trigger_parse=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_fields_raises_value_error(conn: AsyncConnection):
+    await create_meme_source(conn, id=SOURCE_ID)
+    await conn.commit()
+    with pytest.raises(ValueError):
+        await advance_meme_source(
+            SOURCE_ID,
+            moderator_id="agent:cto",
+            trigger_parse=False,
+        )


### PR DESCRIPTION
## Summary

- New `scripts/admin/advance_source.py` CLI: agents can promote
  `meme_source` rows through moderation states (`in_moderation` →
  `parsing_enabled`, snooze, unsnooze, language assignment) without
  driving the Telegram moderator UI as a real Telegram user.
- New `src/storage/moderation.advance_meme_source` shared service:
  the bot moderator handler now calls into it instead of inlining
  snooze/unsnooze cascades, so the bot UI and the CLI cannot drift on
  validation rules. Each call appends to
  `meme_source.data.moderation_log` with the moderator identity
  (`agent:cto` for agents, numeric Telegram user_id for humans).
- Triggers the platform parser on flips to `parsing_enabled` —
  identical behavior to the existing bot path.

Fixes [FFM-1154](https://app.paperclip.team/FFM/issues/FFM-1154).
Unblocks promotion of stuck candidates ([#21848 nourlnews](https://t.me/nourlnews),
[#21849 kozakrichala](https://t.me/kozakrichala)) once deployed.

## Why

Per CTO comment on FFM-1114 (2026-05-09): the agent runtime cannot
write to the prod ffmemes DB — Coolify API returns 403, and the only
existing path to advance `meme_source(in_moderation)` →
`parsing_enabled` is the interactive Telegram bot UI, which requires
a human moderator. This blocks every promoted candidate from
discovery (~30/day, growing) until Daniil opens the bot. Shipping
this turns content-supply growth into a function of agent runtime
availability instead of evening attention.

## Usage

```bash
docker compose exec app python -m scripts.admin.advance_source \
    --id 21848 --language ru --status parsing_enabled \
    --moderator-id agent:cto
```

Full docs in `docs/source-moderation-cli.md`. CLAUDE.md links it
under the new "Source moderation (agent-driven)" section.

## Out of scope

- Auto-promotion based on forward-count + safety filters (follow-up).
- Auto language detection (manual `--language` v1).
- Removing the existing `/discoveredsources` moderator UX.

## Test plan

- [x] `python3 -m ruff check` + `ruff format --check` on all changed files
- [ ] CI: `tests/storage/test_moderation.py` (integration, hits DB):
      audit-trail append, snooze/unsnooze cascades, missing-source
      `LookupError`, invalid-status `ValueError`, no-op no-log
- [ ] CI: `tests/scripts/test_advance_source_cli.py` (argparse +
      mocked service): flag parsing, JSON envelope, error envelopes,
      `--show` read-only path
- [ ] Post-merge / on prod: clear sources 21848 + 21849 with the new
      CLI, then post raw_posts / memes_total / memes_ok counts back
      to FFM-1114 per acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)