### PR TITLE
fix(comms): restore comms_writer narrow-privilege DATABASE_URL binding

### DIFF
--- a/agents/.paperclip.yaml
+++ b/agents/.paperclip.yaml
@@ -86,11 +86,14 @@ agents:
         ANALYST_DATABASE_URL:
           kind: "secret"
           requirement: "optional"
-        # Bound to the existing Analyst read-only DB secret by CEO decision.
-        # This is for Comms data reads; do not map to FFMEMES_DATABASE_URL.
+        # Narrow-privilege writer role for editorial_posts (SELECT/INSERT/UPDATE
+        # on that one table, plus USAGE/SELECT on its identity sequence).
+        # Required so publish_editorial_post can persist the row and the stats
+        # collector picks it up. See docs/comms/comms-writer-role-setup.sql for
+        # the role bootstrap and FFM-919 / FFM-1178 for the rationale. Do NOT
+        # bind to FFMEMES_DATABASE_URL or any full-write app DB secret.
         DATABASE_URL:
           kind: "secret"
-          secretName: "ANALYST_DATABASE_URL"
           requirement: "required"
         FFMEMES_PROD_TELEGRAM_BOT_TOKEN:
           kind: "secret"

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -358,7 +358,8 @@ These are encrypted in Paperclip DB and injected as env vars during agent runs:
 
 | Secret | Used by | Purpose |
 |--------|---------|---------|
-| `ANALYST_DATABASE_URL` | Analyst, QA, Comms | Read-only prod DB access. Comms also receives this as env `DATABASE_URL` by explicit CEO decision; this supports data reads, not `editorial_posts` writes. |
+| `ANALYST_DATABASE_URL` | Analyst, QA, Comms | Read-only prod DB access. |
+| `DATABASE_URL` (comms-manager only) | Comms | `comms_writer` Postgres role URL. Narrow grants: SELECT/INSERT/UPDATE on `editorial_posts` + USAGE/SELECT on its identity sequence + 10s `statement_timeout`. Required by `publish_editorial_post` to claim and update the row that the stats collector reads. Do NOT bind to `FFMEMES_DATABASE_URL` or any full-write app DB secret. |
 | `COOLIFY_ACCESS_TOKEN` | CTO, QA, Release Engineer | Coolify API for container logs |
 | `COOLIFY_BASE_URL` | CTO, QA, Release Engineer | Coolify API URL |
 | `SENTRY_AUTH_TOKEN` | CTO, QA | Sentry CLI authentication (read-only project scope) |
@@ -368,7 +369,7 @@ These are encrypted in Paperclip DB and injected as env vars during agent runs:
 | `TEST_DATABASE_URL` | CTO | Test/staging DB for safe experiments |
 | `TELEGRAM_BOT_TOKEN` | Telegram plugin | @ffnerdbot token (NOT @ffmemesbot!) |
 
-The least-privilege `comms_writer` role in `docs/comms/comms-writer-role-setup.sql` remains available as a future upgrade if Comms needs to persist `editorial_posts` rows from the agent runtime. Do not bind Comms to `FFMEMES_DATABASE_URL` or any full-write app DB secret.
+`comms_writer` is provisioned on prod (role exists with `statement_timeout=10s`; `editorial_posts` ACL `comms_writer=arw/postgres`; `editorial_posts_id_seq` ACL `comms_writer=rU/postgres`). The Paperclip secret `DATABASE_URL` on the comms-manager agent must carry the `comms_writer` connection URL (`postgresql+asyncpg://comms_writer:<password>@<host>:<port>/ff`); the registered password is the one used when `docs/comms/comms-writer-role-setup.sql` was run. See FFM-919 for the original Option-2 decision and FFM-1178 for the runtime restoration.
 
 QA runtime access is considered degraded unless all of these are present in the live QA `adapterConfig.env`: `PATH` with `/paperclip/bin`, `ANALYST_DATABASE_URL`, `COOLIFY_BASE_URL`, `COOLIFY_ACCESS_TOKEN`, `SENTRY_AUTH_TOKEN`, `PREFECT_AUTH_STRING`.
 


### PR DESCRIPTION
## Why

Architecture audit PR #245 added `secretName: ANALYST_DATABASE_URL` on the
comms-manager `DATABASE_URL` env, sending the Comms agent back to a
read-only DB handle. `publish_editorial_post` needs SELECT/INSERT/UPDATE
on `editorial_posts` (claim row + `telegram_message_id` backfill) plus
USAGE on its identity sequence — the analyst URL fails the INSERT and the
stats collector silently skips agent-published posts.

## What

- `agents/.paperclip.yaml`: drop the `secretName: ANALYST_DATABASE_URL`
  mapping on `comms-manager.DATABASE_URL`; restore the
  "narrow-privilege writer role" comment block. The Paperclip control
  plane now sources `DATABASE_URL` from a separately registered secret.
- `docs/paperclip-ops-runbook.md`: update the secrets table to call out
  the `DATABASE_URL` (comms-manager) entry with its narrow grants and
  drop the stale "available as a future upgrade" line; the role is in
  fact provisioned on prod.

## Prod state verified

Queried the prod DB through the analyst read-only handle (`pg_class`,
not `information_schema.role_*`, since RO can't see other roles' grants
through the standard views):

- Role exists with login, `statement_timeout=10s`.
- `editorial_posts` ACL: `comms_writer=arw/postgres` (INSERT, SELECT, UPDATE).
- `editorial_posts_id_seq` ACL: `comms_writer=rU/postgres` (SELECT, USAGE).

So step 1 from FFM-1178 is already done.

## DO NOT MERGE until operator step lands

The remaining gate is operator-only: register the comms-manager
`DATABASE_URL` Paperclip secret with the `comms_writer` connection URL
(`postgresql+asyncpg://comms_writer:<password>@<host>:<port>/ff`). Until
that secret is registered, `agents/_sync_config.py` will fail the
required-secret check on deploy and the comms-manager agent will lose
its config sync. Tracked separately on the FFM-1178 thread.

After the secret is registered, ready-for-review + merge, then verify by
running `publish_editorial_post` from a test Comms heartbeat against a
sandboxed entity_id.

Refs FFM-919, FFM-1178 (blocks FFM-1175).