### PR TITLE
Fix: fallback when chat reply target is missing

### DIFF
--- a/src/tgbot/handlers/chat/utils.py
+++ b/src/tgbot/handlers/chat/utils.py
@@ -3,6 +3,12 @@ import asyncio
 from telegram import InlineKeyboardMarkup, Message
 from telegram.error import BadRequest
 
+MESSAGE_TO_REPLY_NOT_FOUND = "Message to be replied not found"
+
+
+def _is_missing_reply_error(error: BadRequest) -> bool:
+    return MESSAGE_TO_REPLY_NOT_FOUND.lower() in error.message.lower()
+
 
 async def _reply_and_delete(
     message: Message,
@@ -11,10 +17,19 @@ async def _reply_and_delete(
     delete_original: bool = True,
     reply_markup: InlineKeyboardMarkup | None = None,
 ):
-    msg = await message.reply_text(
-        text,
-        reply_markup=reply_markup,
-    )
+    try:
+        msg = await message.reply_text(
+            text,
+            reply_markup=reply_markup,
+        )
+    except BadRequest as e:
+        if not _is_missing_reply_error(e):
+            raise
+        msg = await message.reply_text(
+            text,
+            reply_markup=reply_markup,
+            do_quote=False,
+        )
     await asyncio.sleep(sleep_sec)
     await msg.delete()
 

--- a/tests/tgbot/test_chat_utils.py
+++ b/tests/tgbot/test_chat_utils.py
@@ -1,0 +1,35 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.error import BadRequest
+
+from src.tgbot.handlers.chat.utils import _reply_and_delete
+
+
+@pytest.mark.asyncio
+async def test_reply_and_delete_falls_back_when_reply_message_is_missing():
+    sent_message = AsyncMock()
+    message = AsyncMock()
+    message.reply_text.side_effect = [
+        BadRequest("Message to be replied not found"),
+        sent_message,
+    ]
+
+    await _reply_and_delete(message, "temporary warning", sleep_sec=0)
+
+    assert message.reply_text.await_args_list[0].kwargs == {"reply_markup": None}
+    assert message.reply_text.await_args_list[1].kwargs == {
+        "reply_markup": None,
+        "do_quote": False,
+    }
+    sent_message.delete.assert_awaited_once()
+    message.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reply_and_delete_reraises_unrelated_bad_request():
+    message = AsyncMock()
+    message.reply_text.side_effect = BadRequest("Chat not found")
+
+    with pytest.raises(BadRequest):
+        await _reply_and_delete(message, "temporary warning", sleep_sec=0)


### PR DESCRIPTION
Fixes FFM-1251.

## What changed
- Catch Telegram `BadRequest: Message to be replied not found` in `_reply_and_delete`.
- Retry the temporary helper response with `do_quote=False` so the message is sent without quoting a deleted/unavailable source message.
- Preserve existing cleanup behavior and keep unrelated `BadRequest` errors visible.

## Verification
- `pytest tests/tgbot/test_chat_utils.py`
- `ruff check --fix src/ tests/ && ruff format src/ tests/`

## Review notes
- Staff Engineer should verify the targeted exception handling and that `do_quote=False` is the correct python-telegram-bot 22.7 fallback for non-reply sends.