### PR TITLE
Harden source-voting chat scope and poll targeting

### DIFF
--- a/src/storage/source_voting.py
+++ b/src/storage/source_voting.py
@@ -316,6 +316,8 @@ async def record_source_candidate_vote(
     poll = await get_source_candidate_poll(poll_id)
     if poll is None:
         return {"status": "not_found"}
+    if chat_id != TELEGRAM_MODERATOR_CHAT_ID or poll["chat_id"] != TELEGRAM_MODERATOR_CHAT_ID:
+        return {"status": "wrong_chat", "poll": poll}
     if poll["chat_id"] != chat_id:
         return {"status": "wrong_chat", "poll": poll}
     if poll["status"] != POLL_STATUS_OPEN or poll["closes_at"] <= now:
@@ -663,7 +665,7 @@ async def post_source_candidate_poll_message(
         }
 
     message = await bot.send_message(
-        chat_id=TELEGRAM_MODERATOR_CHAT_ID,
+        chat_id=poll["chat_id"],
         text=format_source_candidate_poll_message(candidate, prepared or {"source": source}),
         reply_markup=source_candidate_vote_keyboard(poll["id"]),
         disable_web_page_preview=True,

--- a/src/storage/source_voting.py
+++ b/src/storage/source_voting.py
@@ -634,6 +634,13 @@ async def post_source_candidate_poll_message(
     prepared: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     now = now or _utcnow()
+    if poll["chat_id"] != TELEGRAM_MODERATOR_CHAT_ID:
+        await cancel_source_candidate_poll(poll["id"])
+        return {
+            "status": "wrong_chat_target",
+            "poll": await get_source_candidate_poll(poll["id"]) or poll,
+        }
+
     candidate = await fetch_one(
         select(meme_source_candidate).where(meme_source_candidate.c.id == poll["candidate_id"])
     )

--- a/tests/storage/test_source_voting.py
+++ b/tests/storage/test_source_voting.py
@@ -315,7 +315,9 @@ async def test_daily_source_cycle_resumes_existing_draft_poll(conn: AsyncConnect
 
 
 @pytest.mark.asyncio
-async def test_post_source_candidate_poll_message_uses_poll_chat_id(conn: AsyncConnection):
+async def test_post_source_candidate_poll_message_cancels_non_moderator_poll(
+    conn: AsyncConnection,
+):
     await _create_candidate(conn)
     await conn.commit()
     prepared = await prepare_source_candidate(CANDIDATE_ID, posts=[_post(4011)])
@@ -330,6 +332,6 @@ async def test_post_source_candidate_poll_message_uses_poll_chat_id(conn: AsyncC
 
     result = await post_source_candidate_poll_message(bot, poll, now=datetime.utcnow())
 
-    assert result["status"] == "posted"
-    sent_kwargs = bot.send_message.await_args.kwargs
-    assert sent_kwargs["chat_id"] == custom_chat_id
+    assert result["status"] == "wrong_chat_target"
+    bot.send_message.assert_not_awaited()
+    assert result["poll"]["status"] == "cancelled"

--- a/tests/storage/test_source_voting.py
+++ b/tests/storage/test_source_voting.py
@@ -28,6 +28,7 @@ from src.storage.source_voting import (
     close_source_candidate_poll,
     create_source_candidate_poll,
     post_new_source_candidate_poll,
+    post_source_candidate_poll_message,
     prepare_source_candidate,
     record_source_candidate_vote,
 )
@@ -175,6 +176,36 @@ async def test_source_candidate_vote_is_unique_and_mutable(conn: AsyncConnection
 
 
 @pytest.mark.asyncio
+async def test_source_candidate_vote_rejects_poll_outside_moderator_chat(
+    conn: AsyncConnection,
+):
+    await _create_candidate(conn)
+    await conn.commit()
+    prepared = await prepare_source_candidate(CANDIDATE_ID, posts=[_post(4010)])
+    wrong_chat_id = TELEGRAM_MODERATOR_CHAT_ID + 99
+    poll = await create_source_candidate_poll(
+        CANDIDATE_ID,
+        prepared_meme_source_id=prepared["source"]["id"],
+        chat_id=wrong_chat_id,
+        now=datetime.utcnow(),
+    )
+    await conn.execute(
+        meme_source_candidate_poll.update()
+        .where(meme_source_candidate_poll.c.id == poll["id"])
+        .values(status=POLL_STATUS_OPEN, message_id=130, opened_at=datetime.utcnow())
+    )
+    await conn.commit()
+
+    result = await record_source_candidate_vote(
+        poll_id=poll["id"],
+        user_id=TEST_ID_START + 10,
+        vote=VOTE_ADD_SOURCE,
+        chat_id=wrong_chat_id,
+    )
+    assert result["status"] == "wrong_chat"
+
+
+@pytest.mark.asyncio
 async def test_close_passed_poll_enables_prepared_source_without_reparsing(
     conn: AsyncConnection,
 ):
@@ -281,3 +312,24 @@ async def test_daily_source_cycle_resumes_existing_draft_poll(conn: AsyncConnect
     assert result["new_poll"]["poll"]["message_id"] == 556
     assert result["new_poll"]["poll"]["status"] == POLL_STATUS_OPEN
     bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_source_candidate_poll_message_uses_poll_chat_id(conn: AsyncConnection):
+    await _create_candidate(conn)
+    await conn.commit()
+    prepared = await prepare_source_candidate(CANDIDATE_ID, posts=[_post(4011)])
+    custom_chat_id = TELEGRAM_MODERATOR_CHAT_ID + 77
+    poll = await create_source_candidate_poll(
+        CANDIDATE_ID,
+        prepared_meme_source_id=prepared["source"]["id"],
+        chat_id=custom_chat_id,
+        now=datetime.utcnow(),
+    )
+    bot = SimpleNamespace(send_message=AsyncMock(return_value=SimpleNamespace(message_id=777)))
+
+    result = await post_source_candidate_poll_message(bot, poll, now=datetime.utcnow())
+
+    assert result["status"] == "posted"
+    sent_kwargs = bot.send_message.await_args.kwargs
+    assert sent_kwargs["chat_id"] == custom_chat_id


### PR DESCRIPTION
## Summary
- enforce moderator-chat-only voting in `record_source_candidate_vote` by validating both callback chat and poll chat against `TELEGRAM_MODERATOR_CHAT_ID`
- send new source-voting poll messages to `poll.chat_id` instead of a hardcoded chat id
- add regression tests for wrong-chat rejection and poll chat-id usage

## Verification
- `docker compose exec app pytest -q tests/storage/test_source_voting.py tests/storage/test_telegram_etl_source_status.py`
- result: `11 passed`
