### PR TITLE
Add low_sent_pool skip-rate alerting

### DIFF
--- a/alembic/versions/2026-05-12_low_sent_pool_skip_alert_index.py
+++ b/alembic/versions/2026-05-12_low_sent_pool_skip_alert_index.py
@@ -16,23 +16,20 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
-    op.execute("COMMIT")
-
     # Supports the daily low_sent_pool skip-rate alert, which scans recent
     # deliveries for one recommendation engine on a production-sized table.
-    op.execute(
-        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
-        "ix_user_meme_reaction_low_sent_pool_sent_at_meme_id "
-        "ON user_meme_reaction (sent_at, meme_id) "
-        "INCLUDE (reaction_id) "
-        "WHERE recommended_by = 'low_sent_pool'"
-    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_user_meme_reaction_low_sent_pool_sent_at_meme_id "
+            "ON user_meme_reaction (sent_at, meme_id) "
+            "INCLUDE (reaction_id) "
+            "WHERE recommended_by = 'low_sent_pool'"
+        )
 
 
 def downgrade() -> None:
-    op.execute("COMMIT")
-
-    op.execute(
-        "DROP INDEX CONCURRENTLY IF EXISTS ix_user_meme_reaction_low_sent_pool_sent_at_meme_id"
-    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_user_meme_reaction_low_sent_pool_sent_at_meme_id"
+        )

--- a/alembic/versions/2026-05-12_low_sent_pool_skip_alert_index.py
+++ b/alembic/versions/2026-05-12_low_sent_pool_skip_alert_index.py
@@ -1,0 +1,38 @@
+"""Add low_sent_pool skip alert index
+
+Revision ID: 9f0a1b2c3d4e
+Revises: 1a2b3c4d5e6f
+Create Date: 2026-05-12 16:30:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9f0a1b2c3d4e"
+down_revision = "1a2b3c4d5e6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+    op.execute("COMMIT")
+
+    # Supports the daily low_sent_pool skip-rate alert, which scans recent
+    # deliveries for one recommendation engine on a production-sized table.
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_user_meme_reaction_low_sent_pool_sent_at_meme_id "
+        "ON user_meme_reaction (sent_at, meme_id) "
+        "INCLUDE (reaction_id) "
+        "WHERE recommended_by = 'low_sent_pool'"
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+
+    op.execute(
+        "DROP INDEX CONCURRENTLY IF EXISTS ix_user_meme_reaction_low_sent_pool_sent_at_meme_id"
+    )

--- a/scripts/serve_flows.py
+++ b/scripts/serve_flows.py
@@ -44,7 +44,7 @@ from src.flows.rewards.uploaded_memes import (
     reward_en_users_for_weekly_top_uploaded_memes,
     reward_ru_users_for_weekly_top_uploaded_memes,
 )
-from src.flows.stats.meme import calculate_meme_stats
+from src.flows.stats.meme import alert_low_sent_pool_skip_rate, calculate_meme_stats
 from src.flows.stats.meme_heavy import calculate_meme_stats_heavy
 from src.flows.stats.meme_source import calculate_meme_source_stats
 
@@ -91,6 +91,10 @@ if __name__ == "__main__":
                     timezone=LON,
                 )
             ],
+        ),
+        alert_low_sent_pool_skip_rate.to_deployment(
+            name="Alert low_sent_pool skip rate",
+            schedules=[CronSchedule(cron="25 7 * * *", timezone=LON)],
         ),
         # ── Parsers (hourly) ──
         parse_telegram_sources.to_deployment(

--- a/src/flows/stats/meme.py
+++ b/src/flows/stats/meme.py
@@ -10,6 +10,12 @@ from src.tgbot.logs import log
 
 logger = logging.getLogger(__name__)
 
+TELEGRAM_LOG_HTML_MESSAGE_LIMIT = 4000
+LOW_SENT_POOL_ALERT_HTML_BUDGET = 3900
+LOW_SENT_POOL_ALERT_MAX_ROWS = 10
+LOW_SENT_POOL_ALERT_FIELD_HTML_LIMIT = 64
+LOW_SENT_POOL_ALERT_SOURCE_URL_HTML_LIMIT = 80
+
 
 @flow(
     name="Calculate meme_stats",
@@ -34,13 +40,38 @@ def _pct(value: float | None) -> str:
     return f"{value * 100:.1f}%"
 
 
+def _escape_html_ellipsized(value: object, max_html_chars: int) -> str:
+    text = str(value or "unknown")
+    suffix = "..."
+    budget = max_html_chars - len(suffix)
+    escaped_parts = []
+    used = 0
+
+    for char in text:
+        escaped_char = html.escape(char)
+        if used + len(escaped_char) > budget:
+            return "".join(escaped_parts) + suffix
+        escaped_parts.append(escaped_char)
+        used += len(escaped_char)
+
+    return "".join(escaped_parts)
+
+
+def _append_line_with_budget(lines: list[str], line: str, budget: int) -> bool:
+    candidate = "\n".join([*lines, line])
+    if len(candidate) > budget:
+        return False
+    lines.append(line)
+    return True
+
+
 def _format_low_sent_pool_skip_rate_alert(
     rows: list[dict],
     skip_rate_threshold: float,
     min_sends: int,
     lookback_days: int,
 ) -> str:
-    ids = " ".join(str(row["meme_id"]) for row in rows[:10])
+    ids = " ".join(str(row["meme_id"]) for row in rows[:LOW_SENT_POOL_ALERT_MAX_ROWS])
     lines = [
         "Low-sent pool skip-rate alert",
         (
@@ -57,17 +88,37 @@ def _format_low_sent_pool_skip_rate_alert(
         "",
     ]
 
-    for row in rows[:10]:
+    displayed_rows = 0
+    for row in rows[:LOW_SENT_POOL_ALERT_MAX_ROWS]:
         action_state = (
             "already_rejected_or_snoozed" if row["already_rejected_or_snoozed"] else "needs_review"
         )
-        source_url = html.escape(str(row["source_url"] or "unknown"))
-        lines.append(
+        source_url = _escape_html_ellipsized(
+            row["source_url"],
+            LOW_SENT_POOL_ALERT_SOURCE_URL_HTML_LIMIT,
+        )
+        source_type = _escape_html_ellipsized(
+            row["source_type"],
+            LOW_SENT_POOL_ALERT_FIELD_HTML_LIMIT,
+        )
+        meme_status = _escape_html_ellipsized(
+            row["meme_status"],
+            LOW_SENT_POOL_ALERT_FIELD_HTML_LIMIT,
+        )
+        source_status = _escape_html_ellipsized(
+            row["source_status"],
+            LOW_SENT_POOL_ALERT_FIELD_HTML_LIMIT,
+        )
+        last_sent_at = _escape_html_ellipsized(
+            row["last_sent_at"],
+            LOW_SENT_POOL_ALERT_FIELD_HTML_LIMIT,
+        )
+        line = (
             "- "
             f"#{row['meme_id']} "
-            f"source=#{row['meme_source_id']}:{html.escape(str(row['source_type']))} "
-            f"meme_status={html.escape(str(row['meme_status']))} "
-            f"source_status={html.escape(str(row['source_status']))} "
+            f"source=#{row['meme_source_id']}:{source_type} "
+            f"meme_status={meme_status} "
+            f"source_status={source_status} "
             f"action={action_state} "
             f"sends={row['sends']} "
             f"reactions={row['explicit_reactions']} "
@@ -76,14 +127,22 @@ def _format_low_sent_pool_skip_rate_alert(
             f"like_rate={_pct(row['like_rate'])} "
             f"skip_rate={_pct(row['skip_rate'])} "
             f"age_days={row['published_age_days']:.1f} "
-            f"last_sent={html.escape(str(row['last_sent_at']))} "
+            f"last_sent={last_sent_at} "
             f"<code>{source_url}</code>"
         )
+        if not _append_line_with_budget(lines, line, LOW_SENT_POOL_ALERT_HTML_BUDGET):
+            break
+        displayed_rows += 1
 
-    if len(rows) > 10:
-        lines.append(f"...and {len(rows) - 10} more; rerun the flow with a larger limit.")
+    remaining_rows = len(rows) - displayed_rows
+    if remaining_rows > 0:
+        summary = f"...and {remaining_rows} more; rerun the flow with a larger limit."
+        _append_line_with_budget(lines, summary, LOW_SENT_POOL_ALERT_HTML_BUDGET)
 
-    return "\n".join(lines)
+    message = "\n".join(lines)
+    if len(message) >= TELEGRAM_LOG_HTML_MESSAGE_LIMIT:
+        logger.warning("Low-sent pool alert exceeded Telegram log budget after formatting")
+    return message
 
 
 @flow(

--- a/src/flows/stats/meme.py
+++ b/src/flows/stats/meme.py
@@ -1,8 +1,14 @@
+import html
+import logging
+
 from prefect import flow
 
 from src.flows.events import safe_emit
 from src.flows.hooks import notify_telegram_on_failure
 from src.stats import meme
+from src.tgbot.logs import log
+
+logger = logging.getLogger(__name__)
 
 
 @flow(
@@ -20,3 +26,107 @@ async def calculate_meme_stats() -> None:
     await meme.calculate_meme_reactions_and_engagement(lookback_hours=3)
 
     safe_emit("ff.stats.meme.completed", "ff.stats.meme")
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"
+
+
+def _format_low_sent_pool_skip_rate_alert(
+    rows: list[dict],
+    skip_rate_threshold: float,
+    min_sends: int,
+    lookback_days: int,
+) -> str:
+    ids = " ".join(str(row["meme_id"]) for row in rows[:10])
+    lines = [
+        "Low-sent pool skip-rate alert",
+        (
+            "Rule: recommended_by=low_sent_pool, "
+            f"last {lookback_days}d, sends >= {min_sends}, "
+            f"explicit down/skip rate > {_pct(skip_rate_threshold)}"
+        ),
+        f"Count: {len(rows)}",
+        (
+            "Review: use "
+            f"<code>/meme {ids}</code> in the moderator chat; "
+            "reject/snooze only after manual inspection. No recommendation traffic changed."
+        ),
+        "",
+    ]
+
+    for row in rows[:10]:
+        action_state = (
+            "already_rejected_or_snoozed" if row["already_rejected_or_snoozed"] else "needs_review"
+        )
+        source_url = html.escape(str(row["source_url"] or "unknown"))
+        lines.append(
+            "- "
+            f"#{row['meme_id']} "
+            f"source=#{row['meme_source_id']}:{html.escape(str(row['source_type']))} "
+            f"meme_status={html.escape(str(row['meme_status']))} "
+            f"source_status={html.escape(str(row['source_status']))} "
+            f"action={action_state} "
+            f"sends={row['sends']} "
+            f"reactions={row['explicit_reactions']} "
+            f"likes={row['likes']} "
+            f"skips={row['skips']} "
+            f"like_rate={_pct(row['like_rate'])} "
+            f"skip_rate={_pct(row['skip_rate'])} "
+            f"age_days={row['published_age_days']:.1f} "
+            f"last_sent={html.escape(str(row['last_sent_at']))} "
+            f"<code>{source_url}</code>"
+        )
+
+    if len(rows) > 10:
+        lines.append(f"...and {len(rows) - 10} more; rerun the flow with a larger limit.")
+
+    return "\n".join(lines)
+
+
+@flow(
+    name="Alert low_sent_pool skip rate",
+    retries=1,
+    retry_delay_seconds=60,
+    timeout_seconds=180,
+    on_failure=[notify_telegram_on_failure],
+)
+async def alert_low_sent_pool_skip_rate(
+    skip_rate_threshold: float = meme.LOW_SENT_POOL_SKIP_RATE_ALERT_THRESHOLD,
+    min_sends: int = meme.LOW_SENT_POOL_SKIP_RATE_ALERT_MIN_SENDS,
+    lookback_days: int = meme.LOW_SENT_POOL_SKIP_RATE_ALERT_LOOKBACK_DAYS,
+    limit: int = meme.LOW_SENT_POOL_SKIP_RATE_ALERT_LIMIT,
+) -> dict:
+    rows = await meme.get_low_sent_pool_skip_rate_alerts(
+        skip_rate_threshold=skip_rate_threshold,
+        min_sends=min_sends,
+        lookback_days=lookback_days,
+        limit=limit,
+    )
+    summary = {
+        "flagged_count": len(rows),
+        "meme_ids": [row["meme_id"] for row in rows],
+        "skip_rate_threshold": skip_rate_threshold,
+        "min_sends": min_sends,
+        "lookback_days": lookback_days,
+    }
+
+    if rows:
+        logger.warning("Flagged %d low_sent_pool memes for skip-rate review", len(rows))
+        await log(
+            _format_low_sent_pool_skip_rate_alert(
+                rows,
+                skip_rate_threshold=skip_rate_threshold,
+                min_sends=min_sends,
+                lookback_days=lookback_days,
+            )
+        )
+
+    safe_emit(
+        "ff.stats.low_sent_pool_skip_rate_alert.completed",
+        "ff.stats.low_sent_pool_skip_rate_alert",
+        summary,
+    )
+    return summary

--- a/src/stats/meme.py
+++ b/src/stats/meme.py
@@ -6,6 +6,11 @@ from src.database import execute, fetch_all
 
 logger = logging.getLogger(__name__)
 
+LOW_SENT_POOL_SKIP_RATE_ALERT_THRESHOLD = 0.5
+LOW_SENT_POOL_SKIP_RATE_ALERT_MIN_SENDS = 10
+LOW_SENT_POOL_SKIP_RATE_ALERT_LOOKBACK_DAYS = 7
+LOW_SENT_POOL_SKIP_RATE_ALERT_LIMIT = 20
+
 
 async def calculate_meme_reactions_and_engagement(
     min_user_reactions: int = 10,
@@ -174,6 +179,94 @@ async def calculate_meme_reactions_and_engagement(
             "min_user_reactions": min_user_reactions,
             "min_meme_reactions": min_meme_reactions,
             "lookback_hours": lookback_hours,
+        },
+    )
+
+
+async def get_low_sent_pool_skip_rate_alerts(
+    skip_rate_threshold: float = LOW_SENT_POOL_SKIP_RATE_ALERT_THRESHOLD,
+    min_sends: int = LOW_SENT_POOL_SKIP_RATE_ALERT_MIN_SENDS,
+    lookback_days: int = LOW_SENT_POOL_SKIP_RATE_ALERT_LOOKBACK_DAYS,
+    limit: int = LOW_SENT_POOL_SKIP_RATE_ALERT_LIMIT,
+) -> list[dict]:
+    """Return low_sent_pool memes whose explicit down/skip rate is above threshold.
+
+    This is a shadow guardrail only. It reads historical delivery/reaction rows
+    and intentionally does not update meme status or recommendation eligibility.
+    """
+
+    query = """
+        WITH LOW_SENT_REACTIONS AS (
+            SELECT
+                R.meme_id,
+                COUNT(*) AS sends,
+                COUNT(*) FILTER (WHERE R.reaction_id = 1) AS likes,
+                COUNT(*) FILTER (WHERE R.reaction_id = 2) AS skips,
+                COUNT(*) FILTER (WHERE R.reaction_id IS NOT NULL) AS explicit_reactions,
+                MIN(R.sent_at) AS first_sent_at,
+                MAX(R.sent_at) AS last_sent_at
+            FROM user_meme_reaction R
+            WHERE R.recommended_by = 'low_sent_pool'
+                AND R.sent_at >= NOW() - (:lookback_days * INTERVAL '1 day')
+            GROUP BY R.meme_id
+        )
+        SELECT
+            M.id AS meme_id,
+            M.status AS meme_status,
+            M.meme_source_id,
+            M.published_at,
+            MS.type AS source_type,
+            MS.status AS source_status,
+            CASE
+                WHEN MS.type = 'telegram' AND MRT.post_id IS NOT NULL
+                    THEN MS.url || '/' || MRT.post_id
+                WHEN MS.type = 'vk' AND MRV.url IS NOT NULL
+                    THEN MRV.url
+                WHEN MS.type = 'instagram' AND MRI.url IS NOT NULL
+                    THEN MRI.url
+                ELSE MS.url
+            END AS source_url,
+            LSR.sends,
+            LSR.likes,
+            LSR.skips,
+            LSR.explicit_reactions,
+            LSR.first_sent_at,
+            LSR.last_sent_at,
+            EXTRACT(EPOCH FROM (NOW() - M.published_at)) / 86400.0 AS published_age_days,
+            (LSR.likes::float / NULLIF(LSR.explicit_reactions, 0)) AS like_rate,
+            (LSR.skips::float / NULLIF(LSR.explicit_reactions, 0)) AS skip_rate,
+            (
+                M.status IN ('rejected', 'snoozed')
+                OR MS.status = 'snoozed'
+            ) AS already_rejected_or_snoozed
+        FROM LOW_SENT_REACTIONS LSR
+        INNER JOIN meme M
+            ON M.id = LSR.meme_id
+        INNER JOIN meme_source MS
+            ON MS.id = M.meme_source_id
+        LEFT JOIN meme_raw_telegram MRT
+            ON MS.type = 'telegram' AND MRT.id = M.raw_meme_id
+        LEFT JOIN meme_raw_vk MRV
+            ON MS.type = 'vk' AND MRV.id = M.raw_meme_id
+        LEFT JOIN meme_raw_ig MRI
+            ON MS.type = 'instagram' AND MRI.id = M.raw_meme_id
+        WHERE LSR.sends >= :min_sends
+            AND LSR.explicit_reactions > 0
+            AND (LSR.skips::float / NULLIF(LSR.explicit_reactions, 0)) > :skip_rate_threshold
+        ORDER BY
+            already_rejected_or_snoozed ASC,
+            skip_rate DESC,
+            sends DESC,
+            meme_id ASC
+        LIMIT :limit
+    """
+    return await fetch_all(
+        text(query),
+        {
+            "skip_rate_threshold": skip_rate_threshold,
+            "min_sends": min_sends,
+            "lookback_days": lookback_days,
+            "limit": limit,
         },
     )
 

--- a/tests/stats/test_low_sent_pool_skip_alerts.py
+++ b/tests/stats/test_low_sent_pool_skip_alerts.py
@@ -1,0 +1,155 @@
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncConnection
+from tests.factories import (
+    cleanup_test_data,
+    create_meme,
+    create_meme_source,
+    create_reaction,
+    create_user,
+)
+
+from src.database import engine
+from src.flows.stats.meme import _format_low_sent_pool_skip_rate_alert
+from src.stats.meme import get_low_sent_pool_skip_rate_alerts
+
+
+@pytest_asyncio.fixture()
+async def conn():
+    async with engine.connect() as conn:
+        await cleanup_test_data(conn)
+        yield conn
+        await cleanup_test_data(conn)
+
+
+async def _create_low_sent_reactions(
+    conn: AsyncConnection,
+    meme_id: int,
+    reaction_ids: list[int | None],
+    *,
+    user_id_start: int,
+    recommended_by: str = "low_sent_pool",
+) -> None:
+    sent_at = datetime.utcnow() - timedelta(hours=1)
+    for idx, reaction_id in enumerate(reaction_ids):
+        user_id = user_id_start + idx
+        await create_user(conn, id=user_id)
+        await create_reaction(
+            conn,
+            user_id=user_id,
+            meme_id=meme_id,
+            reaction_id=reaction_id,
+            recommended_by=recommended_by,
+            sent_at=sent_at + timedelta(seconds=idx),
+            reacted_at=(sent_at + timedelta(seconds=idx + 5) if reaction_id is not None else None),
+        )
+    await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_low_sent_skip_alert_flags_only_strictly_above_threshold(
+    conn: AsyncConnection,
+) -> None:
+    await create_meme_source(conn, id=10001)
+    await create_meme(conn, id=10001, meme_source_id=10001)
+    await create_meme(conn, id=10002, meme_source_id=10001)
+    await create_meme(conn, id=10003, meme_source_id=10001)
+    await conn.commit()
+
+    await _create_low_sent_reactions(
+        conn,
+        10001,
+        [2, 2, 2, 2, 2, 2, 1, 1, 1, 1],
+        user_id_start=11000,
+    )
+    await _create_low_sent_reactions(
+        conn,
+        10002,
+        [2, 2, 2, 2, 2, 1, 1, 1, 1, 1],
+        user_id_start=11100,
+    )
+    await _create_low_sent_reactions(
+        conn,
+        10003,
+        [2, 2, 2, 2, 2, 2, 1, 1, 1, 1],
+        user_id_start=11200,
+        recommended_by="goat",
+    )
+
+    rows = await get_low_sent_pool_skip_rate_alerts(
+        skip_rate_threshold=0.5,
+        min_sends=10,
+        lookback_days=7,
+        limit=10,
+    )
+
+    assert [row["meme_id"] for row in rows] == [10001]
+    row = rows[0]
+    assert row["sends"] == 10
+    assert row["explicit_reactions"] == 10
+    assert row["likes"] == 4
+    assert row["skips"] == 6
+    assert row["like_rate"] == pytest.approx(0.4)
+    assert row["skip_rate"] == pytest.approx(0.6)
+    assert row["already_rejected_or_snoozed"] is False
+
+
+@pytest.mark.asyncio
+async def test_low_sent_skip_alert_includes_already_actioned_metadata(
+    conn: AsyncConnection,
+) -> None:
+    await create_meme_source(conn, id=10011, status="snoozed")
+    await create_meme(conn, id=10011, meme_source_id=10011, status="rejected")
+    await conn.commit()
+
+    await _create_low_sent_reactions(
+        conn,
+        10011,
+        [2, 2, 1],
+        user_id_start=11300,
+    )
+
+    rows = await get_low_sent_pool_skip_rate_alerts(
+        skip_rate_threshold=0.5,
+        min_sends=3,
+        lookback_days=7,
+        limit=10,
+    )
+
+    assert [row["meme_id"] for row in rows] == [10011]
+    assert rows[0]["meme_status"] == "rejected"
+    assert rows[0]["source_status"] == "snoozed"
+    assert rows[0]["already_rejected_or_snoozed"] is True
+
+
+def test_low_sent_alert_message_points_moderators_to_manual_review() -> None:
+    message = _format_low_sent_pool_skip_rate_alert(
+        [
+            {
+                "meme_id": 10001,
+                "meme_source_id": 10002,
+                "source_type": "telegram",
+                "meme_status": "ok",
+                "source_status": "parsing_enabled",
+                "already_rejected_or_snoozed": False,
+                "sends": 10,
+                "explicit_reactions": 10,
+                "likes": 4,
+                "skips": 6,
+                "like_rate": 0.4,
+                "skip_rate": 0.6,
+                "published_age_days": 3.5,
+                "last_sent_at": "2026-05-12 07:00:00",
+                "source_url": "https://t.me/source/123",
+            }
+        ],
+        skip_rate_threshold=0.5,
+        min_sends=10,
+        lookback_days=7,
+    )
+
+    assert "<code>/meme 10001</code>" in message
+    assert "action=needs_review" in message
+    assert "No recommendation traffic changed" in message

--- a/tests/stats/test_low_sent_pool_skip_alerts.py
+++ b/tests/stats/test_low_sent_pool_skip_alerts.py
@@ -12,7 +12,10 @@ from tests.factories import (
 )
 
 from src.database import engine
-from src.flows.stats.meme import _format_low_sent_pool_skip_rate_alert
+from src.flows.stats.meme import (
+    TELEGRAM_LOG_HTML_MESSAGE_LIMIT,
+    _format_low_sent_pool_skip_rate_alert,
+)
 from src.stats.meme import get_low_sent_pool_skip_rate_alerts
 
 
@@ -153,3 +156,40 @@ def test_low_sent_alert_message_points_moderators_to_manual_review() -> None:
     assert "<code>/meme 10001</code>" in message
     assert "action=needs_review" in message
     assert "No recommendation traffic changed" in message
+
+
+def test_low_sent_alert_message_stays_valid_html_under_log_truncation_limit() -> None:
+    long_url = "https://example.com/" + '&<>"' * 1000
+    rows = [
+        {
+            "meme_id": 10000 + idx,
+            "meme_source_id": 20000 + idx,
+            "source_type": "telegram",
+            "meme_status": "ok",
+            "source_status": "parsing_enabled",
+            "already_rejected_or_snoozed": False,
+            "sends": 10 + idx,
+            "explicit_reactions": 10 + idx,
+            "likes": 1,
+            "skips": 9 + idx,
+            "like_rate": 0.1,
+            "skip_rate": 0.9,
+            "published_age_days": 3.5,
+            "last_sent_at": "2026-05-12 07:00:00",
+            "source_url": long_url,
+        }
+        for idx in range(20)
+    ]
+
+    message = _format_low_sent_pool_skip_rate_alert(
+        rows,
+        skip_rate_threshold=0.5,
+        min_sends=10,
+        lookback_days=7,
+    )
+
+    assert len(message) < TELEGRAM_LOG_HTML_MESSAGE_LIMIT
+    assert message.count("<code>") == message.count("</code>")
+    assert "<code>https://example.com/" in message
+    assert "&amp;" in message
+    assert "...and " in message


### PR DESCRIPTION
Fixes FFM-1225.

## What changed
- Adds a shadow stats query for `low_sent_pool` memes with strict explicit down/skip rate > 50% over the last 7 days, guarded by `min_sends=10`.
- Adds a daily Prefect deployment, `Alert low_sent_pool skip rate`, scheduled at 07:25 London time.
- Sends flagged rows to `ADMIN_LOGS_CHAT_ID` with meme id, source, sends, explicit reactions, like rate, skip/down rate, published age, last sent time, and whether the meme/source is already rejected or snoozed.
- Points moderators to `/meme <ids>` for manual inspection. This does not change recommendation weights or hide content.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `ruff check src/ tests/ && ruff format --check src/ tests/`
- `python3 -m compileall src/stats/meme.py src/flows/stats/meme.py tests/stats/test_low_sent_pool_skip_alerts.py`

## Test caveat
- `python3 -m pytest tests/stats/test_low_sent_pool_skip_alerts.py -q` could not complete locally because this runner has no Docker binary and no Postgres listening on `localhost:5432`. The formatter-only test passed before the DB setup errors; CI should run the SQL-backed integration tests with the normal Postgres service.

## Moderator action
When the alert appears in admin logs, moderators should run `/meme <ids>` in the moderator chat, inspect the actual content, then reject or snooze only if the meme/source is genuinely bad. Treat the alert as a review queue, not an automatic quality verdict.