### PR TITLE
Fix outcome audit pagination fidelity

### DIFF
--- a/scripts/paperclip_contracts.py
+++ b/scripts/paperclip_contracts.py
@@ -94,10 +94,9 @@ OUTCOME_ACTIONS: frozenset[str] = DECISION_ACTIONS | frozenset(
     }
 )
 
-# Legacy / typo aliases. Audits resolve these to the canonical name and
-# also flag `outcome_alias_drift` so prompts that still emit the old
-# name surface for cleanup. Keep this map small — every entry is a
-# named gap a prompt or routine description still has to fix.
+# Legacy / typo aliases. Audits resolve these to the canonical name so
+# historical rows continue to count without rewriting old ledger entries.
+# Keep this map small: every entry should preserve a known historical meaning.
 OUTCOME_ALIASES: Mapping[str, str] = {
     "daily_post": "daily_channel_post",
 }

--- a/scripts/paperclip_http.py
+++ b/scripts/paperclip_http.py
@@ -203,7 +203,7 @@ class PaperclipClient:
         path: str,
         *,
         query: dict[str, str] | None = None,
-        limit: int,
+        limit: int | None = None,
         page_size: int = 200,
         dedupe_key: str = "id",
         offset_param: str = "offset",
@@ -215,8 +215,8 @@ class PaperclipClient:
         - Empty page (clean end of data).
         - Duplicate-only page (server ignores `offset` or has a hidden cap).
         - Non-list / non-dict / missing-id responses (shape drift).
-        - Hitting `limit` rows; on the boundary we probe one extra row so an
-          exact-fit dataset isn't reported as truncated.
+        - Hitting an explicit `limit`; on the boundary we probe one extra row
+          so an exact-fit dataset isn't reported as truncated.
 
         `truncation` keys: `truncated` (bool), `reason` (str | None),
         `atOffset` (int | None).
@@ -226,8 +226,11 @@ class PaperclipClient:
         offset = 0
         truncation: dict[str, Any] = {"truncated": False, "reason": None, "atOffset": None}
         base_query = dict(query or {})
-        while len(collected) < limit:
-            page_request_size = min(page_size, limit - len(collected))
+        while limit is None or len(collected) < limit:
+            if limit is None:
+                page_request_size = page_size
+            else:
+                page_request_size = min(page_size, limit - len(collected))
             page_query = dict(base_query)
             page_query[limit_param] = str(page_request_size)
             page_query[offset_param] = str(offset)
@@ -306,7 +309,7 @@ class PaperclipClient:
                 seen.add(item[dedupe_key])
                 collected.append(item)
             offset += len(page)
-        if not truncation["truncated"] and len(collected) >= limit:
+        if limit is not None and not truncation["truncated"] and len(collected) >= limit:
             try:
                 probe_query = dict(base_query)
                 probe_query[limit_param] = "1"

--- a/scripts/paperclip_outcome_audit.py
+++ b/scripts/paperclip_outcome_audit.py
@@ -26,7 +26,6 @@ try:
     from paperclip_contracts import (
         EXECUTION_CATEGORIES,
         ISSUE_CLASSES,
-        OUTCOME_ALIASES,
         canonical_action,
         is_decision_action,
         is_outcome_action,
@@ -43,7 +42,6 @@ except ModuleNotFoundError:
     from scripts.paperclip_contracts import (
         EXECUTION_CATEGORIES,
         ISSUE_CLASSES,
-        OUTCOME_ALIASES,
         canonical_action,
         is_decision_action,
         is_outcome_action,
@@ -126,7 +124,7 @@ def list_agents(client: Paperclip, company_id: str) -> dict[str, str]:
 
 
 def list_issues(
-    client: Paperclip, company_id: str, limit: int
+    client: Paperclip, company_id: str, limit: int | None
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Paginate every status so the audit doesn't silently undercount once the
     company crosses the API's per-request cap.
@@ -135,11 +133,19 @@ def list_issues(
     ceiling probe live in `PaperclipClient.paginate`; this wrapper just
     binds the FFmemes-specific path and status filter.
     """
-    return client.paginate(
-        f"/api/companies/{company_id}/issues",
-        query={"status": ALL_STATUSES},
+    path = f"/api/companies/{company_id}/issues"
+    query = {"status": ALL_STATUSES}
+    issues, truncation = client.paginate(
+        path,
+        query=query,
         limit=limit,
     )
+    return issues, {
+        **truncation,
+        "path": path,
+        "query": query,
+        "requestedLimit": limit,
+    }
 
 
 def classify_issue(issue: dict[str, Any], agents: dict[str, str]) -> str:
@@ -220,12 +226,14 @@ def log_events(since: datetime, limit: int = 12) -> dict[str, Any]:
     decisions: list[dict[str, Any]] = []
     outcomes: list[dict[str, Any]] = []
     alias_drift: Counter[str] = Counter()
+    mapped_aliases: Counter[str] = Counter()
     if not LOG_PATH.exists():
         return {
             "events": [],
             "decisions": [],
             "outcomes": [],
             "aliasDrift": {},
+            "mappedAliases": {},
             "counts": {"events": 0, "decisions": 0, "outcomes": 0},
         }
 
@@ -238,11 +246,10 @@ def log_events(since: datetime, limit: int = 12) -> dict[str, Any]:
             continue
         events.append(entry)
         action = entry.get("action")
-        # Surface log entries still using the legacy `daily_post` alias so a
-        # prompt or routine description can be cleaned up; the outcome still
-        # counts toward `daily_channel_post` via `canonical_action`.
-        if isinstance(action, str) and action in OUTCOME_ALIASES:
-            alias_drift[action] += 1
+        if isinstance(action, str):
+            canonical = canonical_action(action)
+            if canonical and canonical != action:
+                mapped_aliases[f"{action}->{canonical}"] += 1
         if entry_contains_product_decision(entry):
             decisions.append(entry)
         if is_outcome_action(action) or entry_contains_product_decision(entry):
@@ -264,6 +271,7 @@ def log_events(since: datetime, limit: int = 12) -> dict[str, Any]:
         "decisions": [compact(e) for e in decisions[-limit:]],
         "outcomes": [compact(e) for e in outcomes[-limit:]],
         "aliasDrift": dict(alias_drift),
+        "mappedAliases": dict(mapped_aliases),
         "counts": {
             "events": len(events),
             "decisions": len(decisions),
@@ -322,7 +330,9 @@ def active_experiments(today: date) -> list[dict[str, Any]]:
     return rows
 
 
-def build_report(client: Paperclip, company_id: str, days: int, limit: int) -> dict[str, Any]:
+def build_report(
+    client: Paperclip, company_id: str, days: int, limit: int | None
+) -> dict[str, Any]:
     generated = datetime.now(timezone.utc)
     since = generated - timedelta(days=days)
     agents = list_agents(client, company_id)
@@ -402,6 +412,7 @@ def build_report(client: Paperclip, company_id: str, days: int, limit: int) -> d
             "recentDecisions": log["decisions"],
             "recentOutcomes": log["outcomes"],
             "aliasDrift": log["aliasDrift"],
+            "mappedAliases": log["mappedAliases"],
         },
         "activeExperiments": experiments,
         "flags": flags,
@@ -439,8 +450,8 @@ def recommended_actions(flags: list[str]) -> list[str]:
         )
     if "outcome_alias_drift" in flags:
         actions.append(
-            "experiments/log.jsonl still uses a legacy outcome alias; rename it "
-            "to the canonical action so the contract stays single-sourced."
+            "experiments/log.jsonl contains unmapped legacy outcome aliases; add "
+            "an explicit contract mapping or rename them to canonical actions."
         )
     if not actions:
         actions.append(
@@ -508,7 +519,15 @@ def main() -> int:
         default=os.getenv("PAPERCLIP_COMPANY_ID", DEFAULT_COMPANY_ID),
     )
     parser.add_argument("--days", type=int, default=7)
-    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help=(
+            "optional maximum issues to scan; by default the audit follows "
+            "pagination until the API returns a clean end-of-list"
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     args = parser.parse_args()
 
@@ -524,6 +543,16 @@ def main() -> int:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
         print_text(report)
+    if report["issueListTruncation"]["truncated"]:
+        truncation = report["issueListTruncation"]
+        print(
+            "error: issue pagination incomplete "
+            f"path={truncation.get('path')} query={truncation.get('query')} "
+            f"requested_limit={truncation.get('requestedLimit')} "
+            f"reason={truncation.get('reason')} at_offset={truncation.get('atOffset')}",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/specs/paperclip-architecture-ralphex-plan.md
+++ b/specs/paperclip-architecture-ralphex-plan.md
@@ -319,8 +319,8 @@ Verification:
       as `daily_post` vs `daily_channel_post`/`post_published`.
       (`OUTCOME_ACTIONS` + `OUTCOME_ALIASES` + `canonical_action`;
       `daily_post` resolves to `daily_channel_post`. Outcome audit
-      surfaces alias usage as an `outcome_alias_drift` flag so prompts
-      that still emit the legacy name appear in CEO actions.)
+      surfaces known legacy usage in `mappedAliases`; only unmapped legacy
+      names should become `outcome_alias_drift`.)
 - [x] Centralize routine outcome contracts so prompts and audit scripts share
       the same definitions. (`PUBLISHED_MARKERS`, `APPROVAL_MARKERS`,
       `STALE_DRAFT_MARKERS`, `BLOCKED_ACCESS_MARKERS`,
@@ -363,7 +363,7 @@ Verification:
       outcome events exist. (`log_events` runs every `experiments/log.jsonl`
       action through `is_outcome_action` / `canonical_action`, so a log
       line with `action=daily_post` now contributes to `outcomeCount`
-      via the alias and surfaces in `aliasDrift` for cleanup.)
+      via the alias and surfaces in `mappedAliases` for transparency.)
 
 ### Task 7: Tool, Env, And Access Preflight
 

--- a/tests/test_paperclip_http.py
+++ b/tests/test_paperclip_http.py
@@ -240,6 +240,21 @@ def test_paginate_collects_pages_and_dedupes():
     assert trunc["truncated"] is False
 
 
+def test_paginate_without_limit_walks_until_empty_page():
+    captured: list[dict] = []
+    pages = [
+        [{"id": f"i-{n}"} for n in range(200)],
+        [{"id": f"i-{n}"} for n in range(200, 400)],
+        [{"id": "i-400"}],
+        [],
+    ]
+    client = PaperclipClient("https://x.example", "k", opener=_paginate_opener(pages, captured))
+    items, trunc = client.paginate("/api/issues")
+    assert len(items) == 401
+    assert trunc["truncated"] is False
+    assert captured[-1]["url"].endswith("limit=200&offset=401")
+
+
 def test_paginate_flags_duplicate_page_offset_ignored():
     captured: list[dict] = []
     # Server hands back the same first page twice — classic "offset ignored".

--- a/tests/test_paperclip_outcome_audit.py
+++ b/tests/test_paperclip_outcome_audit.py
@@ -1,0 +1,65 @@
+"""Focused tests for the Paperclip outcome audit.
+
+These stay network-free: the live API client is injected behind the small
+`Paperclip` facade, and the experiment log path is monkeypatched to a temp file.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import paperclip_outcome_audit as audit  # noqa: E402
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.seen_limit: int | None | object = object()
+
+    def paginate(self, path: str, **kwargs: Any) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        self.seen_limit = kwargs["limit"]
+        return (
+            [{"id": f"issue-{index}", "status": "done"} for index in range(501)],
+            {"truncated": False, "reason": None, "atOffset": None},
+        )
+
+
+def test_list_issues_default_has_no_global_500_ceiling():
+    client = _FakeClient()
+    issues, truncation = audit.list_issues(client, "company-id", None)  # type: ignore[arg-type]
+
+    assert client.seen_limit is None
+    assert len(issues) == 501
+    assert truncation["truncated"] is False
+    assert truncation["requestedLimit"] is None
+    assert truncation["query"] == {"status": audit.ALL_STATUSES}
+
+
+def test_log_events_maps_known_legacy_alias_without_drift_flag(tmp_path, monkeypatch):
+    log_path = tmp_path / "log.jsonl"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    '{"timestamp":"2026-05-13T07:22:00Z","agent":"comms-manager",'
+                    '"action":"daily_post","status":"success","summary":"published"}'
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(audit, "LOG_PATH", log_path)
+
+    result = audit.log_events(datetime(2026, 5, 13, tzinfo=timezone.utc))
+
+    assert result["counts"]["outcomes"] == 1
+    assert result["aliasDrift"] == {}
+    assert result["mappedAliases"] == {"daily_post->daily_channel_post": 1}
+    assert result["outcomes"][0]["canonicalAction"] == "daily_channel_post"


### PR DESCRIPTION
Fixes FFM-1254.

## Summary

- Make `PaperclipClient.paginate()` support an uncapped mode that follows offset pagination until the API returns an empty page.
- Change `paperclip_outcome_audit.py --days 7` to use uncapped issue pagination by default, while keeping `--limit` as an explicit manual cap.
- Make truncated/capped issue scans fail loudly with path, query, requested limit, reason, and offset metadata.
- Treat known legacy outcome aliases as intentional `mappedAliases` instead of `outcome_alias_drift`.
- Add focused tests for uncapped pagination and legacy alias mapping.

## Notes

Checked FFM-1086 first: it points to PR #239, which is already merged into `production`; there was no open PR to extend.

## Verification

- `ruff check --fix src/ tests/ scripts/paperclip_http.py scripts/paperclip_outcome_audit.py scripts/paperclip_contracts.py`
- `ruff format src/ tests/ scripts/paperclip_http.py scripts/paperclip_outcome_audit.py scripts/paperclip_contracts.py`
- `pytest tests/test_paperclip_http.py tests/test_paperclip_contracts.py tests/test_paperclip_outcome_audit.py` — 46 passed, 1 existing pytest config warning
- `python3 -m py_compile scripts/paperclip_http.py scripts/paperclip_contracts.py scripts/paperclip_outcome_audit.py`
- `git diff --check`
- live smoke: `python3 scripts/paperclip_outcome_audit.py --days 7 --json | jq ...` showed `issueListTruncation.truncated=false`, `aliasDrift={}`, and no `issue_list_truncated` / `outcome_alias_drift` flags
- failure smoke: `python3 scripts/paperclip_outcome_audit.py --days 7 --limit 1 --json` exited 1 with explicit pagination metadata
