### PR TITLE
Add meme like count experiment

### DIFF
--- a/alembic/versions/2026-05-12_meme_like_count_experiment.py
+++ b/alembic/versions/2026-05-12_meme_like_count_experiment.py
@@ -1,0 +1,157 @@
+"""meme like count experiment measurement views
+
+Revision ID: 3d9b4f6a2c10
+Revises: 9f0a1b2c3d4e
+Create Date: 2026-05-12 18:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3d9b4f6a2c10"
+down_revision = "9f0a1b2c3d4e"
+branch_labels = None
+depends_on = None
+
+
+EXPERIMENT_ID = "meme_like_count"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            CREATE VIEW v_meme_like_count_experiment_results AS
+            WITH assignment AS (
+                SELECT
+                    user_id,
+                    variant,
+                    assigned_at,
+                    COALESCE(
+                        (assignment_metadata->>'min_visible_likes')::int,
+                        5
+                    ) AS min_visible_likes
+                FROM experiment_assignment
+                WHERE experiment_id = '{EXPERIMENT_ID}'
+                    AND variant IN ('control', 'treatment')
+            ),
+            feed_events AS (
+                SELECT
+                    a.variant,
+                    a.user_id,
+                    r.meme_id,
+                    r.recommended_by,
+                    r.sent_at,
+                    r.reaction_id,
+                    r.reacted_at,
+                    COALESCE(ms.nlikes, 0) AS current_nlikes,
+                    a.min_visible_likes,
+                    LEAD(r.sent_at) OVER (
+                        PARTITION BY a.user_id
+                        ORDER BY r.sent_at
+                    ) AS next_sent_at
+                FROM assignment a
+                INNER JOIN user_meme_reaction r
+                    ON r.user_id = a.user_id
+                    AND r.sent_at >= a.assigned_at
+                LEFT JOIN meme_stats ms
+                    ON ms.meme_id = r.meme_id
+            ),
+            per_user AS (
+                SELECT
+                    variant,
+                    user_id,
+                    COUNT(*) AS memes_sent,
+                    COUNT(reaction_id) AS explicit_reactions,
+                    COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+                    COUNT(*) FILTER (WHERE reaction_id = 2) AS dislikes
+                FROM feed_events
+                GROUP BY variant, user_id
+            ),
+            event_rollup AS (
+                SELECT
+                    a.variant,
+                    COUNT(DISTINCT a.user_id) AS assigned_users,
+                    COUNT(DISTINCT fe.user_id) AS active_users,
+                    COUNT(fe.meme_id) AS memes_sent,
+                    COUNT(fe.reaction_id) AS explicit_reactions,
+                    COUNT(fe.meme_id) FILTER (
+                        WHERE fe.current_nlikes >= fe.min_visible_likes
+                    ) AS current_threshold_eligible_events,
+                    COUNT(fe.reaction_id) FILTER (
+                        WHERE fe.current_nlikes >= fe.min_visible_likes
+                    ) AS current_threshold_eligible_reactions,
+                    COUNT(*) FILTER (WHERE fe.reaction_id = 1) AS likes,
+                    COUNT(*) FILTER (WHERE fe.reaction_id = 2) AS dislikes,
+                    ROUND(
+                        100.0 * COUNT(*) FILTER (WHERE fe.reaction_id = 1)
+                        / NULLIF(COUNT(fe.reaction_id), 0),
+                        1
+                    ) AS like_rate_pct,
+                    ROUND(
+                        100.0 * COUNT(fe.reaction_id)
+                        / NULLIF(COUNT(fe.meme_id), 0),
+                        1
+                    ) AS explicit_reaction_rate_pct,
+                    COUNT(fe.meme_id) FILTER (
+                        WHERE fe.next_sent_at IS NOT NULL
+                            AND fe.next_sent_at - fe.sent_at <= INTERVAL '30 minutes'
+                    ) AS continuation_events,
+                    ROUND(
+                        100.0 * COUNT(fe.meme_id) FILTER (
+                            WHERE fe.next_sent_at IS NOT NULL
+                                AND fe.next_sent_at - fe.sent_at <= INTERVAL '30 minutes'
+                        ) / NULLIF(COUNT(fe.meme_id), 0),
+                        1
+                    ) AS continuation_rate_pct
+                FROM assignment a
+                LEFT JOIN feed_events fe
+                    ON fe.user_id = a.user_id
+                    AND fe.variant = a.variant
+                GROUP BY a.variant
+            ),
+            user_rollup AS (
+                SELECT
+                    variant,
+                    PERCENTILE_CONT(0.5) WITHIN GROUP (
+                        ORDER BY memes_sent
+                    ) AS median_memes_sent_per_user,
+                    PERCENTILE_CONT(0.5) WITHIN GROUP (
+                        ORDER BY explicit_reactions
+                    ) AS median_reactions_per_user
+                FROM per_user
+                GROUP BY variant
+            )
+            SELECT
+                er.*,
+                ur.median_memes_sent_per_user,
+                ur.median_reactions_per_user
+            FROM event_rollup er
+            LEFT JOIN user_rollup ur
+                ON ur.variant = er.variant
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+            CREATE VIEW v_meme_like_count_experiment_sample_gate AS
+            SELECT
+                variant,
+                COUNT(*) AS assigned_users,
+                COUNT(*) >= 1000 AS sample_gate_met
+            FROM experiment_assignment
+            WHERE experiment_id = '{EXPERIMENT_ID}'
+                AND variant IN ('control', 'treatment')
+            GROUP BY variant
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP VIEW IF EXISTS v_meme_like_count_experiment_sample_gate"))
+    op.execute(sa.text("DROP VIEW IF EXISTS v_meme_like_count_experiment_results"))

--- a/specs/experiment-2026-05-12-meme-like-count.md
+++ b/specs/experiment-2026-05-12-meme-like-count.md
@@ -1,0 +1,58 @@
+# Experiment: Meme Like Count in Reaction Button
+
+**Deployed**: 2026-05-12
+
+## What We Changed
+
+Added a user-level A/B experiment for the private meme feed:
+
+| Variant | Like Button |
+|---------|-------------|
+| `control` | Heart only, current behavior |
+| `treatment` | Heart plus like count when `meme_stats.nlikes >= 5` |
+
+Dislike counts stay hidden. Low-count memes stay visually neutral in treatment,
+so fresh or niche memes do not get negative social proof from `0-4` likes.
+
+## Hypothesis
+
+Visible positive social proof may increase:
+- explicit like rate
+- reaction rate
+- session continuation
+
+Main risks:
+- popularity bias toward already-proven memes
+- lower honest preference signal from users who follow the crowd
+- possible interaction with recommendation experiments
+
+## Measurement
+
+Primary read after each variant has at least 1,000 assigned users:
+
+```sql
+SELECT *
+FROM v_meme_like_count_experiment_results
+ORDER BY variant;
+
+SELECT *
+FROM v_meme_like_count_experiment_sample_gate
+ORDER BY variant;
+```
+
+Primary metrics:
+- `like_rate_pct`
+- `explicit_reaction_rate_pct`
+- `continuation_rate_pct`
+- `median_memes_sent_per_user`
+
+Guardrails:
+- treatment like rate must not rise while continuation rate falls meaningfully
+- treatment must not reduce explicit reaction rate
+- check fresh/low-like meme exposure separately if popularity concentration rises
+
+## Rollback
+
+Disable the experiment by returning `control` from
+`get_visible_meme_like_count()`, or revert the implementation. The migration only
+adds read-only measurement views.

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -39,6 +39,7 @@ async def best_uploaded_memes(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'best_uploaded_memes' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -84,6 +85,7 @@ async def like_spread_and_recent_memes(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'like_spread_and_recent' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -134,6 +136,7 @@ async def get_lr_smoothed(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'lr_smoothed' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -186,6 +189,7 @@ async def get_es_ranked(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'es_ranked' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -244,6 +248,7 @@ async def goat(
         WITH SCORES AS MATERIALIZED (
             SELECT
                 MS.meme_id,
+                MS.nlikes,
                 (
                     1.0
                     * (MS.nlikes - MS.ndislikes)::float / (MS.nmemes_sent + 1)
@@ -279,6 +284,7 @@ async def goat(
             M.id
            , M.type, M.telegram_file_id, M.caption
            , 'goat' AS recommended_by
+           , COALESCE(SCORES.nlikes, 0) AS nlikes
         FROM meme M
         INNER JOIN SCORES
             ON SCORES.meme_id = M.id
@@ -320,10 +326,13 @@ async def get_recently_liked(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'recently_liked' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM CANDIDATES C
         INNER JOIN meme M
             ON M.id = C.id
+        LEFT JOIN meme_stats MS
+            ON MS.meme_id = M.id
 
         INNER JOIN user_language L
             ON L.language_code = M.language_code
@@ -370,6 +379,7 @@ async def cold_start_explore(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'cold_start_explore' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -430,6 +440,7 @@ async def cold_start_adapt(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'cold_start_adapt' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -122,7 +122,8 @@ async def generate_recommendations(
                 M.type,
                 M.telegram_file_id,
                 M.caption,
-                'low_sent_pool' AS recommended_by
+                'low_sent_pool' AS recommended_by,
+                COALESCE(MS.nlikes, 0) AS nlikes
             FROM meme M
             LEFT JOIN meme_stats MS
                 ON MS.meme_id = M.id
@@ -293,8 +294,11 @@ async def generate_recommendations(
                     M.type,
                     M.telegram_file_id,
                     M.caption,
-                    'last_resort' AS recommended_by
+                    'last_resort' AS recommended_by,
+                    COALESCE(MS.nlikes, 0) AS nlikes
                 FROM meme M
+                LEFT JOIN meme_stats MS
+                    ON MS.meme_id = M.id
                 LEFT JOIN user_meme_reaction R
                     ON R.user_id = :user_id
                     AND R.meme_id = M.id

--- a/src/storage/schemas.py
+++ b/src/storage/schemas.py
@@ -12,6 +12,7 @@ class MemeData(CustomModel):
     telegram_file_id: str
     caption: str | None
     recommended_by: str | None = None
+    nlikes: int = 0
 
     @model_validator(mode="before")
     @classmethod
@@ -19,4 +20,5 @@ class MemeData(CustomModel):
         caption = values.get("caption")
         if caption is not None:
             values["caption"] = caption[:1000]
+        values["nlikes"] = int(values.get("nlikes") or 0)
         return values

--- a/src/tgbot/senders/keyboards.py
+++ b/src/tgbot/senders/keyboards.py
@@ -53,9 +53,11 @@ def meme_reaction_keyboard(
     meme_id: int,
     user_id: int,
     referral_button_text: str,
+    visible_like_count: int | None = None,
 ):
     heart = random.choice(HEART_EMOJI)
-    like, dislike = heart, "⏬"
+    like = f"{heart} {visible_like_count}" if visible_like_count is not None else heart
+    dislike = "⏬"
     # like, dislike = "👍", "👎"
 
     return InlineKeyboardMarkup(

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -21,6 +21,7 @@ from src.tgbot.senders.keyboards import (
     select_referral_button_text,
 )
 from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
+from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
 from src.tgbot.senders.utils import collect_user_languages, has_russian_language
 from src.tgbot.service import mark_user_blocked
 from src.tgbot.user_info import get_user_info
@@ -44,6 +45,7 @@ async def send_meme_to_user(bot: Bot, user_id: int, meme: MemeData):
         meme.id,
         user_id,
         referral_button_text,
+        visible_like_count=await get_visible_meme_like_count(user_id, meme.nlikes),
     )
     meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 

--- a/src/tgbot/senders/meme_like_count_experiment.py
+++ b/src/tgbot/senders/meme_like_count_experiment.py
@@ -1,0 +1,83 @@
+import hashlib
+import logging
+from typing import Any
+
+from src.flows.events import safe_emit
+from src.tgbot.service import assign_experiment, get_experiment_variant
+
+logger = logging.getLogger(__name__)
+
+MEME_LIKE_COUNT_EXPERIMENT_ID = "meme_like_count"
+MEME_LIKE_COUNT_CONTROL = "control"
+MEME_LIKE_COUNT_TREATMENT = "treatment"
+MEME_LIKE_COUNT_MIN_VISIBLE_LIKES = 5
+MEME_LIKE_COUNT_SAMPLE_GATE_PER_VARIANT = 1000
+
+
+def _variant_for_user(user_id: int) -> str:
+    key = f"{MEME_LIKE_COUNT_EXPERIMENT_ID}:{user_id}"
+    bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 2
+    if bucket == 0:
+        return MEME_LIKE_COUNT_CONTROL
+    return MEME_LIKE_COUNT_TREATMENT
+
+
+def build_meme_like_count_assignment(user_id: int) -> tuple[str, dict[str, Any]]:
+    variant = _variant_for_user(user_id)
+    return variant, {
+        "assignment_strategy": "sha256(experiment_id:user_id)%2",
+        "min_visible_likes": MEME_LIKE_COUNT_MIN_VISIBLE_LIKES,
+        "shows_dislikes": False,
+        "button_format": "heart_count_when_like_count_reaches_threshold",
+        "sample_gate_per_variant": MEME_LIKE_COUNT_SAMPLE_GATE_PER_VARIANT,
+    }
+
+
+async def get_or_assign_meme_like_count_variant(user_id: int) -> str:
+    variant = await get_experiment_variant(user_id, MEME_LIKE_COUNT_EXPERIMENT_ID)
+    if variant is not None:
+        return variant
+
+    proposed, metadata = build_meme_like_count_assignment(user_id)
+    inserted = await assign_experiment(
+        user_id,
+        MEME_LIKE_COUNT_EXPERIMENT_ID,
+        proposed,
+        metadata,
+    )
+    if inserted:
+        safe_emit(
+            f"ff.experiment.{MEME_LIKE_COUNT_EXPERIMENT_ID}.evaluated",
+            f"user.{user_id}",
+            {
+                "user_id": user_id,
+                "group": proposed,
+                "min_visible_likes": MEME_LIKE_COUNT_MIN_VISIBLE_LIKES,
+            },
+        )
+        return proposed
+
+    return (
+        await get_experiment_variant(user_id, MEME_LIKE_COUNT_EXPERIMENT_ID)
+        or MEME_LIKE_COUNT_CONTROL
+    )
+
+
+async def get_visible_meme_like_count(user_id: int, nlikes: int | None) -> int | None:
+    try:
+        variant = await get_or_assign_meme_like_count_variant(user_id)
+    except Exception:
+        logger.warning(
+            "meme like-count experiment assignment failed for user %d",
+            user_id,
+            exc_info=True,
+        )
+        return None
+
+    if variant != MEME_LIKE_COUNT_TREATMENT:
+        return None
+
+    like_count = int(nlikes or 0)
+    if like_count < MEME_LIKE_COUNT_MIN_VISIBLE_LIKES:
+        return None
+    return like_count

--- a/src/tgbot/senders/next_message.py
+++ b/src/tgbot/senders/next_message.py
@@ -24,6 +24,7 @@ from src.tgbot.senders.meme import (
     send_new_message_with_meme,
 )
 from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
+from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
 from src.tgbot.senders.popups import (
     get_or_assign_first_meme_nudge_variant,
     get_popup_to_send,
@@ -109,6 +110,7 @@ async def next_message(
             meme.id,
             user_id,
             referral_button_text,
+            visible_like_count=await get_visible_meme_like_count(user_id, meme.nlikes),
         )
         meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 

--- a/tests/recommendations/test_engine_contracts.py
+++ b/tests/recommendations/test_engine_contracts.py
@@ -172,7 +172,7 @@ async def test_returns_required_fields(base_data, engine_name):
     results = await retriever.get_candidates(engine_name, USER_ID, limit=50)
     if len(results) == 0:
         pytest.skip(f"{engine_name} returned no results")
-    required = {"id", "type", "telegram_file_id", "recommended_by"}
+    required = {"id", "type", "telegram_file_id", "recommended_by", "nlikes"}
     for r in results:
         missing = required - set(r.keys())
         assert not missing, f"{engine_name} missing fields: {missing}"

--- a/tests/recommendations/test_queue_correctness.py
+++ b/tests/recommendations/test_queue_correctness.py
@@ -63,6 +63,7 @@ def _meme(id: int, recommended_by: str = "test") -> dict:
         "telegram_file_id": f"file_{id}",
         "caption": None,
         "recommended_by": recommended_by,
+        "nlikes": 10,
     }
 
 
@@ -206,7 +207,7 @@ async def test_moderator_gets_low_sent_pool(queue_user):
 
 @pytest.mark.asyncio
 async def test_queue_memes_have_required_fields(queue_user):
-    """Memes in queue should have id, type, telegram_file_id, recommended_by."""
+    """Memes in queue should have fields needed to send and render buttons."""
     stub = _make_stub_retriever(
         {
             "lr_smoothed": [_meme(20001, "lr_smoothed")],
@@ -218,6 +219,7 @@ async def test_queue_memes_have_required_fields(queue_user):
         assert "id" in c
         assert "type" in c or True  # stub has type
         assert "recommended_by" in c
+        assert "nlikes" in c
 
 
 @pytest.mark.asyncio

--- a/tests/test_experiment_assignment.py
+++ b/tests/test_experiment_assignment.py
@@ -140,3 +140,24 @@ async def test_recently_liked_blender_v2_measurement_views_exist():
         assert "recommended_by" in engine_columns
         assert "allocation_pct" in engine_columns
         assert "continuation_rate_pct" in engine_columns
+
+
+@pytest.mark.asyncio
+async def test_meme_like_count_measurement_views_exist():
+    """The like-count experiment has direct result and sample-gate views."""
+    async with engine.begin() as conn:
+        results = await conn.execute(
+            text("SELECT * FROM v_meme_like_count_experiment_results LIMIT 1")
+        )
+        result_columns = list(results.keys())
+        assert "assigned_users" in result_columns
+        assert "current_threshold_eligible_events" in result_columns
+        assert "explicit_reaction_rate_pct" in result_columns
+        assert "continuation_rate_pct" in result_columns
+
+        sample_gate = await conn.execute(
+            text("SELECT * FROM v_meme_like_count_experiment_sample_gate LIMIT 1")
+        )
+        sample_gate_columns = list(sample_gate.keys())
+        assert "assigned_users" in sample_gate_columns
+        assert "sample_gate_met" in sample_gate_columns

--- a/tests/tgbot/test_meme_like_count_experiment.py
+++ b/tests/tgbot/test_meme_like_count_experiment.py
@@ -1,0 +1,87 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.tgbot.senders import meme_like_count_experiment as experiment
+from src.tgbot.senders.keyboards import meme_reaction_keyboard
+
+
+def _button_texts(markup) -> list[str]:
+    return [button.text for row in markup.inline_keyboard for button in row]
+
+
+def test_keyboard_keeps_like_button_plain_without_visible_count(monkeypatch):
+    monkeypatch.setattr("src.tgbot.senders.keyboards.random.choice", lambda hearts: "❤️")
+
+    markup = meme_reaction_keyboard(
+        meme_id=1,
+        user_id=2,
+        referral_button_text="Memes",
+        visible_like_count=None,
+    )
+
+    assert _button_texts(markup) == ["❤️", "⏬"]
+
+
+def test_keyboard_renders_visible_like_count(monkeypatch):
+    monkeypatch.setattr("src.tgbot.senders.keyboards.random.choice", lambda hearts: "❤️")
+
+    markup = meme_reaction_keyboard(
+        meme_id=1,
+        user_id=2,
+        referral_button_text="Memes",
+        visible_like_count=12,
+    )
+
+    assert _button_texts(markup) == ["❤️ 12", "⏬"]
+
+
+def test_like_count_assignment_is_stable():
+    first = experiment.build_meme_like_count_assignment(123)
+    second = experiment.build_meme_like_count_assignment(123)
+
+    assert first == second
+    assert first[0] in {
+        experiment.MEME_LIKE_COUNT_CONTROL,
+        experiment.MEME_LIKE_COUNT_TREATMENT,
+    }
+    assert first[1]["min_visible_likes"] == experiment.MEME_LIKE_COUNT_MIN_VISIBLE_LIKES
+    assert first[1]["shows_dislikes"] is False
+
+
+@pytest.mark.asyncio
+async def test_visible_like_count_is_hidden_for_control():
+    with patch(
+        "src.tgbot.senders.meme_like_count_experiment.get_or_assign_meme_like_count_variant",
+        new_callable=AsyncMock,
+        return_value=experiment.MEME_LIKE_COUNT_CONTROL,
+    ):
+        visible = await experiment.get_visible_meme_like_count(123, 50)
+
+    assert visible is None
+
+
+@pytest.mark.asyncio
+async def test_visible_like_count_uses_threshold_for_treatment():
+    with patch(
+        "src.tgbot.senders.meme_like_count_experiment.get_or_assign_meme_like_count_variant",
+        new_callable=AsyncMock,
+        return_value=experiment.MEME_LIKE_COUNT_TREATMENT,
+    ):
+        below_threshold = await experiment.get_visible_meme_like_count(123, 4)
+        at_threshold = await experiment.get_visible_meme_like_count(123, 5)
+
+    assert below_threshold is None
+    assert at_threshold == 5
+
+
+@pytest.mark.asyncio
+async def test_assignment_error_falls_back_to_hidden_count():
+    with patch(
+        "src.tgbot.senders.meme_like_count_experiment.get_or_assign_meme_like_count_variant",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("db unavailable"),
+    ):
+        visible = await experiment.get_visible_meme_like_count(123, 50)
+
+    assert visible is None


### PR DESCRIPTION
## Summary
- add a separate meme_like_count A/B experiment for private-feed like-button counts
- show like counts only in treatment and only when meme_stats.nlikes >= 5
- add nlikes to recommendation payloads and measurement views for experiment readout

## Tests
- ruff check src/tgbot/senders/meme_like_count_experiment.py src/tgbot/senders/keyboards.py src/tgbot/senders/next_message.py src/tgbot/senders/meme.py src/storage/schemas.py src/recommendations/candidates.py src/recommendations/meme_queue.py tests/tgbot/test_meme_like_count_experiment.py tests/test_experiment_assignment.py tests/recommendations/test_engine_contracts.py tests/recommendations/test_queue_correctness.py
- pytest tests/tgbot/test_meme_like_count_experiment.py tests/recommendations/test_meme_queue.py -q

DB-backed tests were not run locally because the default local DATABASE_URL points at app_db, which is unavailable outside compose; CI provides Postgres.