### PR TITLE
Add meme like count experiment and moderator source voting docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,62 @@
+# Domain Context
+
+## Share Attribution
+
+Telegram bot-sent meme messages do not expose a native forward/share event to the
+bot. If a user forwards a meme message to another chat, the backend cannot
+observe that forwarding action directly.
+
+Bot meme forwarding is inferred only when someone clicks the deep link embedded
+under the forwarded meme. The in-bot meme link format is
+`s_{sharer_user_id}_{meme_id}`. A `/start s_...` event means a user clicked a
+link under a shared meme; it does not prove how many times the original bot
+message was forwarded.
+
+For Telegram channel posts, separate channel analytics can observe post-level
+views and forwards. Those channel post metrics are distinct from private bot
+feed share attribution.
+
+Use these terms consistently:
+
+- Share click: a `/start s_{sharer_user_id}_{meme_id}` event recorded in
+  `user_deep_link_log`.
+- Unique share clickers: distinct users who clicked `s_...` links for a meme,
+  including both existing and new users.
+- New-user invite: a newly created user attributed to an inviter through an
+  `s_...` link and recorded on `user.inviter_id`.
+- Meme click conversion: the meme-level count/rate of users who clicked its
+  `s_...` link after it was shared.
+
+## Moderator Community
+
+**Moderator Chat**:
+The community chat for loyal moderators where the bot can run discussion and source-scouting loops.
+_Avoid_: upload review chat, moderation queue
+
+**Upload Review Chat**:
+The operational chat where uploaded memes are approved or rejected.
+_Avoid_: moderator community chat
+
+**Source Candidate**:
+A public meme source discovered or submitted for possible addition to the bot.
+_Avoid_: approved source, trial source
+
+**Source Trial**:
+A temporary parsing/evaluation period for a source that passed an initial community gate.
+_Avoid_: permanent approval
+
+**Telegram Handler Registrar**:
+A feature-level function that registers python-telegram-bot handlers for one product area.
+_Avoid_: router
+
+## Relationships
+
+- A **Source Candidate** may become a **Source Trial** after a moderator-community vote.
+- A **Source Trial** becomes durable only after regular-user feed outcomes are measured.
+- The **Moderator Chat** is for community loops; the **Upload Review Chat** is for upload decisions.
+- A **Telegram Handler Registrar** owns handler registration for one feature area; the FastAPI webhook router remains separate.
+
+## Flagged ambiguities
+
+- "модераторский чат" can mean the community chat or the uploaded-meme review chat. Resolved: use **Moderator Chat** for the community chat and **Upload Review Chat** for uploaded meme review.
+- "router" can mean FastAPI routing or Telegram handler registration. Resolved: use **Telegram Handler Registrar** for python-telegram-bot handler grouping.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,6 +1,6 @@
 # TODOS
 
-> Last updated: 2026-04-20. Items marked ~~strikethrough~~ with "DONE" are completed.
+> Last updated: 2026-05-12. Items marked ~~strikethrough~~ with "DONE" are completed.
 
 ## P1 — High Priority
 
@@ -37,6 +37,12 @@
 **What:** Replace shell script `.git/hooks/pre-commit` with Yelp's `detect-secrets` framework.
 **Why:** Better coverage for public repo, especially when AI agents push code. Current hook has false positives on doc text.
 **Depends on:** Phase 2 (Engineer agent pushing code).
+
+### Audit python-telegram-bot 22.7 best practices and handler layout
+**What:** Review official PTB 22.7 docs/changelog for handler groups, callback query patterns, lifecycle hooks, rate limiting, webhook/polling setup, and any new recommended syntax. Turn the result into a concrete module layout for `src/tgbot/handlers/`.
+**Why:** Source voting and moderator-community features need clearer Telegram handler boundaries without confusing FastAPI routers with Telegram handler registrars.
+**Files:** `src/tgbot/app.py`, `src/tgbot/handlers/`, `src/tgbot/handlers/moderator/registry.py`
+**Depends on:** Moderator community source-voting prototype design.
 
 ### Per-engine session continuation rate
 **What:** SQL query that computes, for each engine: % of times user continued scrolling after seeing that engine's meme.

--- a/alembic/versions/2026-05-12_meme_like_count_experiment.py
+++ b/alembic/versions/2026-05-12_meme_like_count_experiment.py
@@ -1,7 +1,7 @@
 """meme like count experiment measurement views
 
 Revision ID: 3d9b4f6a2c10
-Revises: 1a2b3c4d5e6f
+Revises: 9f0a1b2c3d4e
 Create Date: 2026-05-12 18:00:00.000000
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "3d9b4f6a2c10"
-down_revision = "1a2b3c4d5e6f"
+down_revision = "9f0a1b2c3d4e"
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/2026-05-12_meme_like_count_experiment.py
+++ b/alembic/versions/2026-05-12_meme_like_count_experiment.py
@@ -1,0 +1,157 @@
+"""meme like count experiment measurement views
+
+Revision ID: 3d9b4f6a2c10
+Revises: 1a2b3c4d5e6f
+Create Date: 2026-05-12 18:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3d9b4f6a2c10"
+down_revision = "1a2b3c4d5e6f"
+branch_labels = None
+depends_on = None
+
+
+EXPERIMENT_ID = "meme_like_count"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            CREATE VIEW v_meme_like_count_experiment_results AS
+            WITH assignment AS (
+                SELECT
+                    user_id,
+                    variant,
+                    assigned_at,
+                    COALESCE(
+                        (assignment_metadata->>'min_visible_likes')::int,
+                        5
+                    ) AS min_visible_likes
+                FROM experiment_assignment
+                WHERE experiment_id = '{EXPERIMENT_ID}'
+                    AND variant IN ('control', 'treatment')
+            ),
+            feed_events AS (
+                SELECT
+                    a.variant,
+                    a.user_id,
+                    r.meme_id,
+                    r.recommended_by,
+                    r.sent_at,
+                    r.reaction_id,
+                    r.reacted_at,
+                    COALESCE(ms.nlikes, 0) AS current_nlikes,
+                    a.min_visible_likes,
+                    LEAD(r.sent_at) OVER (
+                        PARTITION BY a.user_id
+                        ORDER BY r.sent_at
+                    ) AS next_sent_at
+                FROM assignment a
+                INNER JOIN user_meme_reaction r
+                    ON r.user_id = a.user_id
+                    AND r.sent_at >= a.assigned_at
+                LEFT JOIN meme_stats ms
+                    ON ms.meme_id = r.meme_id
+            ),
+            per_user AS (
+                SELECT
+                    variant,
+                    user_id,
+                    COUNT(*) AS memes_sent,
+                    COUNT(reaction_id) AS explicit_reactions,
+                    COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+                    COUNT(*) FILTER (WHERE reaction_id = 2) AS dislikes
+                FROM feed_events
+                GROUP BY variant, user_id
+            ),
+            event_rollup AS (
+                SELECT
+                    a.variant,
+                    COUNT(DISTINCT a.user_id) AS assigned_users,
+                    COUNT(DISTINCT fe.user_id) AS active_users,
+                    COUNT(fe.meme_id) AS memes_sent,
+                    COUNT(fe.reaction_id) AS explicit_reactions,
+                    COUNT(fe.meme_id) FILTER (
+                        WHERE fe.current_nlikes >= fe.min_visible_likes
+                    ) AS current_threshold_eligible_events,
+                    COUNT(fe.reaction_id) FILTER (
+                        WHERE fe.current_nlikes >= fe.min_visible_likes
+                    ) AS current_threshold_eligible_reactions,
+                    COUNT(*) FILTER (WHERE fe.reaction_id = 1) AS likes,
+                    COUNT(*) FILTER (WHERE fe.reaction_id = 2) AS dislikes,
+                    ROUND(
+                        100.0 * COUNT(*) FILTER (WHERE fe.reaction_id = 1)
+                        / NULLIF(COUNT(fe.reaction_id), 0),
+                        1
+                    ) AS like_rate_pct,
+                    ROUND(
+                        100.0 * COUNT(fe.reaction_id)
+                        / NULLIF(COUNT(fe.meme_id), 0),
+                        1
+                    ) AS explicit_reaction_rate_pct,
+                    COUNT(fe.meme_id) FILTER (
+                        WHERE fe.next_sent_at IS NOT NULL
+                            AND fe.next_sent_at - fe.sent_at <= INTERVAL '30 minutes'
+                    ) AS continuation_events,
+                    ROUND(
+                        100.0 * COUNT(fe.meme_id) FILTER (
+                            WHERE fe.next_sent_at IS NOT NULL
+                                AND fe.next_sent_at - fe.sent_at <= INTERVAL '30 minutes'
+                        ) / NULLIF(COUNT(fe.meme_id), 0),
+                        1
+                    ) AS continuation_rate_pct
+                FROM assignment a
+                LEFT JOIN feed_events fe
+                    ON fe.user_id = a.user_id
+                    AND fe.variant = a.variant
+                GROUP BY a.variant
+            ),
+            user_rollup AS (
+                SELECT
+                    variant,
+                    PERCENTILE_CONT(0.5) WITHIN GROUP (
+                        ORDER BY memes_sent
+                    ) AS median_memes_sent_per_user,
+                    PERCENTILE_CONT(0.5) WITHIN GROUP (
+                        ORDER BY explicit_reactions
+                    ) AS median_reactions_per_user
+                FROM per_user
+                GROUP BY variant
+            )
+            SELECT
+                er.*,
+                ur.median_memes_sent_per_user,
+                ur.median_reactions_per_user
+            FROM event_rollup er
+            LEFT JOIN user_rollup ur
+                ON ur.variant = er.variant
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+            CREATE VIEW v_meme_like_count_experiment_sample_gate AS
+            SELECT
+                variant,
+                COUNT(*) AS assigned_users,
+                COUNT(*) >= 1000 AS sample_gate_met
+            FROM experiment_assignment
+            WHERE experiment_id = '{EXPERIMENT_ID}'
+                AND variant IN ('control', 'treatment')
+            GROUP BY variant
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP VIEW IF EXISTS v_meme_like_count_experiment_sample_gate"))
+    op.execute(sa.text("DROP VIEW IF EXISTS v_meme_like_count_experiment_results"))

--- a/specs/experiment-2026-05-12-meme-like-count.md
+++ b/specs/experiment-2026-05-12-meme-like-count.md
@@ -1,0 +1,58 @@
+# Experiment: Meme Like Count in Reaction Button
+
+**Deployed**: 2026-05-12
+
+## What We Changed
+
+Added a user-level A/B experiment for the private meme feed:
+
+| Variant | Like Button |
+|---------|-------------|
+| `control` | Heart only, current behavior |
+| `treatment` | Heart plus like count when `meme_stats.nlikes >= 5` |
+
+Dislike counts stay hidden. Low-count memes stay visually neutral in treatment,
+so fresh or niche memes do not get negative social proof from `0-4` likes.
+
+## Hypothesis
+
+Visible positive social proof may increase:
+- explicit like rate
+- reaction rate
+- session continuation
+
+Main risks:
+- popularity bias toward already-proven memes
+- lower honest preference signal from users who follow the crowd
+- possible interaction with recommendation experiments
+
+## Measurement
+
+Primary read after each variant has at least 1,000 assigned users:
+
+```sql
+SELECT *
+FROM v_meme_like_count_experiment_results
+ORDER BY variant;
+
+SELECT *
+FROM v_meme_like_count_experiment_sample_gate
+ORDER BY variant;
+```
+
+Primary metrics:
+- `like_rate_pct`
+- `explicit_reaction_rate_pct`
+- `continuation_rate_pct`
+- `median_memes_sent_per_user`
+
+Guardrails:
+- treatment like rate must not rise while continuation rate falls meaningfully
+- treatment must not reduce explicit reaction rate
+- check fresh/low-like meme exposure separately if popularity concentration rises
+
+## Rollback
+
+Disable the experiment by returning `control` from
+`get_visible_meme_like_count()`, or revert the implementation. The migration only
+adds read-only measurement views.

--- a/specs/moderator-community-loop.md
+++ b/specs/moderator-community-loop.md
@@ -1,0 +1,292 @@
+# Moderator Community Loop
+
+Date: 2026-05-12
+Status: draft
+
+## Goal
+
+Turn the existing moderator chat into a lightweight source-scouting loop.
+
+The first feature is not general moderation. It is source voting:
+
+1. The bot posts a discovered Telegram source candidate into the moderator chat.
+2. Chat members vote whether this source deserves trial parsing.
+3. Each Telegram user has one current vote per source poll.
+4. A user can change their vote; counters update from unique voters.
+5. After the voting window closes, passing sources enter a controlled trial.
+
+This runs in `TELEGRAM_MODERATOR_CHAT_ID`, not the uploaded-meme review chat.
+
+## Existing Pieces
+
+- `meme_source_candidate`: queue of TG channels discovered from forwarded posts.
+- `/discoveredsources`: private moderator command listing pending candidates.
+- `promote_source_candidate()`: promotes a candidate into `meme_source`.
+- `advance_meme_source()`: shared source transition logic with audit trail.
+- `chat_meme_reaction`: existing "one chat user = one mutable vote" pattern for group meme reactions.
+- `src.tgbot.handlers.moderator.registry.add_moderator_handlers()`: the Telegram handler registrar for moderator-facing bot behavior.
+
+Do not create a generic moderation framework. Keep this feature narrow.
+
+## Handler Boundary
+
+New moderator-community handlers should be registered from `add_moderator_handlers()`, not directly in `src/tgbot/app.py`.
+
+Use "handler registrar" for python-telegram-bot registration code. Do not call this a router in this repo: `src/tgbot/router.py` is the FastAPI webhook router, which is a different concept.
+
+The existing `src/tgbot/app.py` remains the composition root: it builds the application and calls feature registrars in order. Feature modules own their own Telegram handlers.
+
+Moderator-adjacent upload behavior should stay split:
+
+- user-facing meme upload stays in `src/tgbot/handlers/upload`;
+- upload approval/rejection stays tied to the **Upload Review Chat**;
+- source voting and moderator-community source scouting stay under `src/tgbot/handlers/moderator`.
+
+## Data Model
+
+Add two tables.
+
+### `meme_source_candidate_poll`
+
+One row per moderator-chat voting message.
+
+Fields:
+
+- `id integer primary key`
+- `candidate_id integer not null references meme_source_candidate(id) on delete cascade`
+- `chat_id bigint not null`
+- `message_id bigint null`
+- `status string not null default 'draft'`
+- `opened_at timestamp null`
+- `closes_at timestamp not null`
+- `closed_at timestamp null`
+- `result_meme_source_id integer null references meme_source(id) on delete set null`
+- `data jsonb null`
+- `created_at timestamp not null default now()`
+- `updated_at timestamp null`
+
+Statuses:
+
+- `draft`: DB row exists, Telegram message not posted yet.
+- `open`: buttons are live.
+- `passed`: vote passed and candidate was promoted.
+- `rejected`: vote failed and candidate was dismissed.
+- `expired_no_quorum`: not enough unique voters; candidate can be retried later.
+- `cancelled`: bot/admin cancelled the poll.
+
+Indexes:
+
+- `(status, closes_at)` for the finalizer.
+- `candidate_id` for lookup/history.
+- unique `(chat_id, message_id)` where `message_id IS NOT NULL`.
+- partial unique open poll per candidate:
+  `UNIQUE (candidate_id) WHERE status IN ('draft', 'open')`.
+
+Why a poll table exists:
+
+- Need `poll_id` before posting so callback data can be short: `mscv:{poll_id}:1`.
+- Need to track chat message, close time, status, and final trial result.
+- Avoid hiding lifecycle state in `meme_source_candidate.data`.
+
+### `meme_source_candidate_vote`
+
+One row per user per poll. This is the source of truth for unique counters.
+
+Fields:
+
+- `poll_id integer not null references meme_source_candidate_poll(id) on delete cascade`
+- `user_id bigint not null`
+- `vote smallint not null`
+- `created_at timestamp not null default now()`
+- `updated_at timestamp null`
+- primary key `(poll_id, user_id)`
+
+Vote values:
+
+- `1`: add trial
+- `2`: skip
+
+Do not foreign-key `user_id` to `user.id`. The authority here is "pressed a button inside the moderator chat", and some legacy/manual chat members may not have a clean current `user` row. This matches the existing `chat_meme_reaction.user_id` pattern.
+
+Do not store yes/no counters as source-of-truth columns. They are derived:
+
+```sql
+SELECT vote, count(*) AS voters
+FROM meme_source_candidate_vote
+WHERE poll_id = :poll_id
+GROUP BY vote;
+```
+
+This avoids race bugs when a user switches from yes to no.
+
+## Callback Contract
+
+Callback data:
+
+```text
+mscv:{poll_id}:{vote}
+```
+
+Examples:
+
+- `mscv:123:1` means add trial.
+- `mscv:123:2` means skip.
+
+Button labels:
+
+- `✅ Add trial 4`
+- `❌ Skip 1`
+
+The callback handler must:
+
+1. Load the poll.
+2. Ensure `poll.status = 'open'`.
+3. Ensure `now() < poll.closes_at`.
+4. Ensure `update.effective_chat.id = TELEGRAM_MODERATOR_CHAT_ID`.
+5. Ensure callback `chat_id` matches `poll.chat_id`.
+6. Upsert the vote:
+
+```sql
+INSERT INTO meme_source_candidate_vote (poll_id, user_id, vote)
+VALUES (:poll_id, :user_id, :vote)
+ON CONFLICT (poll_id, user_id)
+DO UPDATE SET vote = EXCLUDED.vote, updated_at = now();
+```
+
+7. Recompute unique counts from `meme_source_candidate_vote`.
+8. Edit only the reply markup with refreshed counters.
+9. Answer callback with a short message: `Голос учтен` or `Голос изменен`.
+
+If the poll is closed, answer `Голосование уже закрыто` and do not write.
+
+## Poll Posting Flow
+
+Run from a small scheduled flow or admin command.
+
+1. Select candidates:
+   - `meme_source_candidate.status = 'discovered'`;
+   - no `draft/open` poll exists for the candidate;
+   - no poll was posted for the candidate in the last 7 days;
+   - URL does not already exist in `meme_source`;
+   - order by `times_forwarded DESC, last_seen_at DESC`.
+2. Insert `meme_source_candidate_poll` as `draft`, with `closes_at = now() + interval '24 hours'`.
+3. Send Telegram message to `TELEGRAM_MODERATOR_CHAT_ID` with callback buttons containing the new `poll_id`.
+4. Update poll with `chat_id`, `message_id`, `opened_at`, `status='open'`.
+5. If send fails, mark `status='cancelled'` and keep the candidate discoverable.
+
+Start with 1-3 source polls per day to avoid turning the chat into an ops feed.
+
+Message content should include:
+
+- source URL;
+- `times_forwarded`;
+- when first/last seen;
+- sample source language if known;
+- one-line explanation: "Vote means: give this source trial parsing, not permanent approval."
+
+## Closing Rule
+
+First prototype:
+
+- voting window: 24 hours;
+- quorum: 5 unique voters;
+- pass threshold: yes share >= 70%;
+- admin veto can be added later, but do not block v1 on it.
+
+Outcomes:
+
+- `total < 5`: mark poll `expired_no_quorum`; candidate remains `discovered` but is not reposted for 7 days.
+- `yes / total >= 0.70`: mark poll `passed`; promote and trial-enable the source.
+- otherwise: mark poll `rejected`; dismiss candidate with `dismissed_reason='source_vote:{poll_id}'`.
+
+Do not early-close as soon as five yes votes appear. The first experiment should measure participation across a full day.
+
+## Passing Source Flow
+
+On pass:
+
+1. Call `promote_source_candidate(candidate_id, added_by_user_id=<system/admin id>)`.
+2. Determine language:
+   - preferred: inherit `language_code` from `sample_meme_source_id`;
+   - fallback: leave in `in_moderation` and ask an admin/moderator to choose language.
+3. If language is known, call `advance_meme_source()`:
+   - `moderator_id='source-vote:{poll_id}'`
+   - `language_code=<inherited language>`
+   - `status='parsing_enabled'`
+   - `trigger_parse=True`
+4. Merge vote/trial metadata into `meme_source.data`:
+
+```json
+{
+  "source_vote": {
+    "poll_id": 123,
+    "candidate_id": 90,
+    "chat_id": -1001305866294,
+    "message_id": 456,
+    "yes": 7,
+    "no": 1,
+    "closed_at": "2026-05-12T20:00:00Z"
+  },
+  "trial": {
+    "status": "active",
+    "started_at": "2026-05-12T20:00:00Z",
+    "target_regular_impressions": 300,
+    "min_ok_memes": 20
+  }
+}
+```
+
+5. Update poll `result_meme_source_id`.
+6. Edit the moderator-chat message with final result.
+
+## Trial Measurement
+
+The vote decides whether to test. It does not decide permanent quality.
+
+Evaluate a trial source using regular-user outcomes:
+
+- exclude `user.type IN ('moderator', 'admin')`;
+- minimum sample: 20 ok memes or 300 regular-user impressions;
+- primary metric: source-level regular-user `engagement_score` / `lr_smoothed`;
+- secondary: regular like rate, fast-skip rate, median `sec_to_react`, duplicate/ad rate;
+- compare against sources with the same language and similar recency.
+
+Decision:
+
+- above median comparable source: keep `parsing_enabled`;
+- below p25 comparable source after sample: `snoozed`;
+- no sample yet: keep trial active.
+
+## Why This Shape
+
+This avoids table sprawl:
+
+- `meme_source_candidate` remains discovery queue.
+- `meme_source_candidate_poll` is the chat decision lifecycle.
+- `meme_source_candidate_vote` is the one-user-one-current-vote ledger.
+- `meme_source.data` stores trial metadata after promotion.
+
+It also avoids counter bugs:
+
+- no duplicate votes because `(poll_id, user_id)` is the key;
+- repeated same vote only updates `updated_at`;
+- switching yes to no changes exactly one row;
+- displayed counters are always derived from unique vote rows.
+
+## Prototype Scope
+
+Ship the smallest useful version:
+
+1. Migration + `database.py` table definitions.
+2. Poll posting service for one candidate.
+3. Callback handler with mutable unique votes.
+4. Manual/admin command or small scheduled flow to post 1 source poll.
+5. Finalizer for closed polls.
+6. Basic tests:
+   - repeated same vote does not increase count;
+   - yes -> no changes counts;
+   - non-moderator-chat callback is rejected;
+   - expired poll rejects new votes;
+   - passed poll promotes candidate once.
+
+Do not build weighted scout scores in v1. Record clean votes first; weighting can come after we have data.

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -39,6 +39,7 @@ async def best_uploaded_memes(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'best_uploaded_memes' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -84,6 +85,7 @@ async def like_spread_and_recent_memes(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'like_spread_and_recent' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -134,6 +136,7 @@ async def get_lr_smoothed(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'lr_smoothed' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -186,6 +189,7 @@ async def get_es_ranked(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'es_ranked' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -244,6 +248,7 @@ async def goat(
         WITH SCORES AS MATERIALIZED (
             SELECT
                 MS.meme_id,
+                MS.nlikes,
                 (
                     1.0
                     * (MS.nlikes - MS.ndislikes)::float / (MS.nmemes_sent + 1)
@@ -279,6 +284,7 @@ async def goat(
             M.id
            , M.type, M.telegram_file_id, M.caption
            , 'goat' AS recommended_by
+           , COALESCE(SCORES.nlikes, 0) AS nlikes
         FROM meme M
         INNER JOIN SCORES
             ON SCORES.meme_id = M.id
@@ -320,10 +326,13 @@ async def get_recently_liked(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'recently_liked' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM CANDIDATES C
         INNER JOIN meme M
             ON M.id = C.id
+        LEFT JOIN meme_stats MS
+            ON MS.meme_id = M.id
 
         INNER JOIN user_language L
             ON L.language_code = M.language_code
@@ -370,6 +379,7 @@ async def cold_start_explore(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'cold_start_explore' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS
@@ -430,6 +440,7 @@ async def cold_start_adapt(
             M.id
             , M.type, M.telegram_file_id, M.caption
             , 'cold_start_adapt' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
         INNER JOIN meme_stats MS

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -122,7 +122,8 @@ async def generate_recommendations(
                 M.type,
                 M.telegram_file_id,
                 M.caption,
-                'low_sent_pool' AS recommended_by
+                'low_sent_pool' AS recommended_by,
+                COALESCE(MS.nlikes, 0) AS nlikes
             FROM meme M
             LEFT JOIN meme_stats MS
                 ON MS.meme_id = M.id
@@ -293,8 +294,11 @@ async def generate_recommendations(
                     M.type,
                     M.telegram_file_id,
                     M.caption,
-                    'last_resort' AS recommended_by
+                    'last_resort' AS recommended_by,
+                    COALESCE(MS.nlikes, 0) AS nlikes
                 FROM meme M
+                LEFT JOIN meme_stats MS
+                    ON MS.meme_id = M.id
                 LEFT JOIN user_meme_reaction R
                     ON R.user_id = :user_id
                     AND R.meme_id = M.id

--- a/src/storage/schemas.py
+++ b/src/storage/schemas.py
@@ -12,6 +12,7 @@ class MemeData(CustomModel):
     telegram_file_id: str
     caption: str | None
     recommended_by: str | None = None
+    nlikes: int = 0
 
     @model_validator(mode="before")
     @classmethod
@@ -19,4 +20,5 @@ class MemeData(CustomModel):
         caption = values.get("caption")
         if caption is not None:
             values["caption"] = caption[:1000]
+        values["nlikes"] = int(values.get("nlikes") or 0)
         return values

--- a/src/tgbot/app.py
+++ b/src/tgbot/app.py
@@ -244,8 +244,6 @@ def add_handlers(application: Application) -> None:
         )
     )
 
-    add_moderator_handlers(application)
-
     ############## popup reaction
     application.add_handler(
         CallbackQueryHandler(
@@ -270,6 +268,8 @@ def add_handlers(application: Application) -> None:
             filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
         )
     )
+
+    add_moderator_handlers(application)
 
     ######################
     # broadcast texts

--- a/src/tgbot/app.py
+++ b/src/tgbot/app.py
@@ -21,10 +21,7 @@ from src.tgbot.constants import (
     LANG_SETTINGS_LANG_CHANGE_CALLBACK_PATTERN,
     MEME_BUTTON_CALLBACK_DATA_REGEXP,
     MEME_QUEUE_IS_EMPTY_ALERT_CALLBACK_DATA,
-    MEME_SOURCE_SET_LANG_REGEXP,
-    MEME_SOURCE_SET_STATUS_REGEXP,
     POPUP_BUTTON_CALLBACK_DATA_REGEXP,
-    SOURCE_CANDIDATE_ACTION_REGEXP,
     TELEGRAM_CHANNEL_RU_CHAT_ID,
     TELEGRAM_FEEDBACK_CHAT_ID,
     TELEGRAM_MODERATOR_CHAT_ID,
@@ -68,15 +65,7 @@ from src.tgbot.handlers.chat.send_tokens import (
     reward_active_chat_users,
     send_tokens_to_reply,
 )
-from src.tgbot.handlers.moderator import get_meme, meme_source
-from src.tgbot.handlers.moderator.invite import (
-    MODERATOR_INVITE_CALLBACK_DATA,
-    handle_moderator_invite_callback,
-)
-from src.tgbot.handlers.moderator.source_candidates import (
-    handle_discovered_sources_command,
-    handle_source_candidate_action,
-)
+from src.tgbot.handlers.moderator.registry import add_moderator_handlers
 from src.tgbot.handlers.payments.purchase import (
     PURCHASE_TOKEN_CALLBACK_DATA_REGEXP,
     handle_new_token_purchase_request_callback,
@@ -255,12 +244,7 @@ def add_handlers(application: Application) -> None:
         )
     )
 
-    application.add_handler(
-        CallbackQueryHandler(
-            handle_moderator_invite_callback,
-            pattern=rf"^{MODERATOR_INVITE_CALLBACK_DATA}$",
-        )
-    )
+    add_moderator_handlers(application)
 
     ############## popup reaction
     application.add_handler(
@@ -406,34 +390,6 @@ def add_handlers(application: Application) -> None:
         )
     )
 
-    # meme source management
-    application.add_handlers(
-        [
-            MessageHandler(
-                filters=filters.ChatType.PRIVATE
-                & filters.Regex("^(https://t.me|https://vk.com|https://www.instagram.com)"),
-                callback=meme_source.handle_meme_source_link,
-            ),
-            CallbackQueryHandler(
-                meme_source.handle_meme_source_language_selection,
-                pattern=MEME_SOURCE_SET_LANG_REGEXP,
-            ),
-            CallbackQueryHandler(
-                meme_source.handle_meme_source_change_status,
-                pattern=MEME_SOURCE_SET_STATUS_REGEXP,
-            ),
-            CommandHandler(
-                "discoveredsources",
-                handle_discovered_sources_command,
-                filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
-            ),
-            CallbackQueryHandler(
-                handle_source_candidate_action,
-                pattern=SOURCE_CANDIDATE_ACTION_REGEXP,
-            ),
-        ]
-    )
-
     application.add_handler(
         CallbackQueryHandler(
             alerts.handle_empty_meme_queue_alert,
@@ -455,22 +411,6 @@ def add_handlers(application: Application) -> None:
     )
 
     application.add_error_handler(error.send_stacktrace_to_tg_chat, block=False)
-
-    # show meme / memes by ids
-    application.add_handlers(
-        [
-            CommandHandler(
-                "meme",
-                get_meme.handle_get_meme,
-                filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
-            ),
-            CommandHandler(
-                "show",
-                get_meme.handle_show_memes,
-                filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
-            ),
-        ]
-    )
 
     # show user info
     application.add_handler(

--- a/src/tgbot/handlers/moderator/registry.py
+++ b/src/tgbot/handlers/moderator/registry.py
@@ -1,0 +1,65 @@
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    MessageHandler,
+    filters,
+)
+
+from src.tgbot.constants import (
+    MEME_SOURCE_SET_LANG_REGEXP,
+    MEME_SOURCE_SET_STATUS_REGEXP,
+    SOURCE_CANDIDATE_ACTION_REGEXP,
+)
+from src.tgbot.handlers.moderator import get_meme, meme_source
+from src.tgbot.handlers.moderator.invite import (
+    MODERATOR_INVITE_CALLBACK_DATA,
+    handle_moderator_invite_callback,
+)
+from src.tgbot.handlers.moderator.source_candidates import (
+    handle_discovered_sources_command,
+    handle_source_candidate_action,
+)
+
+
+def add_moderator_handlers(application: Application) -> None:
+    application.add_handlers(
+        [
+            CallbackQueryHandler(
+                handle_moderator_invite_callback,
+                pattern=rf"^{MODERATOR_INVITE_CALLBACK_DATA}$",
+            ),
+            MessageHandler(
+                filters=filters.ChatType.PRIVATE
+                & filters.Regex("^(https://t.me|https://vk.com|https://www.instagram.com)"),
+                callback=meme_source.handle_meme_source_link,
+            ),
+            CallbackQueryHandler(
+                meme_source.handle_meme_source_language_selection,
+                pattern=MEME_SOURCE_SET_LANG_REGEXP,
+            ),
+            CallbackQueryHandler(
+                meme_source.handle_meme_source_change_status,
+                pattern=MEME_SOURCE_SET_STATUS_REGEXP,
+            ),
+            CommandHandler(
+                "discoveredsources",
+                handle_discovered_sources_command,
+                filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
+            ),
+            CallbackQueryHandler(
+                handle_source_candidate_action,
+                pattern=SOURCE_CANDIDATE_ACTION_REGEXP,
+            ),
+            CommandHandler(
+                "meme",
+                get_meme.handle_get_meme,
+                filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
+            ),
+            CommandHandler(
+                "show",
+                get_meme.handle_show_memes,
+                filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
+            ),
+        ]
+    )

--- a/src/tgbot/senders/keyboards.py
+++ b/src/tgbot/senders/keyboards.py
@@ -53,9 +53,11 @@ def meme_reaction_keyboard(
     meme_id: int,
     user_id: int,
     referral_button_text: str,
+    visible_like_count: int | None = None,
 ):
     heart = random.choice(HEART_EMOJI)
-    like, dislike = heart, "⏬"
+    like = f"{heart} {visible_like_count}" if visible_like_count is not None else heart
+    dislike = "⏬"
     # like, dislike = "👍", "👎"
 
     return InlineKeyboardMarkup(

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -21,6 +21,7 @@ from src.tgbot.senders.keyboards import (
     select_referral_button_text,
 )
 from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
+from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
 from src.tgbot.senders.utils import collect_user_languages, has_russian_language
 from src.tgbot.service import mark_user_blocked
 from src.tgbot.user_info import get_user_info
@@ -44,6 +45,7 @@ async def send_meme_to_user(bot: Bot, user_id: int, meme: MemeData):
         meme.id,
         user_id,
         referral_button_text,
+        visible_like_count=await get_visible_meme_like_count(user_id, meme.nlikes),
     )
     meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 

--- a/src/tgbot/senders/meme_like_count_experiment.py
+++ b/src/tgbot/senders/meme_like_count_experiment.py
@@ -1,0 +1,83 @@
+import hashlib
+import logging
+from typing import Any
+
+from src.flows.events import safe_emit
+from src.tgbot.service import assign_experiment, get_experiment_variant
+
+logger = logging.getLogger(__name__)
+
+MEME_LIKE_COUNT_EXPERIMENT_ID = "meme_like_count"
+MEME_LIKE_COUNT_CONTROL = "control"
+MEME_LIKE_COUNT_TREATMENT = "treatment"
+MEME_LIKE_COUNT_MIN_VISIBLE_LIKES = 5
+MEME_LIKE_COUNT_SAMPLE_GATE_PER_VARIANT = 1000
+
+
+def _variant_for_user(user_id: int) -> str:
+    key = f"{MEME_LIKE_COUNT_EXPERIMENT_ID}:{user_id}"
+    bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 2
+    if bucket == 0:
+        return MEME_LIKE_COUNT_CONTROL
+    return MEME_LIKE_COUNT_TREATMENT
+
+
+def build_meme_like_count_assignment(user_id: int) -> tuple[str, dict[str, Any]]:
+    variant = _variant_for_user(user_id)
+    return variant, {
+        "assignment_strategy": "sha256(experiment_id:user_id)%2",
+        "min_visible_likes": MEME_LIKE_COUNT_MIN_VISIBLE_LIKES,
+        "shows_dislikes": False,
+        "button_format": "heart_count_when_like_count_reaches_threshold",
+        "sample_gate_per_variant": MEME_LIKE_COUNT_SAMPLE_GATE_PER_VARIANT,
+    }
+
+
+async def get_or_assign_meme_like_count_variant(user_id: int) -> str:
+    variant = await get_experiment_variant(user_id, MEME_LIKE_COUNT_EXPERIMENT_ID)
+    if variant is not None:
+        return variant
+
+    proposed, metadata = build_meme_like_count_assignment(user_id)
+    inserted = await assign_experiment(
+        user_id,
+        MEME_LIKE_COUNT_EXPERIMENT_ID,
+        proposed,
+        metadata,
+    )
+    if inserted:
+        safe_emit(
+            f"ff.experiment.{MEME_LIKE_COUNT_EXPERIMENT_ID}.evaluated",
+            f"user.{user_id}",
+            {
+                "user_id": user_id,
+                "group": proposed,
+                "min_visible_likes": MEME_LIKE_COUNT_MIN_VISIBLE_LIKES,
+            },
+        )
+        return proposed
+
+    return (
+        await get_experiment_variant(user_id, MEME_LIKE_COUNT_EXPERIMENT_ID)
+        or MEME_LIKE_COUNT_CONTROL
+    )
+
+
+async def get_visible_meme_like_count(user_id: int, nlikes: int | None) -> int | None:
+    try:
+        variant = await get_or_assign_meme_like_count_variant(user_id)
+    except Exception:
+        logger.warning(
+            "meme like-count experiment assignment failed for user %d",
+            user_id,
+            exc_info=True,
+        )
+        return None
+
+    if variant != MEME_LIKE_COUNT_TREATMENT:
+        return None
+
+    like_count = int(nlikes or 0)
+    if like_count < MEME_LIKE_COUNT_MIN_VISIBLE_LIKES:
+        return None
+    return like_count

--- a/src/tgbot/senders/next_message.py
+++ b/src/tgbot/senders/next_message.py
@@ -24,6 +24,7 @@ from src.tgbot.senders.meme import (
     send_new_message_with_meme,
 )
 from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
+from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
 from src.tgbot.senders.popups import (
     get_or_assign_first_meme_nudge_variant,
     get_popup_to_send,
@@ -109,6 +110,7 @@ async def next_message(
             meme.id,
             user_id,
             referral_button_text,
+            visible_like_count=await get_visible_meme_like_count(user_id, meme.nlikes),
         )
         meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 

--- a/tests/recommendations/test_engine_contracts.py
+++ b/tests/recommendations/test_engine_contracts.py
@@ -172,7 +172,7 @@ async def test_returns_required_fields(base_data, engine_name):
     results = await retriever.get_candidates(engine_name, USER_ID, limit=50)
     if len(results) == 0:
         pytest.skip(f"{engine_name} returned no results")
-    required = {"id", "type", "telegram_file_id", "recommended_by"}
+    required = {"id", "type", "telegram_file_id", "recommended_by", "nlikes"}
     for r in results:
         missing = required - set(r.keys())
         assert not missing, f"{engine_name} missing fields: {missing}"

--- a/tests/recommendations/test_queue_correctness.py
+++ b/tests/recommendations/test_queue_correctness.py
@@ -63,6 +63,7 @@ def _meme(id: int, recommended_by: str = "test") -> dict:
         "telegram_file_id": f"file_{id}",
         "caption": None,
         "recommended_by": recommended_by,
+        "nlikes": 10,
     }
 
 
@@ -206,7 +207,7 @@ async def test_moderator_gets_low_sent_pool(queue_user):
 
 @pytest.mark.asyncio
 async def test_queue_memes_have_required_fields(queue_user):
-    """Memes in queue should have id, type, telegram_file_id, recommended_by."""
+    """Memes in queue should have fields needed to send and render buttons."""
     stub = _make_stub_retriever(
         {
             "lr_smoothed": [_meme(20001, "lr_smoothed")],
@@ -218,6 +219,7 @@ async def test_queue_memes_have_required_fields(queue_user):
         assert "id" in c
         assert "type" in c or True  # stub has type
         assert "recommended_by" in c
+        assert "nlikes" in c
 
 
 @pytest.mark.asyncio

--- a/tests/test_experiment_assignment.py
+++ b/tests/test_experiment_assignment.py
@@ -140,3 +140,24 @@ async def test_recently_liked_blender_v2_measurement_views_exist():
         assert "recommended_by" in engine_columns
         assert "allocation_pct" in engine_columns
         assert "continuation_rate_pct" in engine_columns
+
+
+@pytest.mark.asyncio
+async def test_meme_like_count_measurement_views_exist():
+    """The like-count experiment has direct result and sample-gate views."""
+    async with engine.begin() as conn:
+        results = await conn.execute(
+            text("SELECT * FROM v_meme_like_count_experiment_results LIMIT 1")
+        )
+        result_columns = list(results.keys())
+        assert "assigned_users" in result_columns
+        assert "current_threshold_eligible_events" in result_columns
+        assert "explicit_reaction_rate_pct" in result_columns
+        assert "continuation_rate_pct" in result_columns
+
+        sample_gate = await conn.execute(
+            text("SELECT * FROM v_meme_like_count_experiment_sample_gate LIMIT 1")
+        )
+        sample_gate_columns = list(sample_gate.keys())
+        assert "assigned_users" in sample_gate_columns
+        assert "sample_gate_met" in sample_gate_columns

--- a/tests/tgbot/test_meme_like_count_experiment.py
+++ b/tests/tgbot/test_meme_like_count_experiment.py
@@ -1,0 +1,87 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.tgbot.senders import meme_like_count_experiment as experiment
+from src.tgbot.senders.keyboards import meme_reaction_keyboard
+
+
+def _button_texts(markup) -> list[str]:
+    return [button.text for row in markup.inline_keyboard for button in row]
+
+
+def test_keyboard_keeps_like_button_plain_without_visible_count(monkeypatch):
+    monkeypatch.setattr("src.tgbot.senders.keyboards.random.choice", lambda hearts: "❤️")
+
+    markup = meme_reaction_keyboard(
+        meme_id=1,
+        user_id=2,
+        referral_button_text="Memes",
+        visible_like_count=None,
+    )
+
+    assert _button_texts(markup) == ["❤️", "⏬"]
+
+
+def test_keyboard_renders_visible_like_count(monkeypatch):
+    monkeypatch.setattr("src.tgbot.senders.keyboards.random.choice", lambda hearts: "❤️")
+
+    markup = meme_reaction_keyboard(
+        meme_id=1,
+        user_id=2,
+        referral_button_text="Memes",
+        visible_like_count=12,
+    )
+
+    assert _button_texts(markup) == ["❤️ 12", "⏬"]
+
+
+def test_like_count_assignment_is_stable():
+    first = experiment.build_meme_like_count_assignment(123)
+    second = experiment.build_meme_like_count_assignment(123)
+
+    assert first == second
+    assert first[0] in {
+        experiment.MEME_LIKE_COUNT_CONTROL,
+        experiment.MEME_LIKE_COUNT_TREATMENT,
+    }
+    assert first[1]["min_visible_likes"] == experiment.MEME_LIKE_COUNT_MIN_VISIBLE_LIKES
+    assert first[1]["shows_dislikes"] is False
+
+
+@pytest.mark.asyncio
+async def test_visible_like_count_is_hidden_for_control():
+    with patch(
+        "src.tgbot.senders.meme_like_count_experiment.get_or_assign_meme_like_count_variant",
+        new_callable=AsyncMock,
+        return_value=experiment.MEME_LIKE_COUNT_CONTROL,
+    ):
+        visible = await experiment.get_visible_meme_like_count(123, 50)
+
+    assert visible is None
+
+
+@pytest.mark.asyncio
+async def test_visible_like_count_uses_threshold_for_treatment():
+    with patch(
+        "src.tgbot.senders.meme_like_count_experiment.get_or_assign_meme_like_count_variant",
+        new_callable=AsyncMock,
+        return_value=experiment.MEME_LIKE_COUNT_TREATMENT,
+    ):
+        below_threshold = await experiment.get_visible_meme_like_count(123, 4)
+        at_threshold = await experiment.get_visible_meme_like_count(123, 5)
+
+    assert below_threshold is None
+    assert at_threshold == 5
+
+
+@pytest.mark.asyncio
+async def test_assignment_error_falls_back_to_hidden_count():
+    with patch(
+        "src.tgbot.senders.meme_like_count_experiment.get_or_assign_meme_like_count_variant",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("db unavailable"),
+    ):
+        visible = await experiment.get_visible_meme_like_count(123, 50)
+
+    assert visible is None


### PR DESCRIPTION
## Summary
- add meme-like-count experiment assignment/measurement plumbing and SQL view migration
- move moderator-facing Telegram handler registration into a feature registrar
- document the moderator community source-voting prototype and PTB best-practice follow-up

## Verification
- docker compose exec app ruff check src/ tests/
- docker compose exec app ruff format --check src/ tests/
- docker compose exec app pytest tests/ -x -q
- local app healthcheck returned {"status":"ok"}

## Notes
- rebased onto fresh production by cherry-picking only the intended commits
- fixed Alembic down_revision so there is exactly one migration head
