### PR TITLE
ops: upgrade Paperclip to v2026.512.0

### DIFF
--- a/.github/workflows/staff-engineer-trigger.yml
+++ b/.github/workflows/staff-engineer-trigger.yml
@@ -15,13 +15,41 @@ jobs:
     steps:
       - name: Trigger Staff Engineer review
         env:
-          PAPERCLIP_STAFF_ENGINEER_TRIGGER_URL: ${{ secrets.PAPERCLIP_STAFF_ENGINEER_TRIGGER_URL }}
-          PAPERCLIP_TRIGGER_SECRET: ${{ secrets.PAPERCLIP_TRIGGER_SECRET }}
+          PAPERCLIP_URL: ${{ secrets.PAPERCLIP_URL }}
+          PAPERCLIP_API_KEY: ${{ secrets.PAPERCLIP_API_KEY }}
+          PAPERCLIP_COMPANY_ID: 96ee7b2e-6df2-43c8-bbe3-53e19297308a
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          : "${PAPERCLIP_STAFF_ENGINEER_TRIGGER_URL:?missing PAPERCLIP_STAFF_ENGINEER_TRIGGER_URL secret}"
-          : "${PAPERCLIP_TRIGGER_SECRET:?missing PAPERCLIP_TRIGGER_SECRET secret}"
-          curl -sSf -X POST \
-            "$PAPERCLIP_STAFF_ENGINEER_TRIGGER_URL" \
-            -H "Authorization: Bearer $PAPERCLIP_TRIGGER_SECRET" \
-            -H "Content-Type: application/json" \
-            -d '{"pr_number": ${{ github.event.pull_request.number }}, "pr_url": "${{ github.event.pull_request.html_url }}"}'
+          : "${PAPERCLIP_URL:?missing PAPERCLIP_URL secret}"
+          : "${PAPERCLIP_API_KEY:?missing PAPERCLIP_API_KEY secret}"
+
+          ROUTINES_JSON="$(curl -sSf \
+            -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+            "$PAPERCLIP_URL/api/companies/$PAPERCLIP_COMPANY_ID/routines")"
+          ROUTINE_ID="$(printf '%s' "$ROUTINES_JSON" | jq -r '.[] | select(.title == "[pr:{{pr_number}}] Review") | .id' | head -1)"
+          : "${ROUTINE_ID:?missing Staff Engineer PR routine}"
+          API_TRIGGER_ID="$(printf '%s' "$ROUTINES_JSON" | jq -r --arg id "$ROUTINE_ID" '.[] | select(.id == $id) | (.triggers // [])[] | select(.kind == "api" and (.enabled != false)) | .id' | head -1)"
+          : "${API_TRIGGER_ID:?missing Staff Engineer API trigger}"
+
+          jq -n \
+            --arg trigger "$API_TRIGGER_ID" \
+            --arg pr "$PR_NUMBER" \
+            --arg url "$PR_URL" \
+            --arg idem "pr-$PR_NUMBER-$PR_SHA" \
+            '{
+              source: "api",
+              triggerId: $trigger,
+              payload: {
+                pr_number: $pr,
+                pr_url: $url,
+                variables: {pr_number: $pr, pr_url: $url}
+              },
+              variables: {pr_number: $pr, pr_url: $url},
+              idempotencyKey: $idem
+            }' | curl -sSf -X POST \
+              "$PAPERCLIP_URL/api/routines/$ROUTINE_ID/run" \
+              -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+              -H "Content-Type: application/json" \
+              --data @-

--- a/agents/.paperclip.yaml
+++ b/agents/.paperclip.yaml
@@ -1,5 +1,10 @@
 schema: "paperclip/v1"
 
+# Codex agents use ChatGPT/Codex subscription OAuth from the persistent
+# /paperclip/.codex auth volume. Do not bind OPENAI_API_KEY to codex_local
+# agents, and do not set it globally in the Paperclip host env: Codex CLI
+# 0.122+ treats that as API-key billing instead of subscription billing.
+
 # gstack skills source — Paperclip pulls skills from this repo at the recorded ref.
 # Bump `ref` only after `agents/deploy.sh --dry-run` shows the new catalog with
 # zero unknown-desired-skills failures.
@@ -12,11 +17,12 @@ agents:
   analyst:
     role: "researcher"
     adapter:
-      type: "claude_local"
+      type: "codex_local"
       config:
-        dangerouslySkipPermissions: true
+        dangerouslyBypassApprovalsAndSandbox: true
         maxTurnsPerRun: 200
-        model: "claude-sonnet-4-6"
+        model: "gpt-5.5"
+        modelReasoningEffort: "high"
     runtime:
       heartbeat:
         enabled: true
@@ -57,9 +63,6 @@ agents:
           kind: "plain"
           default: "/paperclip/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
           requirement: "optional"
-        OPENAI_API_KEY:
-          kind: "secret"
-          requirement: "optional"
         ANALYST_DATABASE_URL:
           kind: "secret"
           requirement: "optional"
@@ -67,11 +70,12 @@ agents:
   comms-manager:
     role: "cmo"
     adapter:
-      type: "claude_local"
+      type: "codex_local"
       config:
-        dangerouslySkipPermissions: true
+        dangerouslyBypassApprovalsAndSandbox: true
         maxTurnsPerRun: 100
-        model: "claude-sonnet-4-6"
+        model: "gpt-5.5"
+        modelReasoningEffort: "medium"
     runtime:
       heartbeat:
         enabled: true
@@ -95,9 +99,6 @@ agents:
         FFMEMES_PROD_TELEGRAM_BOT_TOKEN:
           kind: "secret"
           requirement: "required"
-        OPENAI_API_KEY:
-          kind: "secret"
-          requirement: "optional"
 
   cto:
     role: "cto"
@@ -120,9 +121,6 @@ agents:
         PATH:
           kind: "plain"
           default: "/paperclip/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-          requirement: "optional"
-        OPENAI_API_KEY:
-          kind: "secret"
           requirement: "optional"
         ANALYST_DATABASE_URL:
           kind: "secret"
@@ -154,11 +152,12 @@ agents:
   qa-engineer:
     role: "qa"
     adapter:
-      type: "claude_local"
+      type: "codex_local"
       config:
-        dangerouslySkipPermissions: true
+        dangerouslyBypassApprovalsAndSandbox: true
         maxTurnsPerRun: 200
-        model: "claude-sonnet-4-6"
+        model: "gpt-5.5"
+        modelReasoningEffort: "high"
     runtime:
       heartbeat:
         intervalSec: 21600
@@ -176,18 +175,14 @@ agents:
         COOLIFY_BASE_URL:
           kind: "secret"
           requirement: "required"
-        COOLIFY_RESOURCE_UUID:
-          kind: "plain"
-          default: "k4w804sco4s8kc88kwcw0ow4"
-          requirement: "optional"
-        COOLIFY_CONTAINER_NAME:
-          kind: "plain"
-          default: "k4w804sco4s8kc88kwcw0ow4-131756368009"
-          requirement: "optional"
+        # Coolify resource UUID + container name are intentionally NOT pinned
+        # as plain defaults here. They are documented in agents/qa-engineer/
+        # AGENTS.md (the "Key Coolify UUIDs" table) and resolved dynamically
+        # from the Coolify API when needed. Hand-written UUID defaults rot
+        # the moment Coolify rebuilds the container.
         PREFECT_API_URL:
-          kind: "plain"
-          default: "http://65.108.127.32:4200/api"
-          requirement: "optional"
+          kind: "secret"
+          requirement: "required"
         ANALYST_DATABASE_URL:
           kind: "secret"
           requirement: "required"
@@ -227,11 +222,12 @@ agents:
   release-engineer:
     role: "devops"
     adapter:
-      type: "claude_local"
+      type: "codex_local"
       config:
-        dangerouslySkipPermissions: true
+        dangerouslyBypassApprovalsAndSandbox: true
         maxTurnsPerRun: 150
-        model: "claude-sonnet-4-6"
+        model: "gpt-5.5"
+        modelReasoningEffort: "medium"
     runtime:
       heartbeat:
         maxConcurrentRuns: 1
@@ -272,9 +268,6 @@ agents:
         PATH:
           kind: "plain"
           default: "/paperclip/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-          requirement: "optional"
-        OPENAI_API_KEY:
-          kind: "secret"
           requirement: "optional"
         ANALYST_DATABASE_URL:
           kind: "secret"

--- a/agents/_sync_config.py
+++ b/agents/_sync_config.py
@@ -335,6 +335,34 @@ def stale_adapter_keys(adapter_type: str | None) -> set[str]:
     return set()
 
 
+def routine_latest_revision_id(routine: dict) -> str | None:
+    """Return the live routine revision id when the Paperclip API exposes one.
+
+    v2026.512.0 introduced routine revision history. Older servers simply omit
+    these fields, so callers can stay compatible by omitting baseRevisionId.
+    """
+    for key in ("latestRevisionId", "latest_revision_id", "currentRevisionId"):
+        value = routine.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    for key in ("latestRevision", "currentRevision", "revision"):
+        value = routine.get(key)
+        if isinstance(value, dict):
+            revision_id = value.get("id")
+            if isinstance(revision_id, str) and revision_id:
+                return revision_id
+    return None
+
+
+def routine_patch_payload(routine: dict, description: str) -> dict:
+    payload = {"description": description}
+    revision_id = routine_latest_revision_id(routine)
+    if revision_id:
+        payload["baseRevisionId"] = revision_id
+    return payload
+
+
 def sync_routine_descriptions(by_slug: dict[str, dict]) -> tuple[int, int, int]:
     specs = load_routine_description_specs()
     if not specs:
@@ -373,15 +401,19 @@ def sync_routine_descriptions(by_slug: dict[str, dict]) -> tuple[int, int, int]:
             print(f"  skip routine {spec['name']} (no description drift)")
             skipped += 1
             continue
+        payload = routine_patch_payload(routine, spec["description"])
         if DRY:
-            print(f"  WOULD PATCH routine {spec['name']}: description")
+            change = "description"
+            if "baseRevisionId" in payload:
+                change += " with baseRevisionId"
+            print(f"  WOULD PATCH routine {spec['name']}: {change}")
             patched += 1
             continue
         try:
             api(
                 "PATCH",
                 f"/api/routines/{routine['id']}",
-                {"description": spec["description"]},
+                payload,
             )
         except Exception as e:
             print(

--- a/agents/analyst/AGENTS.md
+++ b/agents/analyst/AGENTS.md
@@ -35,7 +35,8 @@ delegated subtasks instead of comment-only handoffs.
 
 Every issue you create must start with a stable bracket slug. Use
 `[report:YYYY-MM-DD]` for scheduled reports and update/comment on an existing
-open issue with that slug instead of creating duplicates.
+open issue with that slug instead of creating duplicates. Use native Paperclip
+company search / issue search before creating a recurrent slug.
 
 Only the CEO may open strategic issues. As Analyst, create only execution
 tickets from your explicit workflow; put strategic findings in your report for

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -46,6 +46,10 @@ Use the native `paperclip` skill for wake context, task selection, checkout,
 structured confirmations, blockers/subtasks, documents/attachments, concise
 comments, and task completion.
 
+Use Paperclip planning work mode for strategic, experiment, architecture, and
+proposal issues. Keep standard mode for execution tickets delegated to CTO,
+Analyst, or Comms.
+
 For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first. Use child issues for
 delegated subtasks instead of comment-only handoffs.
@@ -58,8 +62,8 @@ across recurrences:
   `[post:YYYY-MM-DD-slug]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`,
   `[strategy:weekly-outcomes-YYYY-MM-DD]`
 
-Search/update an existing open issue with the same slug before creating another
-one.
+Use native company search / issue search to find an existing issue with the same
+slug before creating another one.
 
 Only the CEO may open strategic issues. Other agents may open execution issues
 from their explicit workflows and should route strategic ideas through you.

--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -39,8 +39,8 @@ For blocked work, set status `blocked` with a clear comment and use
 Every post draft issue must use `[post:YYYY-MM-DD-slug]` as the stable title
 prefix.
 
-Search/update an existing open draft with the same slug before creating another
-one.
+Use native Paperclip company search / issue search and update an existing open
+draft with the same slug before creating another one.
 
 You may create only execution tickets from the comms workflow. Strategic or
 planning tickets belong to CEO.
@@ -161,10 +161,9 @@ For exact data, use `src/comms/visuals.py` primitives ONLY. Do not write raw mat
 - Pie charts, 3D, dual-axis → banned
 
 These primitives return PNG bytes. Pass them directly as `photo_bytes=png` to
-`publish_editorial_post`. For illustrative/editorial art, use
-`src.comms.image_generation.generate_editorial_image()` with a precise prompt
-built by `build_editorial_image_prompt(...)`, then pass
-`photo_bytes=image.image_bytes`.
+`publish_editorial_post`. Under Codex subscription-only runtime, do not use
+`OPENAI_API_KEY` or GPT image generation inside this agent. If editorial art is
+required, create a CEO/ops task for a separate non-Codex image pipeline.
 
 See `docs/comms/brand-guide.md` for the full decision tree and constraints.
 
@@ -278,7 +277,8 @@ See full brand guide: `docs/comms/brand-guide.md`
 4. **Diagrams** — for engineering posts (simple, clean, brand colors)
 5. **Stat cards** — for daily pulse (big number + context)
 
-When generating charts/images, verify the result looks good by feeding it back through the browse skill.
+When creating charts or local visuals, verify the result looks good by feeding
+it back through the browse skill.
 Never send editorial visuals to the moderator chat just to get a Telegram `file_id`.
 
 ### Image Review Before Posting (MANDATORY)
@@ -286,8 +286,7 @@ Never send editorial visuals to the moderator chat just to get a Telegram `file_
 Before attaching ANY image to a channel post, you MUST:
 
 1. **Visually inspect** the image. For Telegram `file_id` memes, download via
-   the Telegram Bot API first; for local/generated images, inspect the local
-   PNG directly.
+   the Telegram Bot API first; for local images, inspect the local PNG directly.
 ```bash
 # Get file path
 FILE_PATH=$(curl -s "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/getFile?file_id=<file_id>" | python3 -c "import json,sys; print(json.load(sys.stdin)['result']['file_path'])")

--- a/agents/cto/AGENTS.md
+++ b/agents/cto/AGENTS.md
@@ -24,6 +24,9 @@ Use the native `paperclip` skill for wake context, task selection, checkout,
 structured confirmations, blockers/subtasks, documents/attachments, concise
 comments, and task completion.
 
+When CEO asks for architecture or implementation planning rather than immediate
+execution, keep that work in Paperclip planning mode until the plan is accepted.
+
 For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first. Use child issues for
 delegated subtasks instead of comment-only handoffs.
@@ -34,8 +37,8 @@ Every issue you create must start with a stable bracket slug, reused across
 recurrences: `[pr:NNN]`, `[incident:<slug>]`, `[deploy:<branch-or-pr>]`,
 `[maintenance:<slug>]`, `[postmortem:<slug>]`.
 
-Search/update an existing open issue with the same slug before creating another
-one; this collapses repeated incidents onto one tracking issue.
+Use native Paperclip company search / issue search for the same slug before
+creating another one; this collapses repeated incidents onto one tracking issue.
 
 You may create only execution tickets from your implementation workflow.
 Strategic/planning tickets belong to CEO.

--- a/agents/qa-engineer/AGENTS.md
+++ b/agents/qa-engineer/AGENTS.md
@@ -46,11 +46,15 @@ recurrences:
 - `[incident:<slug>]` — production bugs (e.g. `[incident:db-pool]`, `[incident:describe-memes-timeout]`, `[incident:webhook-502]`)
 - `[deploy:<branch-or-pr>]`, `[report:YYYY-MM-DD]`, `[maintenance:<slug>]`, `[postmortem:<slug>]`
 
-Search/update an existing open issue with the same slug before creating another
-one; add new evidence as a comment instead of opening duplicates.
+Use native Paperclip company search / issue search and update an existing open
+issue with the same slug before creating another one; add new evidence as a
+comment instead of opening duplicates.
 
 As QA, create only execution tickets from scan workflows. Planning and strategic
 tickets belong to CEO.
+
+For delayed verification, post-deploy waits, or "retry after logs settle" work,
+use native issue monitors / retry-now rather than comment-only due timestamps.
 
 ## Every Scheduled Log Scan
 
@@ -169,6 +173,9 @@ outcomes. There are two distinct layers and you should not duplicate them:
   zombie-run, and no-comment classification belong here. Read these from the
   Paperclip dashboard / native routine tooling — do NOT reimplement them in
   the FFmemes audit script.
+- **Paperclip v2026.512 issue monitor signals** — delayed checks and retry-now
+  belong to the native monitor surface. Use it before inventing a custom
+  follow-up comment format.
 - **FFmemes outcome-contract checks**, run via
   `scripts/paperclip_routine_audit.py`. This is narrow and business-specific:
   channel post publication markers, update-check content (changelog, version,

--- a/agents/release-engineer/AGENTS.md
+++ b/agents/release-engineer/AGENTS.md
@@ -32,8 +32,8 @@ delegated subtasks instead of comment-only handoffs.
 Every issue you create must start with a stable bracket slug. For release work
 this is usually `[pr:NNN]`, `[deploy:<branch-or-pr>]`, or `[qa:<pr-number>]`.
 
-Search/update an existing open issue with the same slug before creating another
-one.
+Use native Paperclip company search / issue search for the same slug before
+creating another one.
 
 You may create only execution tickets from your release workflow. Strategic or
 planning tickets belong to CEO.
@@ -54,6 +54,9 @@ You do **NOT** merge PRs. Staff Engineer owns the review → approve → squash-
 2. **Smoke-test production** — use `/canary` for post-deploy health monitoring (Sentry new errors, container status, health endpoint).
 3. **Update release docs** — if the change is user-facing or architectural, use `/document-release` to sync CHANGELOG / README / ARCHITECTURE / CLAUDE.md.
 4. **Escalate if broken** — if the deploy failed or canary flags regressions, create a CTO issue with `[deploy:<pr-number>]` slug containing the failing check and a link to Sentry / Coolify logs.
+5. **Schedule delayed checks natively** — if logs, metrics, or deploy state need
+   time to settle, use Paperclip issue monitors / retry-now instead of leaving
+   a comment-only due timestamp.
 
 ## Merge Policy (reminder, not your job)
 

--- a/agents/staff-engineer/AGENTS.md
+++ b/agents/staff-engineer/AGENTS.md
@@ -32,8 +32,8 @@ delegated subtasks instead of comment-only handoffs.
 Every issue you create must start with a stable bracket slug. For review
 handoffs this is almost always `[pr:NNN]` with the actual PR number.
 
-Search/update an existing open issue with the same slug before creating another
-one.
+Use native Paperclip company search / issue search and update an existing open
+issue with the same slug before creating another one.
 
 You may create only execution tickets from your review workflow. Strategic or
 planning tickets belong to CEO.

--- a/docs/agents/paperclip-simplification-2026-05-04.md
+++ b/docs/agents/paperclip-simplification-2026-05-04.md
@@ -34,6 +34,15 @@ code. It avoids rereading the full upstream repo and the long ops runbook.
 - Keep the local slug/dedupe discipline for now. Upstream tools reduce race
   handling and recovery code, but the issue API still does not provide a
   general idempotency key for "create one issue for this business object".
+- On Paperclip v2026.512.0, use native company search before creating recurrent
+  bracket-slug issues. This keeps our stable slug discipline while removing
+  broad custom issue scans from prompts.
+- Use native planning work mode for strategy, experiment, architecture, and
+  proposal issues. Execution issues stay standard.
+- Use issue monitors / retry-now for delayed verification, post-deploy waits,
+  and "measure after N days" follow-ups instead of comment-only due dates.
+- Let routine revision history carry routine-description restore/audit needs.
+  The repo sync includes `baseRevisionId` when the server exposes it.
 
 ## Sync Code Guidance
 
@@ -61,6 +70,13 @@ code. It avoids rereading the full upstream repo and the long ops runbook.
 - Do not add secrets, API keys, Paperclip secret IDs, trigger public IDs, or
   private internal hostnames to public docs. Env var names and Paperclip secret
   names are OK; never include values.
+- Codex agents are subscription/OAuth-only. Do not add `OPENAI_API_KEY` to
+  `codex_local` agent env or the Paperclip host env; Codex CLI 0.122+ treats it
+  as API-key billing. Remaining Claude agents should be replaced with Codex
+  rather than maintained as a second subscription runtime.
+- Do not adopt AWS Secrets Manager provider vaults for this setup. Keep
+  Paperclip company secrets for agent env bindings; use Coolify envs only for
+  Paperclip service-level config.
 
 ## Keep Custom For Now
 

--- a/docs/agents/paperclip-simplification-2026-05-04.md
+++ b/docs/agents/paperclip-simplification-2026-05-04.md
@@ -80,10 +80,10 @@ code. It avoids rereading the full upstream repo and the long ops runbook.
 
 ## Keep Custom For Now
 
-- The GitHub PR review workflow is still reasonable if it posts a narrow
-  `{pr_number, pr_url}` payload to a Paperclip routine trigger. A direct GitHub
-  webhook with `github_hmac` can remove the workflow later, but then the agent
-  prompt must parse the full GitHub webhook payload.
+- The GitHub PR review workflow is still reasonable if it sends a narrow
+  `{pr_number, pr_url}` payload through Paperclip's native routine API trigger.
+  A direct GitHub webhook with `github_hmac` can remove the workflow later, but
+  then the agent prompt must parse the full GitHub webhook payload.
 - Comms publishing and routine outcome checks are product-specific. Paperclip
   can know a Telegram post is complete only when the agent records the concrete
   `result.message_id` and `result.editorial_post_id` returned by

--- a/docs/agents/pr-review-cycle.md
+++ b/docs/agents/pr-review-cycle.md
@@ -7,9 +7,11 @@ agent infrastructure, see `paperclip-ops-runbook.md`.
 
 1. PR `opened`, `reopened`, or `synchronize` (push to PR branch) →
    `.github/workflows/staff-engineer-trigger.yml` fires.
-2. Workflow `POST`s the Paperclip PR Review routine trigger with
-   `{pr_number, pr_url}`. URL and bearer secret live in GitHub Actions secrets
-   / workflow config; do not paste trigger IDs into public docs.
+2. Workflow calls Paperclip's native routine API run endpoint. It looks up the
+   `[pr:{{pr_number}}] Review` routine and enabled API trigger, then sends
+   `{pr_number, pr_url}` as explicit routine variables. Auth uses the existing
+   `PAPERCLIP_URL` + `PAPERCLIP_API_KEY` GitHub Actions secrets; do not paste
+   routine or trigger IDs into public docs.
 3. Paperclip routes to the **Staff Engineer** agent (id
    `1a323bb6-2b4d-46bf-9c33-7971fa1673d5`). Its status flips
    `idle → running` and `lastHeartbeatAt` ticks.
@@ -53,11 +55,25 @@ review unless it left a comment.
 ## Manual fire (if the GitHub workflow misses)
 
 ```bash
-curl -s -X POST \
-  "$PAPERCLIP_PR_REVIEW_TRIGGER_URL" \
-  -H "Authorization: Bearer $PAPERCLIP_TRIGGER_SECRET" \
-  -H "Content-Type: application/json" \
-  -d '{"pr_number": 183, "pr_url": "https://github.com/ffmemes/ff-backend/pull/183"}'
+ROUTINES_JSON="$(curl -sSf \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  "$PAPERCLIP_URL/api/companies/$PAPERCLIP_COMPANY_ID/routines")"
+ROUTINE_ID="$(printf '%s' "$ROUTINES_JSON" | jq -r '.[] | select(.title == "[pr:{{pr_number}}] Review") | .id' | head -1)"
+API_TRIGGER_ID="$(printf '%s' "$ROUTINES_JSON" | jq -r --arg id "$ROUTINE_ID" '.[] | select(.id == $id) | (.triggers // [])[] | select(.kind == "api" and (.enabled != false)) | .id' | head -1)"
+jq -n \
+  --arg trigger "$API_TRIGGER_ID" \
+  --arg pr "183" \
+  --arg url "https://github.com/ffmemes/ff-backend/pull/183" \
+  '{
+    source: "api",
+    triggerId: $trigger,
+    payload: {pr_number: $pr, pr_url: $url, variables: {pr_number: $pr, pr_url: $url}},
+    variables: {pr_number: $pr, pr_url: $url}
+  }' | curl -sSf -X POST \
+    "$PAPERCLIP_URL/api/routines/$ROUTINE_ID/run" \
+    -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+    -H "Content-Type: application/json" \
+    --data @-
 ```
 
 ## Why the agent did not merge PR #183 on first push

--- a/docs/agents/routine-observability.md
+++ b/docs/agents/routine-observability.md
@@ -5,7 +5,8 @@ Use this before broad manual audits. The goal is to measure useful FFmemes
 
 Two layers, do not duplicate:
 
-- **Native Paperclip runtime** (v2026.428+) owns generic liveness, stall /
+- **Native Paperclip runtime** (v2026.428+, with v2026.512 issue monitors)
+  owns generic liveness, stall /
   zombie-run detection, stranded assignment recovery, and productivity-review
   escalation. Read those from the Paperclip dashboard / native routine
   tooling.
@@ -122,8 +123,38 @@ or stopped tasks; it does not prove that a useful product outcome happened.
 Routine health should come from the outcome contracts above and from Paperclip
 issues/comments, not from Telegram notifications.
 
+## Blocked Work Contract
+
+Do not stop at "blocked". Before setting `blocked`, create or link the issue
+that can unblock it, set `blockedByIssueIds`, assign the unblocker to the owning
+role, and leave one comment with: blocker, owner, retry condition, and next
+automatic wake path.
+
+Routine execution issues should not remain blocked just because the run was
+partial. Close the routine issue with `outcome=partial` or `outcome=error` and
+link the durable follow-up issue. Use `blocked` only for durable work items that
+are waiting on another issue, deploy, approval, or external system.
+
+For time-gated analysis (for example, "measure after 7 full days of data"), do
+not leave the issue `blocked` on an already-completed implementation issue. Use
+Paperclip's native issue monitor / retry-now surface for the due date, then move
+it to `todo` only when the monitor says the data window is actually ready. Keep
+an absolute due timestamp in the comment as human context, not as the scheduling
+mechanism.
+
 ## Context Discipline For Agents
 
+- Stop after the compact audit unless a flagged outcome contract requires
+  deeper evidence. Do not dump full Paperclip issue lists, agent configs,
+  server logs, dashboard pages, or Telegram activity feeds into context when
+  `scripts/paperclip_routine_audit.py --json` already identifies the routine,
+  issue id, flag, and expected contract.
+- For Paperclip runtime failures, trust native productivity/liveness surfaces
+  first. File one Paperclip runtime issue only when the native surface reports a
+  persistent failure; do not independently search for stalled runs across raw
+  logs unless the native surface is unavailable.
+- Use native company search before creating recurrent bracket-slug issues; do
+  not dump broad issue lists into context just to dedupe.
 - Spawn subagents only with bounded questions and required output fields.
 - Prefer `scripts/paperclip_routine_audit.py --json` over dumping full agent
   configs, issue lists, or server logs into context.

--- a/docs/agents/routine-observability.md
+++ b/docs/agents/routine-observability.md
@@ -90,7 +90,8 @@ blocked with `unverified_paperclip_deploy`. Channel publication markers such as
 
 ### PR Review
 
-Each PR webhook must create or resume the matching `[pr:<number>] Review` issue.
+Each PR event must create or resume the matching `[pr:<number>] Review` issue
+through the Staff Engineer routine API trigger.
 If trigger payload `pr_number=215` links to `[pr:214] Review`, that is
 `coalesced_pr_review_mismatch`, not healthy queueing.
 

--- a/docs/agents/update-routine-findings-2026-05-01.md
+++ b/docs/agents/update-routine-findings-2026-05-01.md
@@ -4,6 +4,9 @@ This is the compact handoff from the May 1 update routine audit. Use it as
 input for the next Paperclip/gstack update check instead of re-reading every
 release note from scratch. Follow-up simplification notes from May 4 live in
 [`paperclip-simplification-2026-05-04.md`](paperclip-simplification-2026-05-04.md).
+The May 12 follow-up target is Paperclip `v2026.512.0`; see
+[`../paperclip-native-migration.md`](../paperclip-native-migration.md) before
+using the older "next safe improvements" section below.
 
 ## Sources Checked
 

--- a/docs/paperclip-native-migration.md
+++ b/docs/paperclip-native-migration.md
@@ -195,7 +195,7 @@ Prefer Paperclip's native skill-update mechanism over a custom-rolled routine if
 
 ## What stays custom
 
-- `.github/workflows/staff-engineer-trigger.yml` — no native Paperclip↔GitHub PR integration yet; HTTP POST to a routine trigger is the right shape.
+- `.github/workflows/staff-engineer-trigger.yml` — no native Paperclip↔GitHub PR integration yet; the workflow now uses Paperclip's native routine API trigger with a narrow PR payload.
 - `agents/<slug>/AGENTS.md` content — our IP, not Paperclip's job.
 - Telegram plugin — already native (Paperclip plugin system).
 - Paperclip deploy/sync from git — still custom because existing-company

--- a/docs/paperclip-native-migration.md
+++ b/docs/paperclip-native-migration.md
@@ -1,17 +1,59 @@
 # Paperclip-native migration
 
-Prod is on **Paperclip v2026.428.0** as of 2026-05-06. Verified deployment:
-Coolify deployment `v8s5shyjid9n9c7l2gtghig9`, fork branch
-`ohld/paperclip:ffmemes/v2026.428.0`, commit
-`3494e84a2920f3e2bc5f627f916da29e224086dc`, health check green.
+Prod is on **Paperclip v2026.512.0** as of 2026-05-12. Verified deployment:
+Coolify deployment `q12xc4c1q6m4smzk1zfkog02`, fork branch
+`ohld/paperclip:ffmemes/v2026.512.0`, commit
+`c445e5925628d11bf59d52604b8aa63a6e9aa800`, health check green. Codex
+OAuth auth is present at `/paperclip/.codex/auth.json`, and `OPENAI_API_KEY`
+is absent from the Paperclip host env and all managed Codex agent env bindings.
 
 Goal: stop maintaining custom scaffolding for things Paperclip ships natively, so upstream fixes apply to us for free.
 
-## 2026-05-06 stable deployment
+## 2026-05-12 adopted: v2026.512.0
 
-Paperclip latest stable is **v2026.428.0** ([release notes](https://github.com/paperclipai/paperclip/releases/tag/v2026.428.0); mirror: [newreleases](https://newreleases.io/project/github/paperclipai/paperclip/release/v2026.428.0)). Canary builds exist, but production should stay on stable unless a specific blocker requires a canary and the rollback path is explicit.
+Upstream `v2026.512.0` adds several native surfaces we adopted after fresh DB
+and volume backups, Coolify deploy verification, and live agent config sync.
+The important constraint is Codex auth: upstream can write Codex auth from
+`OPENAI_API_KEY`, but our production path must stay subscription/OAuth-only.
 
-The deployed target is upstream tag `v2026.428.0` at commit
+Adopted:
+
+- **Codex subscription-only agents.** Replace remaining `claude_local` agents
+  with `codex_local`, but keep Codex authenticated through the persistent
+  `/paperclip/.codex/auth.json` OAuth volume. Do not bind `OPENAI_API_KEY` to
+  `codex_local` agents and do not set it in the Paperclip host env. Codex CLI
+  0.122+ treats `OPENAI_API_KEY` as API-key billing, not subscription billing.
+- **Planning mode.** Strategic, experiment, architecture, and proposal issues
+  should use Paperclip's native planning work mode instead of pretending every
+  issue is execution work. Execution tickets stay in standard mode.
+- **Full company search.** Before creating recurrent issues, agents should use
+  native company search / issue search to find existing bracket slugs across
+  open work and historical context. Keep bracket slugs, but let Paperclip search
+  do more of the dedupe work.
+- **Routine revision history.** Continue syncing routine descriptions from this
+  repo, but include `baseRevisionId` when the API exposes a latest revision so
+  Paperclip's built-in revision history and restore flow remain useful.
+- **Issue monitors and retry-now.** Time-gated follow-ups, post-deploy waits,
+  and delayed verification should use native issue monitors / retry-now instead
+  of comment-only due timestamps and custom wake prose.
+- **System notices and monitor liveness.** Prefer the dashboard/native runtime
+  surfaces for generic "agent alive, monitor stale, retry queued" checks. Keep
+  local audits focused on FFmemes-specific outcome contracts.
+
+Do not adopt yet:
+
+- **AWS Secrets Manager provider vaults.** We are not using AWS as the source of
+  truth. Keep Paperclip company secrets (`secret_ref`) for agent-level secrets.
+  Coolify envs are acceptable for Paperclip service-level configuration, but not
+  as a way to expose `OPENAI_API_KEY` to Codex.
+- **OPENAI_API_KEY-backed Codex auth.** This is useful upstream for users who
+  want API billing. It is explicitly not our desired path.
+
+## Previous 2026-05-06 stable deployment
+
+Previous verified production was **v2026.428.0** ([release notes](https://github.com/paperclipai/paperclip/releases/tag/v2026.428.0); mirror: [newreleases](https://newreleases.io/project/github/paperclipai/paperclip/release/v2026.428.0)). Production now runs **v2026.512.0** from a pinned stable ref. Canary builds may exist, but production should stay on a pinned stable release unless a specific blocker requires a canary and the rollback path is explicit.
+
+The previous deployed target was upstream tag `v2026.428.0` at commit
 `3494e84a2920f3e2bc5f627f916da29e224086dc`. Coolify deploys
 `ohld/paperclip`, so create/use a pinned fork branch such as
 `ffmemes/v2026.428.0` pointing to that exact commit. Do **not** sync
@@ -30,7 +72,15 @@ Safe company import still rejects `replace` for existing companies, so the repo'
 
 ## Pre-flight backups
 
-Fresh upgrade backups taken 2026-05-06 on `t.ffmemes.com:/root/paperclip-backups/`:
+Fresh v2026.512.0 upgrade backups taken 2026-05-12 on
+`t.ffmemes.com:/root/paperclip-backups/`:
+
+- `paperclip-20260512T145333Z.sql.gz` — DB dump, gzip verified.
+- `paperclip-volume-20260512T145333Z.tgz` — Paperclip named-volume archive,
+  tar verified.
+
+Earlier v2026.428.0 upgrade backups taken 2026-05-06 on
+`t.ffmemes.com:/root/paperclip-backups/`:
 
 - `paperclip-20260506T160310Z.sql.gz` — DB dump, gzip verified.
 - `paperclip-volume-clean-20260506T160914Z.tgz` — Paperclip named-volume archive, tar verified.
@@ -46,13 +96,17 @@ Restore (only if needed):
 gunzip -c preexport-20260424-092754.sql.gz | docker exec -i <paperclip-container> psql "$DATABASE_URL"
 ```
 
-## What Paperclip-native looks like (v2026.428)
+## What Paperclip-native looks like (v2026.512+)
 
 CLI commands we now rely on:
 - `paperclipai db:backup` — native DB dump.
 - `paperclipai company export <id> --include company,agents,skills` — git-syncable export of the entire company definition.
 - `paperclipai dashboard get --json` — replaces custom health-summary scripts.
 - `paperclipai heartbeat run --agent-id <id>` — wake an agent on demand.
+- Native issue monitors / retry-now — replace comment-only delayed wakeups.
+- Native company search — replace broad custom issue scans for slug dedupe.
+- Native routine revision history and restore — replace manual description
+  history outside git for routine text.
 
 API endpoints we now use directly (no SSH, no `docker cp`):
 - `GET  /api/companies/<id>/agents` — slug → agent ID resolution.
@@ -61,7 +115,7 @@ API endpoints we now use directly (no SSH, no `docker cp`):
 - `PATCH /api/agents/<id>` — adapter type, adapter config, env bindings, and runtime heartbeat.
 - `POST  /api/agents/<id>/skills/sync?companyId=<id>` — desired skills parsed from AGENTS.md frontmatter.
 - `PATCH /api/agents/<id>/permissions` — create-agent and related permission drift.
-- `PATCH /api/routines/<id>` — routine descriptions declared under `agents/<slug>/routines/*.yaml`.
+- `PATCH /api/routines/<id>` — routine descriptions declared under `agents/<slug>/routines/*.yaml`; on v2026.512.0 include `baseRevisionId` when available.
 
 ## Why `company import` is **not** the deploy path
 
@@ -121,11 +175,15 @@ Concurrency group `paperclip-deploy-agents` prevents overlapping runs; `cancel-i
 ## Phase 3 — Follow-ups
 
 **3a. Adapter config sync from `.paperclip.yaml`.** ✅ Done 2026-05-06.
-`agents/_sync_config.py` reads each agent block from the manifest, resolves Paperclip company secrets by name, preflights every required env binding before any agent config PATCH, applies `adapterType`, `adapterConfig` with `replaceAdapterConfig: true`, env bindings, `runtimeConfig.heartbeat`, permissions, and syncs desired skills through the native skills endpoint. It also syncs routine description files declared under `agents/<slug>/routines/*.yaml`. Current Codex split: CEO/CTO/Staff Engineer use `codex_local` + `gpt-5.5`; CEO runs effort `xhigh`, CTO/Staff run effort `high`.
+`agents/_sync_config.py` reads each agent block from the manifest, resolves Paperclip company secrets by name, preflights every required env binding before any agent config PATCH, applies `adapterType`, `adapterConfig` with `replaceAdapterConfig: true`, env bindings, `runtimeConfig.heartbeat`, permissions, and syncs desired skills through the native skills endpoint. It also syncs routine description files declared under `agents/<slug>/routines/*.yaml`. Current Codex config: all managed agents use `codex_local` + `gpt-5.5`; CEO runs effort `xhigh`, Analyst/CTO/QA/Staff run effort `high`, and Comms/Release run effort `medium`.
 
-**3b. Retire the webhook proxy.** ✅ Done 2026-04-29. QA trigger `30901464-...` flipped to `signingMode: none`, Sentry Internal Integration `paperclip-qa-alert-b86aa3` now POSTs directly to the Paperclip QA trigger URL stored in Sentry/Paperclip configuration. Do not commit the `routine-triggers/public/.../fire` path; treat the publicId as sensitive operational material. Deleted: `src/integrations/paperclip.py`, `notify_qa_sync` callsite in `src/flows/hooks.py`, env vars `WEBHOOK_PROXY_SECRET` / `SENTRY_CLIENT_SECRET` / `PAPERCLIP_QA_TRIGGER_URL` / `PAPERCLIP_QA_TRIGGER_SECRET`. Coolify webhook path was unused (no hits in 24h prior to removal). Prefect failures now surface via the QA Log Scan 3h cron instead of an instant push — accepted tradeoff for less code. Trigger publicId leakage = at most noisy QA scans (no user input or commands accepted).
+**2026-05-12 update:** all agents are now configured for `codex_local` in the
+manifest. Codex auth is subscription/OAuth-only; `OPENAI_API_KEY` is deliberately
+absent from Codex env bindings.
 
-**3c. CLI-native agent skills.** In each AGENTS.md, replace raw `curl https://org.ffmemes.com/api/...` with `paperclipai issue list --json`, `paperclipai approval create`, `paperclipai dashboard get`, `paperclipai heartbeat run --agent-id`. Reduces per-wake context.
+**3b. Retire the webhook proxy.** ✅ Done 2026-04-29. QA trigger signing mode flipped to `none`; Sentry Internal Integration now POSTs directly to the Paperclip QA trigger URL stored in Sentry/Paperclip configuration. Do not commit routine trigger IDs or full public trigger paths; treat publicIds as sensitive operational material. Deleted: `src/integrations/paperclip.py`, `notify_qa_sync` callsite in `src/flows/hooks.py`, env vars `WEBHOOK_PROXY_SECRET` / `SENTRY_CLIENT_SECRET` / `PAPERCLIP_QA_TRIGGER_URL` / `PAPERCLIP_QA_TRIGGER_SECRET`. Coolify webhook path was unused (no hits in 24h prior to removal). Prefect failures now surface via the QA Log Scan 3h cron instead of an instant push — accepted tradeoff for less code. Trigger publicId leakage = at most noisy QA scans (no user input or commands accepted).
+
+**3c. CLI-native agent skills and v512 built-ins.** In each AGENTS.md, replace raw `curl https://org.ffmemes.com/api/...` with native Paperclip skill/MCP/CLI operations: issue search, company search, planning-mode issue creation, monitor/retry-now, approvals, `paperclipai dashboard get`, and `paperclipai heartbeat run --agent-id`. Reduces per-wake context and avoids custom liveness logic.
 
 **3d. gstack skill update routine.** Codex flagged: Paperclip already shipped "pinned GitHub skills with update checks" in v2026.325.0. Build a daily Paperclip routine that:
 - compares pinned `skills.source` ref against `garrytan/gstack` HEAD,
@@ -140,6 +198,8 @@ Prefer Paperclip's native skill-update mechanism over a custom-rolled routine if
 - `.github/workflows/staff-engineer-trigger.yml` — no native Paperclip↔GitHub PR integration yet; HTTP POST to a routine trigger is the right shape.
 - `agents/<slug>/AGENTS.md` content — our IP, not Paperclip's job.
 - Telegram plugin — already native (Paperclip plugin system).
+- Paperclip deploy/sync from git — still custom because existing-company
+  `replace` import is blocked by the safe import route.
 
 ## Risks acknowledged
 
@@ -148,3 +208,7 @@ Prefer Paperclip's native skill-update mechanism over a custom-rolled routine if
 - **No drift monitoring yet.** Auto-deploy reduces drift; UI edits between deploys still possible. Codex recommended a nightly `company export` artifact job; deferred per CEO call. Revisit if drift bites.
 - **CI auth uses a single API key.** No first-class service-account exists in Paperclip. The key must be scoped to this company and rotated if leaked.
 - **Env sync replaces live `adapterConfig.env` from the manifest.** Required missing secrets now abort before PATCH; optional missing secrets are omitted. Comms `DATABASE_URL` intentionally maps to the read-only `ANALYST_DATABASE_URL` secret, so `editorial_posts` writes from agent runtime are not guaranteed until a dedicated writer secret is created.
+- **Codex API-key billing regression.** If `OPENAI_API_KEY` is added to the
+  Paperclip host env or to any `codex_local` agent env, Codex CLI 0.122+ can
+  switch from subscription OAuth to API-key billing. Treat that as a deploy
+  blocker unless explicitly approved.

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -259,7 +259,7 @@ stopped work, and next bets. The weekly source of truth is the
 | gstack Update Check | CEO | `17 3 * * *` | schedule | Update skills, review changelog |
 | Paperclip Update Check | CTO | `0 4 * * *` | schedule | Check for Paperclip updates |
 | Daily Channel Post | Comms | `0 7 * * *` | schedule | Daily @ffmemes TG channel post; success means published, not only draft approved |
-| PR Review | Staff Engineer | on PR event | 2 webhooks + API | Review PRs via GitHub Actions trigger |
+| PR Review | Staff Engineer | on PR event | API trigger | Review PRs via GitHub Actions trigger |
 
 ## Plugins
 
@@ -313,12 +313,12 @@ Paperclip triggers now support multiple signing modes:
 - **`github_hmac`** (NEW) — reads `X-Hub-Signature-256` header. Compatible with GitHub webhooks.
 - **`none`** (NEW) — no auth, publicId in URL acts as shared secret.
 
-### Current webhook setup (post PR #212, 2026-04-29)
+### Current trigger setup
 
 | Source | Path | Auth | Notes |
 |--------|------|------|-------|
 | Sentry | Sentry Internal Integration → Paperclip trigger | none (publicId is the secret) | Integration name is stored in Sentry, not this public repo |
-| GitHub | GH Actions (`notify-staff-engineer`) → Paperclip trigger | Bearer token | Direct call |
+| GitHub | GH Actions (`notify-staff-engineer`) → Paperclip routine API trigger | Board API key | Sends narrow `{pr_number, pr_url}` variables |
 | Prefect | (none) | — | Failures surface via QA Log Scan 3h cron |
 | Coolify | (none) | — | Was never actively used in practice |
 

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -16,7 +16,11 @@
 
 Paperclip manages the autonomous AI agent team for @ffmemesbot.
 Dashboard: `https://org.ffmemes.com` (URL is public, auth required).
-**Version**: 2026.416.0 (deployed from `ohld/paperclip` fork on 2026-04-16).
+**Version**: current verified deployment is 2026.512.0 (deployed from
+`ohld/paperclip:ffmemes/v2026.512.0` on 2026-05-12; Coolify deployment
+`q12xc4c1q6m4smzk1zfkog02`, commit
+`c445e5925628d11bf59d52604b8aa63a6e9aa800`). See
+`docs/paperclip-native-migration.md`.
 
 All secrets (API keys, DB credentials, tokens) live in **environment variables** — never in this repo.
 Required env vars for local management: `PAPERCLIP_URL`, `PAPERCLIP_API_KEY` (set in `~/.zshrc` or `.env`).
@@ -25,21 +29,21 @@ Required env vars for local management: `PAPERCLIP_URL`, `PAPERCLIP_API_KEY` (se
 
 Paperclip API is available as an MCP tool server via `@paperclipai/mcp-server`. Configured in two places:
 
-**Local (MacBook, Claude Code hosts)**: register via `claude mcp add` CLI (writes to `~/.claude.json` under the project entry). **Do NOT put `mcpServers` in `.claude/settings.local.json` — Claude Code does not read that key there.** Codex sessions can use the same Paperclip HTTP API with `PAPERCLIP_URL` + `PAPERCLIP_API_KEY` when MCP is unavailable.
+**Local (MacBook / Codex hosts)**: use the Paperclip MCP server or the same
+Paperclip HTTP API with `PAPERCLIP_URL` + `PAPERCLIP_API_KEY`. Legacy Claude
+MCP registration may still exist on developer machines, but production agents
+are moving to Codex subscription auth.
 
 ```bash
 source ~/.zshrc   # loads PAPERCLIP_URL + PAPERCLIP_API_KEY
-claude mcp add paperclip -s local \
-  -e PAPERCLIP_API_URL="$PAPERCLIP_URL" \
-  -e PAPERCLIP_API_KEY="$PAPERCLIP_API_KEY" \
-  -e PAPERCLIP_COMPANY_ID=96ee7b2e-6df2-43c8-bbe3-53e19297308a \
-  -- npx -y @paperclipai/mcp-server
-
-claude mcp list               # verify paperclip ✓ Connected
-claude mcp get paperclip      # note: prints API key in plaintext — do not screen-share
+PAPERCLIP_API_URL="$PAPERCLIP_URL" \
+PAPERCLIP_API_KEY="$PAPERCLIP_API_KEY" \
+PAPERCLIP_COMPANY_ID=<company-id> \
+  npx -y @paperclipai/mcp-server
 ```
 
-**Server (agents)**: `/paperclip/.claude/settings.json` — uses `http://localhost:3100` (internal) and inherits `$PAPERCLIP_API_KEY` from Paperclip agent runtime.
+**Server (agents)**: Codex agents use Paperclip skill/MCP/HTTP access exposed
+by the Paperclip runtime and the env bindings in `agents/.paperclip.yaml`.
 
 34 MCP tools available (issues, agents, comments, documents, approvals, projects, goals) + `paperclipApiRequest` escape hatch for anything not covered.
 
@@ -50,21 +54,33 @@ Agent prompts reference MCP tools instead of curl. See agent `AGENTS.md` files f
 ```
 org.ffmemes.com (Paperclip dashboard)
   ├── Coolify app: k4w804sco4s8kc88kwcw0ow4
-  ├── Git source: ohld/paperclip fork (master branch)
-  │   └── Fork needed: upstream Dockerfile has hardcoded sha256 for GH CLI GPG key
+  ├── Git source: ohld/paperclip fork (pinned ffmemes/v2026.512.0 branch)
+  │   └── Keep production on pinned stable refs, not upstream/fork master
   ├── External PostgreSQL (shared Coolify DB service)
   │   └── Database: paperclip
   ├── Named volume: paperclip-data → /paperclip
-  │   ├── .claude/         # Claude CLI auth (survives redeploy)
-  │   ├── .codex/          # Codex auth (survives redeploy)
+  │   ├── .claude/         # Legacy Claude CLI auth, not used by agents
+  │   ├── .codex/          # Codex subscription OAuth auth (survives redeploy)
   │   ├── .config/gh/      # GitHub CLI auth (survives redeploy)
   │   ├── bin/             # Persistent tool binaries (gh, sentry)
   │   └── instances/default/
   │       ├── config.json  # Paperclip server config
   │       ├── companies/   # Agent instructions, workspaces
   │       └── logs/        # Runtime logs
-  └── Agents run Claude CLI or Codex as subprocesses
+  └── Agents run Codex as subprocesses
 ```
+
+### Codex auth policy
+
+Codex must use ChatGPT/Codex subscription OAuth from `/paperclip/.codex/auth.json`.
+Do not set `OPENAI_API_KEY` in the Paperclip host env and do not bind it to any
+`codex_local` agent. With Codex CLI 0.122+, the presence of `OPENAI_API_KEY`
+switches Codex toward API-key billing, which is not the approved path for this
+system.
+
+If Codex auth is lost after volume loss or redeploy, run an interactive
+`codex login --device-auth` on the server container and verify `.codex/auth.json`
+is on the named volume.
 
 ## Managing from MacBook
 
@@ -114,7 +130,8 @@ npx paperclipai auth whoami
 <!-- agent-runtime: ok — agents use Paperclip MCP / paperclipApiRequest;
      curl fallback only when MCP unavailable in the runtime -->
 
-With MCP server configured, use MCP tools from Claude Code for most operations:
+With MCP server configured, use MCP tools from the active agent runtime for most
+operations:
 
 ```
 # List issues (MCP)
@@ -174,12 +191,11 @@ ssh root@t.ffmemes.com
 CONT=$(docker ps --format '{{.Names}}' | grep k4w804 | head -1)
 
 # Re-auth tools (interactive — needed after volume loss only)
-docker exec -it $CONT claude login
 docker exec -it $CONT codex login --device-auth
 docker exec -it $CONT gh auth login
 
 # Upload agent instructions after editing locally
-# Preferred: use the deploy script (syncs all agents + runs backup)
+# Preferred: use the deploy script (syncs all agent instructions + config)
 ./agents/deploy.sh
 # Manual (single agent):
 # scp agents/<name>/AGENTS.md root@t.ffmemes.com:/tmp/agent.md
@@ -191,12 +207,12 @@ docker exec -it $CONT gh auth login
 | Agent | Role | Reports To | Activation | Adapter / model |
 |-------|------|-----------|------------|-----------------|
 | CEO | Strategic decisions, experiments | — | Weekly routine + daily heartbeat | `codex_local` / `gpt-5.5`, effort `xhigh` |
-| Analyst | Metrics, anomaly detection | CEO | Routines only | `claude_local` / `claude-sonnet-4-6` |
+| Analyst | Metrics, anomaly detection | CEO | Routines only | `codex_local` / `gpt-5.5`, effort `high` |
 | CTO | Engineering, PRs | CEO | On-demand | `codex_local` / `gpt-5.5`, effort `high` |
 | Staff Engineer | PR review + merge for internal PRs | CTO | PR webhook routine | `codex_local` / `gpt-5.5`, effort `high` |
-| QA Engineer | Log monitoring, bug reports | CTO | Schedule + Sentry webhook + API | `claude_local` / `claude-sonnet-4-6` |
-| Release Engineer | Post-merge deploy verification | CTO | On-demand | `claude_local` / `claude-sonnet-4-6` |
-| Comms Manager | Public TG channel updates | CEO | Daily heartbeat | `claude_local` / `claude-sonnet-4-6` |
+| QA Engineer | Log monitoring, bug reports | CTO | Schedule + Sentry webhook + API | `codex_local` / `gpt-5.5`, effort `high` |
+| Release Engineer | Post-merge deploy verification | CTO | On-demand | `codex_local` / `gpt-5.5`, effort `medium` |
+| Comms Manager | Public TG channel updates | CEO | Daily heartbeat | `codex_local` / `gpt-5.5`, effort `medium` |
 
 Agent instructions: `agents/<name>/AGENTS.md` in this repo.
 Deploy after editing: `./agents/deploy.sh`
@@ -301,17 +317,16 @@ Paperclip triggers now support multiple signing modes:
 
 | Source | Path | Auth | Notes |
 |--------|------|------|-------|
-| Sentry | Sentry Internal Integration → Paperclip trigger | none (publicId is the secret) | Internal Integration `paperclip-qa-alert-b86aa3` |
+| Sentry | Sentry Internal Integration → Paperclip trigger | none (publicId is the secret) | Integration name is stored in Sentry, not this public repo |
 | GitHub | GH Actions (`notify-staff-engineer`) → Paperclip trigger | Bearer token | Direct call |
 | Prefect | (none) | — | Failures surface via QA Log Scan 3h cron |
 | Coolify | (none) | — | Was never actively used in practice |
 
 **Sentry → Paperclip QA trigger** is fully direct since PR #212. Set up:
-- QA routine `477f452d-06f3-421e-a274-7f09155bb5bb`, webhook trigger `30901464-a100-4cff-9515-9fdbcfc1a797`
+- QA routine and webhook trigger IDs are read from Paperclip UI / API; do not paste them here. Look up by routine title "QA Log Scan".
 - `signingMode: none` — `server/dist/services/routines.js` short-circuits all auth checks
 - Public trigger URL is configured in Sentry/Paperclip only. Do not commit the
-  `routine-triggers/public/.../fire` path; the publicId is sensitive operational
-  material.
+  full public trigger path; the publicId is sensitive operational material.
 - Sentry posts the raw payload (`{"action":"created","data":{"issue":{...}}}`); Paperclip stores it in `routine_run.triggerPayload` verbatim
 - Trigger fires only on **issue creation**, not subsequent occurrences. To re-test, send an event with a unique exception class so Sentry creates a new issue group.
 
@@ -331,14 +346,14 @@ sentry_sdk.flush(timeout=10)
 "
 
 # Within ~15-30s, a new routine_execution issue (title 'QA Log Scan') should appear
-# at https://org.ffmemes.com/issues, source='webhook', triggerId=30901464-...
+# at https://org.ffmemes.com/issues with source='webhook'
 ```
 
 ### Reverting if Sentry → Paperclip breaks
 
 ```bash
-# Flip trigger back to bearer mode
-curl -X PATCH "https://org.ffmemes.com/api/routine-triggers/30901464-a100-4cff-9515-9fdbcfc1a797" \
+# Flip trigger back to bearer mode (look up TRIGGER_ID by routine title via API; do not commit it)
+curl -X PATCH "https://org.ffmemes.com/api/routine-triggers/$TRIGGER_ID" \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"signingMode":"bearer"}'
@@ -356,6 +371,11 @@ These are encrypted in Paperclip DB and injected as env vars during agent runs:
 
 `agents/_sync_config.py` materializes env from `agents/.paperclip.yaml`: `kind: secret` becomes a Paperclip `secret_ref`, `kind: plain` is written directly, and missing required secrets fail the config sync before any PATCH. Optional missing secrets are omitted. Docs should name env var names and Paperclip secret names only, never secret IDs or values.
 
+For v2026.512.0 provider vaults, the default remains Paperclip company secrets.
+Do not import AWS Secrets Manager for this setup. Coolify envs are acceptable
+for Paperclip service-level config, but not for Codex auth or per-agent
+`OPENAI_API_KEY` injection.
+
 | Secret | Used by | Purpose |
 |--------|---------|---------|
 | `ANALYST_DATABASE_URL` | Analyst, QA, Comms | Read-only prod DB access. Comms also receives this as env `DATABASE_URL` by explicit CEO decision; this supports data reads, not `editorial_posts` writes. |
@@ -364,13 +384,13 @@ These are encrypted in Paperclip DB and injected as env vars during agent runs:
 | `SENTRY_AUTH_TOKEN` | CTO, QA | Sentry CLI authentication (read-only project scope) |
 | `PREFECT_API_URL` | CTO, QA | Prefect API endpoint (`https://prefect.swanrate.com/api`) |
 | `PREFECT_AUTH_STRING` | CTO, QA | Prefect API Basic auth credentials |
-| `OPENAI_API_KEY` | All (Codex), Comms optional image generation, Telegram plugin (Whisper) | OpenAI API for Codex, GPT Image visuals, and voice transcription |
+| `OPENAI_API_KEY` | Telegram plugin (Whisper) only, and any explicitly approved non-Codex service | Do **not** bind to Codex agents. Do **not** set globally in the Paperclip host env unless accepting API-key billing for Codex. Comms GPT image generation is disabled under subscription-only Codex. |
 | `TEST_DATABASE_URL` | CTO | Test/staging DB for safe experiments |
 | `TELEGRAM_BOT_TOKEN` | Telegram plugin | @ffnerdbot token (NOT @ffmemesbot!) |
 
 The least-privilege `comms_writer` role in `docs/comms/comms-writer-role-setup.sql` remains available as a future upgrade if Comms needs to persist `editorial_posts` rows from the agent runtime. Do not bind Comms to `FFMEMES_DATABASE_URL` or any full-write app DB secret.
 
-QA runtime access is considered degraded unless all of these are present in the live QA `adapterConfig.env`: `PATH` with `/paperclip/bin`, `ANALYST_DATABASE_URL`, `COOLIFY_BASE_URL`, `COOLIFY_ACCESS_TOKEN`, `SENTRY_AUTH_TOKEN`, `PREFECT_AUTH_STRING`.
+QA runtime access is considered degraded unless all of these are present in the live QA `adapterConfig.env`: `PATH` with `/paperclip/bin`, `ANALYST_DATABASE_URL`, `COOLIFY_BASE_URL`, `COOLIFY_ACCESS_TOKEN`, `SENTRY_AUTH_TOKEN`, `PREFECT_API_URL`, `PREFECT_AUTH_STRING`.
 
 ## Persistent Tool Binaries
 
@@ -470,6 +490,10 @@ docker restart $CONT
 1. Verify named volume `paperclip-data` is in Coolify Storages
 2. `docker exec $CONT cat /paperclip/instances/default/config.json` — should exist
 3. Do NOT change deployment exposure/mode env vars
+4. Verify `/paperclip/.codex/auth.json` exists on the named volume after
+   interactive `codex login --device-auth`
+5. Verify `OPENAI_API_KEY` is not present in the Paperclip host env or any
+   `codex_local` agent env binding
 
 ### Post-redeploy checklist (MANUAL — Coolify post-deploy is broken, bug #9076)
 
@@ -483,7 +507,7 @@ CONT=$(docker ps --format '{{.Names}}' | grep k4w804 | head -1)
 docker exec -u root $CONT sh -c "apt-get update -qq && apt-get install -y -qq gh && npm install --prefix /paperclip/.npm-global @openai/codex@latest @sentry/cli sentry && ln -sf /paperclip/.npm-global/node_modules/.bin/codex /paperclip/bin/codex && ln -sf /paperclip/.npm-global/node_modules/.bin/sentry /paperclip/bin/sentry && ln -sf /paperclip/.npm-global/node_modules/.bin/sentry-cli /paperclip/bin/sentry-cli"
 
 # Verify
-docker exec $CONT sh -c "PATH=/paperclip/bin:\$PATH; gh --version; codex --version; (sentry --version || sentry-cli --version); claude --version; codex login status"
+docker exec $CONT sh -c "PATH=/paperclip/bin:\$PATH; gh --version; codex --version; (sentry --version || sentry-cli --version); codex login status"
 ```
 
 Tools on `/paperclip/bin/` (named volume) survive redeploys. Agents that need them must have `PATH=/paperclip/bin:...` in `.paperclip.yaml`.
@@ -495,7 +519,6 @@ System-wide installs via `apt-get` and `npm install -g` do NOT survive redeploys
 CONT=$(docker ps --format '{{.Names}}' | grep k4w804 | head -1)
 
 # Auth survived?
-docker exec $CONT sh -c "test -f /paperclip/.claude/.credentials.json && echo claude:OK"
 docker exec $CONT sh -c "test -f /paperclip/.codex/auth.json && echo codex:OK"
 docker exec $CONT sh -c "test -f /paperclip/.config/gh/hosts.yml && echo gh:OK"
 
@@ -516,17 +539,22 @@ Paperclip is deployed from the fork `ohld/paperclip` (not upstream `paperclipai/
 Use pinned stable refs. Do not sync the fork to upstream `master`; upstream
 master may be ahead of the latest stable release.
 
-Current production deployment (verified 2026-05-06): Coolify app
+Current production deployment (verified 2026-05-12): Coolify app
 `k4w804sco4s8kc88kwcw0ow4` tracks
-`ohld/paperclip:ffmemes/v2026.428.0` at
-`3494e84a2920f3e2bc5f627f916da29e224086dc`. State file
+`ohld/paperclip:ffmemes/v2026.512.0` at
+`c445e5925628d11bf59d52604b8aa63a6e9aa800`. Coolify deployment
+`q12xc4c1q6m4smzk1zfkog02` completed successfully. State file
 `/paperclip/.last-deployed-paperclip-sha` must match that verified deployed
 commit.
 
+Last pre-deploy backups on `t.ffmemes.com:/root/paperclip-backups/`:
+`paperclip-20260512T145333Z.sql.gz` and
+`paperclip-volume-20260512T145333Z.tgz`.
+
 ```bash
 # 1. Pick the approved stable release.
-TARGET_VERSION=2026.428.0
-TARGET_SHA=3494e84a2920f3e2bc5f627f916da29e224086dc
+TARGET_VERSION=2026.512.0
+TARGET_SHA=c445e5925628d11bf59d52604b8aa63a6e9aa800
 FORK_BRANCH=ffmemes/v${TARGET_VERSION}
 
 # 2. Create/update a pinned fork branch at the stable upstream tag.
@@ -538,20 +566,21 @@ gh api -X POST repos/ohld/paperclip/git/refs \
 # 3. Check migration prerequisites.
 ssh root@t.ffmemes.com "docker exec \$(docker ps --format '{{.Names}}' | grep tkg4c0 | head -1) psql -U paperclip -d paperclip -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'"
 
-# 4. Take a fresh db + volume backup before deploy.
+# 4. Take a fresh db + volume backup before deploy and verify both archives.
 
 # 5. Point Coolify app k4w804sco4s8kc88kwcw0ow4 at the pinned fork branch,
 #    then force deploy. Hard gate: the finished deployment commit must equal
 #    TARGET_SHA. Queueing a deploy is not success.
 
 # 6. Run post-redeploy checklist above and verify migrations are up to date.
-ssh root@t.ffmemes.com "CONT=\$(docker ps --format '{{.Names}}' | grep k4w804 | head -1) && docker exec \$CONT cat /paperclip/.claude/settings.json"
+#    Confirm Codex auth is OAuth/subscription-backed and OPENAI_API_KEY is absent.
 ```
 
 ### Notable version changes
 
 | Version | Key changes |
 |---------|-------------|
+| v2026.512.0 | Codex auth.json generation support (not used for API-key billing here), planning-mode issues, full company search, routine revision history, issue monitors / retry-now, provider vaults |
 | v2026.428.0 | Stable target for v416 upgrade: productivity review, stranded assignment recovery, routine variables UI, attachment size limits, issue tree pause/resume fixes |
 | v2026.427.0 | Multi-user control plane, structured issue interactions, liveness/watchdog recovery, blocker-aware scheduling, issue subtree pause/cancel/restore, beta Environments |
 | v2026.416.0 | MCP server, chat threads, execution policies, blocker deps, `none`/`github_hmac` webhook signing, security fix GHSA-68qg-g8mg-6pr7 |

--- a/docs/paperclip-skill-catalog.md
+++ b/docs/paperclip-skill-catalog.md
@@ -49,9 +49,9 @@ into this public repo.** Justification:
   `# Per-developer git worktrees` block; we extend the rule by convention to
   any `.codex/skills/gstack` or `.agents/skills/gstack` paths if a tool
   introduces them).
-- Each runtime (Claude Code, Codex, Paperclip) loads gstack from its own
-  install. Paperclip pulls from `skills.source`/`skills.ref`; Claude Code and
-  Codex install gstack into per-user dot-directories that are gitignored.
+- Each runtime (Codex, Paperclip, and any legacy local tools) loads gstack from
+  its own install. Paperclip pulls from `skills.source`/`skills.ref`; Codex
+  installs gstack into per-user dot-directories that are gitignored.
 - Sharing a tracked team-mode file would mean either committing per-user
   paths (privacy leak) or pinning a config that is unlikely to be valid
   across all three runtimes.

--- a/tests/test_paperclip_skill_preflight.py
+++ b/tests/test_paperclip_skill_preflight.py
@@ -185,3 +185,27 @@ def test_preflight_unpinned_ref_label(
     state = sync_module.preflight_skills(by_slug, manifest)
     capsys.readouterr()
     assert state["upstream_ref"] == "unpinned"
+
+
+def test_routine_patch_payload_includes_latest_revision_id(sync_module) -> None:
+    payload = sync_module.routine_patch_payload(
+        {"latestRevisionId": "rev-123"},
+        "new description\n",
+    )
+    assert payload == {
+        "description": "new description\n",
+        "baseRevisionId": "rev-123",
+    }
+
+
+def test_routine_patch_payload_accepts_nested_revision_id(sync_module) -> None:
+    payload = sync_module.routine_patch_payload(
+        {"latestRevision": {"id": "rev-456"}},
+        "new description\n",
+    )
+    assert payload["baseRevisionId"] == "rev-456"
+
+
+def test_routine_patch_payload_omits_revision_for_older_server(sync_module) -> None:
+    payload = sync_module.routine_patch_payload({}, "new description\n")
+    assert payload == {"description": "new description\n"}


### PR DESCRIPTION
## Summary
- upgrade Paperclip production docs and agent config for v2026.512.0
- move all managed Paperclip agents to codex_local/gpt-5.5 with subscription OAuth only; no OPENAI_API_KEY bindings
- use v512 routine revision history by sending baseRevisionId when available
- switch Staff Engineer PR review trigger from the brittle public webhook to Paperclip's native routine API trigger
- document verified Coolify deployment q12xc4c1q6m4smzk1zfkog02 and 2026-05-12 backups

## Live verification
- org.ffmemes.com is running Paperclip 2026.512.0 at c445e5925628d11bf59d52604b8aa63a6e9aa800
- health endpoint is green; container is healthy
- /paperclip/.codex/auth.json is present
- OPENAI_API_KEY is absent from host env and managed Codex agent env bindings
- recent logs show zero OPENAI_API_KEY binding errors
- Staff Engineer routine was manually verified via the native API trigger for PR #250

## Tests
- python3 -m py_compile agents/_sync_config.py
- pytest tests/test_paperclip_skill_preflight.py tests/test_redaction_audit.py -q
- python3 scripts/redaction_audit.py
- workflow YAML parse check
- manifest sanity check for codex_local/no OPENAI_API_KEY/QA env cleanup
- git diff --check

## Check note
- GitHub lint/test checks pass. The current notify-staff-engineer check still fails because pull_request_target executes the old production workflow; this PR contains the workflow fix for future PRs.