### PR TITLE
feat: add Sentry upload observability

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ asyncpg==0.31.*
 fastapi==0.136.*
 uvicorn[standard]==0.46.*
 
-sentry-sdk==2.58.*
+sentry-sdk==2.60.*
 
 # prefect + worker
 prefect==3.6.*

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from src import redis
 from src.config import app_configs, settings
-from src.observability.sentry import before_send_log
+from src.observability.sentry import before_send, before_send_log
 from src.tgbot import app as tgbot_app
 from src.tgbot.router import router as tgbot_router
 
@@ -64,6 +64,8 @@ if settings.ENVIRONMENT.is_deployed:
         ignore_errors=[
             "telegram.error.Forbidden",  # handled by error.py → marks user as blocked_bot
         ],
+        include_local_variables=False,
+        before_send=before_send,
         before_send_log=before_send_log,
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,10 +5,12 @@ from typing import AsyncGenerator
 import httpx
 import sentry_sdk
 from fastapi import FastAPI
+from sentry_sdk.integrations.logging import LoggingIntegration
 from starlette.middleware.cors import CORSMiddleware
 
 from src import redis
 from src.config import app_configs, settings
+from src.observability.sentry import before_send_log
 from src.tgbot import app as tgbot_app
 from src.tgbot.router import router as tgbot_router
 
@@ -50,9 +52,19 @@ if settings.ENVIRONMENT.is_deployed:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
         environment=settings.ENVIRONMENT.value,
+        release=f"ff-backend@{settings.APP_VERSION}",
+        enable_logs=True,
+        integrations=[
+            LoggingIntegration(
+                sentry_logs_level=logging.WARNING,
+                level=logging.INFO,
+                event_level=logging.ERROR,
+            ),
+        ],
         ignore_errors=[
             "telegram.error.Forbidden",  # handled by error.py → marks user as blocked_bot
         ],
+        before_send_log=before_send_log,
     )
 
 

--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Observability helpers for backend integrations."""

--- a/src/observability/sentry.py
+++ b/src/observability/sentry.py
@@ -26,6 +26,23 @@ SENSITIVE_KEY_PARTS = (
 
 MAX_CONTEXT_STRING_LENGTH = 500
 MAX_LOG_BODY_LENGTH = 2000
+SENTRY_LOG_PARAMETER_PREFIX = "sentry.message.parameter."
+URL_PATTERN = re.compile(r"https?://[^\s)>\]]+")
+BEARER_TOKEN_PATTERN = re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE)
+SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b(api[_-]?key|authorization|bot[_-]?token|dsn|password|secret|token)"
+    r"\s*[:=]\s*([^\s,;]+)"
+)
+TELEGRAM_BOT_TOKEN_PATTERN = re.compile(r"\b\d{6,}:[A-Za-z0-9_-]{20,}\b")
+HIGH_ENTROPY_TOKEN_PATTERN = re.compile(
+    r"\b(?=[A-Za-z0-9_-]{32,}\b)(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9_-]+\b"
+)
+
+
+def before_send(event: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any] | None:
+    """Remove sensitive exception payloads before Sentry stores an event."""
+    _drop_exception_frame_vars(event)
+    return event
 
 
 def before_send_log(log: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any] | None:
@@ -33,13 +50,12 @@ def before_send_log(log: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any
     attributes = log.get("attributes")
     if isinstance(attributes, dict):
         log["attributes"] = {
-            key: "[Filtered]" if _is_sensitive_key(key) else value
-            for key, value in attributes.items()
+            key: _scrub_log_attribute(key, value) for key, value in attributes.items()
         }
 
     body = log.get("body")
-    if isinstance(body, str) and len(body) > MAX_LOG_BODY_LENGTH:
-        log["body"] = body[:MAX_LOG_BODY_LENGTH] + "...[truncated]"
+    if isinstance(body, str):
+        log["body"] = _scrub_log_text(body)
 
     return log
 
@@ -307,6 +323,48 @@ def _clean_scalar(value: Any) -> Any:
     return text
 
 
+def _drop_exception_frame_vars(event: dict[str, Any]) -> None:
+    exception = event.get("exception")
+    if not isinstance(exception, dict):
+        return
+
+    values = exception.get("values")
+    if not isinstance(values, list):
+        return
+
+    for exception_value in values:
+        if not isinstance(exception_value, dict):
+            continue
+        stacktrace = exception_value.get("stacktrace")
+        if not isinstance(stacktrace, dict):
+            continue
+        frames = stacktrace.get("frames")
+        if not isinstance(frames, list):
+            continue
+        for frame in frames:
+            if isinstance(frame, dict):
+                frame.pop("vars", None)
+
+
+def _scrub_log_attribute(key: str, value: Any) -> Any:
+    if _is_sensitive_key(key) or _is_sentry_log_parameter_key(key):
+        return "[Filtered]"
+    if isinstance(value, str):
+        return _scrub_log_text(value)
+    return value
+
+
+def _scrub_log_text(text: str) -> str:
+    scrubbed = URL_PATTERN.sub("[Filtered]", text)
+    scrubbed = BEARER_TOKEN_PATTERN.sub("Bearer [Filtered]", scrubbed)
+    scrubbed = SECRET_ASSIGNMENT_PATTERN.sub(r"\1=[Filtered]", scrubbed)
+    scrubbed = TELEGRAM_BOT_TOKEN_PATTERN.sub("[Filtered]", scrubbed)
+    scrubbed = HIGH_ENTROPY_TOKEN_PATTERN.sub("[Filtered]", scrubbed)
+    if len(scrubbed) > MAX_LOG_BODY_LENGTH:
+        return scrubbed[:MAX_LOG_BODY_LENGTH] + "...[truncated]"
+    return scrubbed
+
+
 def _tag_value(value: Any) -> str:
     return str(_clean_scalar(value))[:200].replace("\n", " ")
 
@@ -320,6 +378,10 @@ def _enum_value(value: Any) -> Any:
 def _is_sensitive_key(key: str) -> bool:
     normalized = key.lower()
     return any(part in normalized for part in SENSITIVE_KEY_PARTS)
+
+
+def _is_sentry_log_parameter_key(key: str) -> bool:
+    return key.lower().startswith(SENTRY_LOG_PARAMETER_PREFIX)
 
 
 def _is_raw_telegram_file_id_key(key: str) -> bool:

--- a/src/observability/sentry.py
+++ b/src/observability/sentry.py
@@ -1,0 +1,335 @@
+import logging
+import re
+from contextlib import contextmanager
+from enum import Enum
+from typing import Any, Iterator
+
+import sentry_sdk
+
+logger = logging.getLogger(__name__)
+
+SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "authorization",
+    "bot_token",
+    "database_url",
+    "dsn",
+    "hash",
+    "openai",
+    "openrouter",
+    "password",
+    "redis_url",
+    "secret",
+    "session",
+    "token",
+)
+
+MAX_CONTEXT_STRING_LENGTH = 500
+MAX_LOG_BODY_LENGTH = 2000
+
+
+def before_send_log(log: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any] | None:
+    """Scrub searchable Sentry Logs before they leave the process."""
+    attributes = log.get("attributes")
+    if isinstance(attributes, dict):
+        log["attributes"] = {
+            key: "[Filtered]" if _is_sensitive_key(key) else value
+            for key, value in attributes.items()
+        }
+
+    body = log.get("body")
+    if isinstance(body, str) and len(body) > MAX_LOG_BODY_LENGTH:
+        log["body"] = body[:MAX_LOG_BODY_LENGTH] + "...[truncated]"
+
+    return log
+
+
+@contextmanager
+def telegram_update_scope(update: Any) -> Iterator[None]:
+    """Attach Telegram update context to Sentry events produced by one webhook."""
+    with sentry_sdk.new_scope() as scope:
+        user_id = _get_attr(getattr(update, "effective_user", None), "id")
+        if user_id is not None:
+            scope.set_user({"id": str(user_id)})
+
+        update_type = _telegram_update_type(update)
+        chat = getattr(update, "effective_chat", None)
+        message = getattr(update, "effective_message", None)
+        callback_query = getattr(update, "callback_query", None)
+        callback_route = _callback_route(getattr(callback_query, "data", None))
+
+        scope.set_tag("ff.module", "telegram_update")
+        scope.set_tag("telegram.update_type", update_type)
+        if getattr(chat, "type", None):
+            scope.set_tag("telegram.chat_type", chat.type)
+        if callback_route:
+            scope.set_tag("telegram.callback_route", callback_route)
+
+        scope.set_context(
+            "telegram_update",
+            _clean_context(
+                {
+                    "update_id": _get_attr(update, "update_id"),
+                    "update_type": update_type,
+                    "user_id": user_id,
+                    "chat_id": _get_attr(chat, "id"),
+                    "chat_type": _get_attr(chat, "type"),
+                    "message_id": _get_attr(message, "message_id"),
+                    "callback_route": callback_route,
+                }
+            ),
+        )
+        yield
+
+
+def user_upload_observability_context(
+    meme: dict[str, Any],
+    meme_upload: dict[str, Any],
+) -> dict[str, Any]:
+    """Build safe user-upload context without raw Telegram payloads or file IDs."""
+    media = meme_upload.get("media") or {}
+    forward_origin = meme_upload.get("forward_origin") or {}
+
+    return {
+        "meme": _clean_context(
+            {
+                "id": meme.get("id"),
+                "type": _enum_value(meme.get("type")),
+                "status": _enum_value(meme.get("status")),
+                "language_code": meme.get("language_code"),
+                "has_telegram_file_id": bool(meme.get("telegram_file_id")),
+            }
+        ),
+        "user_upload": _clean_context(
+            {
+                "upload_id": meme_upload.get("id"),
+                "user_id": meme_upload.get("user_id"),
+                "message_id": meme_upload.get("message_id"),
+                "language_code": meme_upload.get("language_code"),
+                "forward_origin_type": forward_origin.get("type"),
+            }
+        ),
+        "telegram_media": _clean_context(
+            {
+                "file_size": media.get("file_size"),
+                "mime_type": media.get("mime_type"),
+                "duration": media.get("duration"),
+                "width": media.get("width"),
+                "height": media.get("height"),
+            }
+        ),
+    }
+
+
+def capture_handled_issue(
+    message: str,
+    *,
+    level: str = "warning",
+    user_id: int | str | None = None,
+    tags: dict[str, Any] | None = None,
+    contexts: dict[str, Any] | None = None,
+    error: BaseException | None = None,
+) -> str | None:
+    """Capture a handled backend failure as a Sentry event with safe context."""
+    try:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_level(level)
+            if user_id is not None:
+                scope.set_user({"id": str(user_id)})
+
+            for key, value in (tags or {}).items():
+                if value is not None:
+                    scope.set_tag(key, _tag_value(value))
+
+            for key, value in (contexts or {}).items():
+                scope.set_context(key, _clean_context(value))
+
+            if error is not None:
+                scope.set_context(
+                    "error",
+                    _clean_context(
+                        {
+                            "type": type(error).__name__,
+                            "message": str(error),
+                        }
+                    ),
+                )
+
+            return scope.capture_message(message, level=level)
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to capture handled Sentry issue")
+        return None
+
+
+def capture_handled_exception(
+    message: str,
+    error: BaseException,
+    *,
+    level: str = "error",
+    user_id: int | str | None = None,
+    tags: dict[str, Any] | None = None,
+    contexts: dict[str, Any] | None = None,
+) -> str | None:
+    """Capture a handled exception with stack trace and safe context."""
+    try:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_level(level)
+            if user_id is not None:
+                scope.set_user({"id": str(user_id)})
+
+            for key, value in (tags or {}).items():
+                if value is not None:
+                    scope.set_tag(key, _tag_value(value))
+
+            for key, value in (contexts or {}).items():
+                scope.set_context(key, _clean_context(value))
+
+            scope.set_context(
+                "handled_failure",
+                _clean_context(
+                    {
+                        "message": message,
+                        "type": type(error).__name__,
+                    }
+                ),
+            )
+            return sentry_sdk.capture_exception(error)
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to capture handled Sentry exception")
+        return None
+
+
+def capture_telegram_storage_upload_failure(
+    meme: dict[str, Any],
+    *,
+    reason: str,
+    attempt: int | None = None,
+    max_attempts: int | None = None,
+    content_size: int | None = None,
+    error: BaseException | None = None,
+    observability_context: dict[str, Any] | None = None,
+) -> str | None:
+    contexts = dict(observability_context or {})
+    contexts["telegram_storage_upload"] = _clean_context(
+        {
+            "reason": reason,
+            "attempt": attempt,
+            "max_attempts": max_attempts,
+            "content_size": content_size,
+            "meme_id": meme.get("id"),
+            "meme_type": _enum_value(meme.get("type")),
+        }
+    )
+    user_id = _context_user_id(observability_context)
+
+    return capture_handled_issue(
+        "telegram_storage_upload.failed",
+        level="warning",
+        user_id=user_id,
+        tags={
+            "ff.module": "telegram_storage_upload",
+            "ff.failure_kind": reason,
+            "meme.type": _enum_value(meme.get("type")),
+            "error.type": type(error).__name__ if error else None,
+        },
+        contexts=contexts,
+        error=error,
+    )
+
+
+def sentry_log_extra(context: dict[str, Any] | None = None, **values: Any) -> dict[str, Any]:
+    """Flatten safe context into LogRecord extras for Sentry Logs and JSON logs."""
+    extra: dict[str, Any] = {}
+    for namespace, namespace_values in (context or {}).items():
+        if not isinstance(namespace_values, dict):
+            continue
+        for key, value in namespace_values.items():
+            if _is_scalar(value) and not _is_sensitive_key(key):
+                extra[f"ff_{namespace}_{key}"] = _clean_scalar(value)
+
+    for key, value in values.items():
+        if _is_scalar(value) and not _is_sensitive_key(key):
+            extra[f"ff_{key}"] = _clean_scalar(value)
+
+    return extra
+
+
+def _telegram_update_type(update: Any) -> str:
+    for field in (
+        "message",
+        "edited_message",
+        "callback_query",
+        "inline_query",
+        "chosen_inline_result",
+        "pre_checkout_query",
+        "chat_member",
+        "my_chat_member",
+        "chat_boost",
+    ):
+        if getattr(update, field, None) is not None:
+            return field
+    return "unknown"
+
+
+def _callback_route(callback_data: Any) -> str | None:
+    if not isinstance(callback_data, str) or not callback_data:
+        return None
+    route = re.sub(r"\d+", "{id}", callback_data)
+    return route[:120]
+
+
+def _context_user_id(context: dict[str, Any] | None) -> int | str | None:
+    user_upload = (context or {}).get("user_upload")
+    if isinstance(user_upload, dict):
+        return user_upload.get("user_id")
+    return None
+
+
+def _clean_context(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): "[Filtered]" if _is_sensitive_key(str(key)) else _clean_context(item)
+            for key, item in value.items()
+            if not _is_raw_telegram_file_id_key(str(key))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_clean_context(item) for item in value[:10]]
+    return _clean_scalar(value)
+
+
+def _clean_scalar(value: Any) -> Any:
+    value = _enum_value(value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    text = str(value)
+    if len(text) > MAX_CONTEXT_STRING_LENGTH:
+        return text[:MAX_CONTEXT_STRING_LENGTH] + "...[truncated]"
+    return text
+
+
+def _tag_value(value: Any) -> str:
+    return str(_clean_scalar(value))[:200].replace("\n", " ")
+
+
+def _enum_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.lower()
+    return any(part in normalized for part in SENSITIVE_KEY_PARTS)
+
+
+def _is_raw_telegram_file_id_key(key: str) -> bool:
+    return key in {"file_id", "telegram_file_id", "raw_file_id"}
+
+
+def _is_scalar(value: Any) -> bool:
+    value = _enum_value(value)
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+def _get_attr(value: Any, attr: str) -> Any:
+    return getattr(value, attr, None) if value is not None else None

--- a/src/storage/upload.py
+++ b/src/storage/upload.py
@@ -9,6 +9,10 @@ from pydantic import AnyHttpUrl
 from telegram.error import BadRequest, RetryAfter
 
 from src.config import settings
+from src.observability.sentry import (
+    capture_telegram_storage_upload_failure,
+    sentry_log_extra,
+)
 from src.storage.constants import MemeStatus, MemeType
 from src.storage.parsers.constants import USER_AGENT
 from src.storage.service import (
@@ -16,6 +20,8 @@ from src.storage.service import (
     update_meme,
 )
 from src.tgbot.bot import bot
+
+logger = logging.getLogger(__name__)
 
 
 async def download_meme_content_file(
@@ -128,11 +134,15 @@ async def _upload_meme_content_to_tg(
 async def upload_meme_content_to_tg(
     meme: dict[str, Any],
     content: bytes,
+    *,
+    observability_context: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     # just a wrapper to handle retries
 
     meme_result = None
-    for _ in range(3):  # attempts
+    max_attempts = 3
+    content_size = len(content)
+    for attempt in range(1, max_attempts + 1):
         try:
             meme_result = await _upload_meme_content_to_tg(
                 meme_id=meme["id"],
@@ -142,15 +152,64 @@ async def upload_meme_content_to_tg(
             if meme_result and meme_result.get("telegram_file_id"):
                 return meme_result
         except RetryAfter as e:
-            logging.warning(f"Flood control exceeded: {e}")
+            logger.warning(
+                "Flood control exceeded while uploading meme to Telegram",
+                extra=sentry_log_extra(
+                    observability_context,
+                    meme_id=meme["id"],
+                    meme_type=meme["type"],
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    retry_after=e.retry_after,
+                    content_size=content_size,
+                    error_type=type(e).__name__,
+                ),
+            )
             await asyncio.sleep(e.retry_after)
         except BadRequest as e:
-            logging.warning("Can't upload meme %s. Telegram error: %s", meme["id"], e)
+            logger.warning(
+                "Telegram rejected meme upload: %s",
+                e,
+                extra=sentry_log_extra(
+                    observability_context,
+                    meme_id=meme["id"],
+                    meme_type=meme["type"],
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    content_size=content_size,
+                    error_type=type(e).__name__,
+                ),
+            )
+            capture_telegram_storage_upload_failure(
+                meme,
+                reason="bad_request",
+                attempt=attempt,
+                max_attempts=max_attempts,
+                content_size=content_size,
+                error=e,
+                observability_context=observability_context,
+            )
             await update_meme(meme["id"], status=MemeStatus.BROKEN_CONTENT_LINK)
             return None
 
         await asyncio.sleep(3)  # flood control
 
-    logging.warning(f"Meme {meme['id']} failed to upload to Telegram after 3 attempts.")
+    logger.warning(
+        "Meme failed to upload to Telegram after retries",
+        extra=sentry_log_extra(
+            observability_context,
+            meme_id=meme["id"],
+            meme_type=meme["type"],
+            max_attempts=max_attempts,
+            content_size=content_size,
+        ),
+    )
+    capture_telegram_storage_upload_failure(
+        meme,
+        reason="retry_exhausted",
+        max_attempts=max_attempts,
+        content_size=content_size,
+        observability_context=observability_context,
+    )
     await update_meme(meme["id"], status=MemeStatus.BROKEN_CONTENT_LINK)
     return None

--- a/src/tgbot/app.py
+++ b/src/tgbot/app.py
@@ -16,6 +16,7 @@ from telegram.ext import (
 )
 
 from src.config import settings
+from src.observability.sentry import telegram_update_scope
 from src.tgbot.constants import (
     LANG_SETTINGS_END_CALLBACK_DATA,
     LANG_SETTINGS_LANG_CHANGE_CALLBACK_PATTERN,
@@ -454,36 +455,37 @@ async def process_event(payload: dict) -> None:
     # https://github.com/python-telegram-bot/python-telegram-bot/wiki/Webhooks#custom-solution
 
     lock = None
-    try:
-        user_id = _get_update_user_id(update)
-        if user_id is not None:
-            try:
-                # FastAPI runs webhook background tasks concurrently across Gunicorn workers.
-                # Keep one user's handler chain serialized so double taps/retries don't overlap
-                # DB-heavy reaction and next-message operations.
-                lock = await acquire_update_user_lock(user_id)
-            except Exception:  # noqa: BLE001
-                logging.warning(
-                    "Failed to acquire Telegram update lock for user %s; processing unlocked",
-                    user_id,
-                    exc_info=True,
-                )
-
-        await application.process_update(update)
-    except Exception as e:
-        import sys
-
-        cb = ""
-        if update.callback_query:
-            cb = f" cb={update.callback_query.data}"
-        sys.stderr.write(f"[process_event] UNHANDLED ERROR{cb}: {e}\n")
-        sys.stderr.flush()
-        raise
-    finally:
+    with telegram_update_scope(update):
         try:
-            await release_update_user_lock(lock)
-        except Exception:  # noqa: BLE001
-            logging.warning("Failed to release Telegram update lock", exc_info=True)
+            user_id = _get_update_user_id(update)
+            if user_id is not None:
+                try:
+                    # FastAPI runs webhook background tasks concurrently across Gunicorn workers.
+                    # Keep one user's handler chain serialized so double taps/retries don't overlap
+                    # DB-heavy reaction and next-message operations.
+                    lock = await acquire_update_user_lock(user_id)
+                except Exception:  # noqa: BLE001
+                    logging.warning(
+                        "Failed to acquire Telegram update lock for user %s; processing unlocked",
+                        user_id,
+                        exc_info=True,
+                    )
+
+            await application.process_update(update)
+        except Exception as e:
+            import sys
+
+            cb = ""
+            if update.callback_query:
+                cb = f" cb={update.callback_query.data}"
+            sys.stderr.write(f"[process_event] UNHANDLED ERROR{cb}: {e}\n")
+            sys.stderr.flush()
+            raise
+        finally:
+            try:
+                await release_update_user_lock(lock)
+            except Exception:  # noqa: BLE001
+                logging.warning("Failed to release Telegram update lock", exc_info=True)
 
 
 async def setup_webhook(application: Application) -> None:

--- a/src/tgbot/handlers/upload/moderation.py
+++ b/src/tgbot/handlers/upload/moderation.py
@@ -16,6 +16,12 @@ from src.flows.storage.memes import (
     add_watermark_to_meme_content,
     upload_meme_content_to_tg,
 )
+from src.observability.sentry import (
+    capture_handled_exception,
+    capture_handled_issue,
+    sentry_log_extra,
+    user_upload_observability_context,
+)
 from src.recommendations.service import create_user_meme_reaction
 from src.stats.meme import calculate_meme_reactions_and_engagement
 from src.stats.meme_source import calculate_meme_source_stats
@@ -38,6 +44,8 @@ UPLOADED_MEME_REVIEW_CALLBACK_DATA_REGEXP = r"upload:(\d+):review:(\w+)"
 LEADERBOARD_URL = (
     "https://metabase.okhlopkov.com/public/question/663c4def-4b42-4303-aa3b-73ab5bfa677a"
 )
+
+logger = logging.getLogger(__name__)
 
 
 async def _notify_uploader(
@@ -114,6 +122,41 @@ async def _check_duplicate_via_ocr(meme: dict[str, Any]) -> tuple[dict[str, Any]
 async def uploaded_meme_auto_review(
     meme: dict[str, Any], meme_upload: dict[str, Any], bot: Bot
 ) -> None:
+    observability_context = user_upload_observability_context(meme, meme_upload)
+    try:
+        return await _uploaded_meme_auto_review(meme, meme_upload, bot, observability_context)
+    except Exception as exc:
+        logger.warning(
+            "Unhandled user upload auto-review failure",
+            exc_info=True,
+            extra=sentry_log_extra(
+                observability_context,
+                phase="auto_review",
+                error_type=type(exc).__name__,
+            ),
+        )
+        capture_handled_exception(
+            "user_upload.auto_review_unhandled",
+            exc,
+            level="error",
+            user_id=meme_upload.get("user_id"),
+            tags={
+                "ff.module": "user_upload",
+                "ff.failure_kind": "auto_review_unhandled",
+                "meme.type": meme.get("type"),
+                "error.type": type(exc).__name__,
+            },
+            contexts=observability_context,
+        )
+        raise
+
+
+async def _uploaded_meme_auto_review(
+    meme: dict[str, Any],
+    meme_upload: dict[str, Any],
+    bot: Bot,
+    observability_context: dict[str, Any],
+) -> None:
     uploader_lang = await _get_uploader_lang(meme_upload["user_id"])
 
     logging.info(f"Downloading meme {meme['id']} content")
@@ -122,13 +165,35 @@ async def uploaded_meme_auto_review(
     logging.info(f"Adding watermark to meme {meme['id']} content")
     watermarked_meme_content = await add_watermark_to_meme_content(image_bytes, meme["type"])
     if watermarked_meme_content is None:
+        capture_handled_issue(
+            "user_upload.watermark_failed",
+            level="warning",
+            user_id=meme_upload.get("user_id"),
+            tags={
+                "ff.module": "user_upload",
+                "ff.failure_kind": "watermark_failed",
+                "meme.type": meme.get("type"),
+            },
+            contexts=observability_context,
+        )
         return await _notify_uploader(
             bot, meme_upload, localizer.t("upload.watermark_failed", uploader_lang)
         )
 
     logging.info(f"Uploading watermarked meme {meme['id']} content to Telegram")
-    meme = await upload_meme_content_to_tg(meme, watermarked_meme_content)
+    meme = await upload_meme_content_to_tg(
+        meme,
+        watermarked_meme_content,
+        observability_context=observability_context,
+    )
     if meme is None:
+        logger.warning(
+            "User upload could not be stored in Telegram",
+            extra=sentry_log_extra(
+                observability_context,
+                phase="upload_to_storage",
+            ),
+        )
         return await _notify_uploader(
             bot, meme_upload, localizer.t("upload.tg_upload_failed", uploader_lang)
         )

--- a/tests/storage/test_upload_observability.py
+++ b/tests/storage/test_upload_observability.py
@@ -1,0 +1,46 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from telegram.error import BadRequest
+
+from src.storage import upload
+from src.storage.constants import MemeStatus, MemeType
+
+
+@pytest.mark.asyncio
+async def test_upload_meme_content_bad_request_captures_sentry_context(monkeypatch):
+    telegram_error = BadRequest("Photo_invalid_dimensions")
+    store_upload = AsyncMock(side_effect=telegram_error)
+    update_meme = AsyncMock()
+    capture_failure = Mock()
+
+    monkeypatch.setattr(upload, "_upload_meme_content_to_tg", store_upload)
+    monkeypatch.setattr(upload, "update_meme", update_meme)
+    monkeypatch.setattr(upload, "capture_telegram_storage_upload_failure", capture_failure)
+    monkeypatch.setattr(upload.asyncio, "sleep", AsyncMock())
+
+    meme = {"id": 101, "type": MemeType.IMAGE}
+    context = {"user_upload": {"upload_id": 202, "user_id": 303}}
+
+    result = await upload.upload_meme_content_to_tg(
+        meme,
+        b"image-bytes",
+        observability_context=context,
+    )
+
+    assert result is None
+    store_upload.assert_awaited_once_with(
+        meme_id=101,
+        meme_type=MemeType.IMAGE,
+        content=b"image-bytes",
+    )
+    update_meme.assert_awaited_once_with(101, status=MemeStatus.BROKEN_CONTENT_LINK)
+    capture_failure.assert_called_once_with(
+        meme,
+        reason="bad_request",
+        attempt=1,
+        max_attempts=3,
+        content_size=len(b"image-bytes"),
+        error=telegram_error,
+        observability_context=context,
+    )

--- a/tests/test_sentry_observability.py
+++ b/tests/test_sentry_observability.py
@@ -1,0 +1,93 @@
+from src.observability.sentry import (
+    before_send_log,
+    sentry_log_extra,
+    user_upload_observability_context,
+)
+from src.storage.constants import MemeStatus, MemeType
+
+
+def test_user_upload_observability_context_keeps_safe_upload_facts_without_file_ids():
+    context = user_upload_observability_context(
+        {
+            "id": 101,
+            "type": MemeType.IMAGE,
+            "status": MemeStatus.CREATED,
+            "language_code": "ru",
+            "telegram_file_id": "raw-telegram-file-id",
+        },
+        {
+            "id": 202,
+            "user_id": 303,
+            "message_id": 404,
+            "language_code": "ru",
+            "forward_origin": {"type": "user", "sender_user": {"id": 1}},
+            "media": {
+                "file_id": "raw-file-id",
+                "file_unique_id": "raw-file-unique-id",
+                "file_size": 12345,
+                "mime_type": "image/jpeg",
+                "width": 800,
+                "height": 600,
+            },
+        },
+    )
+
+    assert context["meme"] == {
+        "id": 101,
+        "type": "image",
+        "status": "created",
+        "language_code": "ru",
+        "has_telegram_file_id": True,
+    }
+    assert context["user_upload"] == {
+        "upload_id": 202,
+        "user_id": 303,
+        "message_id": 404,
+        "language_code": "ru",
+        "forward_origin_type": "user",
+    }
+    assert context["telegram_media"] == {
+        "file_size": 12345,
+        "mime_type": "image/jpeg",
+        "duration": None,
+        "width": 800,
+        "height": 600,
+    }
+
+
+def test_sentry_log_extra_flattens_safe_context_and_filters_secret_values():
+    extra = sentry_log_extra(
+        {
+            "user_upload": {
+                "upload_id": 202,
+                "user_id": 303,
+                "bot_token": "secret",
+            }
+        },
+        phase="upload_to_storage",
+        sentry_dsn="secret",
+    )
+
+    assert extra == {
+        "ff_user_upload_upload_id": 202,
+        "ff_user_upload_user_id": 303,
+        "ff_phase": "upload_to_storage",
+    }
+
+
+def test_before_send_log_scrubs_searchable_attributes_and_truncates_body():
+    log = {
+        "body": "x" * 2100,
+        "attributes": {
+            "ff_user_upload_upload_id": 202,
+            "authorization": "Bearer secret",
+        },
+    }
+
+    scrubbed = before_send_log(log, {})
+
+    assert scrubbed is log
+    assert scrubbed["attributes"]["ff_user_upload_upload_id"] == 202
+    assert scrubbed["attributes"]["authorization"] == "[Filtered]"
+    assert len(scrubbed["body"]) < 2100
+    assert scrubbed["body"].endswith("...[truncated]")

--- a/tests/test_sentry_observability.py
+++ b/tests/test_sentry_observability.py
@@ -1,4 +1,5 @@
 from src.observability.sentry import (
+    before_send,
     before_send_log,
     sentry_log_extra,
     user_upload_observability_context,
@@ -77,10 +78,12 @@ def test_sentry_log_extra_flattens_safe_context_and_filters_secret_values():
 
 def test_before_send_log_scrubs_searchable_attributes_and_truncates_body():
     log = {
-        "body": "x" * 2100,
+        "body": "token=secret-value " + ("x" * 2100),
         "attributes": {
             "ff_user_upload_upload_id": 202,
             "authorization": "Bearer secret",
+            "sentry.message.parameter.0": "https://api.telegram.org/bot123:secret/sendPhoto",
+            "message": "callback token=secret-value",
         },
     }
 
@@ -89,5 +92,36 @@ def test_before_send_log_scrubs_searchable_attributes_and_truncates_body():
     assert scrubbed is log
     assert scrubbed["attributes"]["ff_user_upload_upload_id"] == 202
     assert scrubbed["attributes"]["authorization"] == "[Filtered]"
+    assert scrubbed["attributes"]["sentry.message.parameter.0"] == "[Filtered]"
+    assert scrubbed["attributes"]["message"] == "callback token=[Filtered]"
+    assert scrubbed["body"].startswith("token=[Filtered]")
     assert len(scrubbed["body"]) < 2100
     assert scrubbed["body"].endswith("...[truncated]")
+
+
+def test_before_send_drops_exception_frame_vars():
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "filename": "src/tgbot/handlers/upload/moderation.py",
+                                "vars": {
+                                    "meme": {"telegram_file_id": "raw-file-id"},
+                                    "image_bytes": "raw-bytes",
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+
+    scrubbed = before_send(event, {})
+
+    assert scrubbed is event
+    frame = scrubbed["exception"]["values"][0]["stacktrace"]["frames"][0]
+    assert "vars" not in frame

--- a/tests/tgbot/test_upload_observability.py
+++ b/tests/tgbot/test_upload_observability.py
@@ -1,0 +1,30 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.storage.constants import MemeType
+from src.tgbot.handlers.upload.moderation import uploaded_meme_auto_review
+
+
+@pytest.mark.asyncio
+async def test_uploaded_meme_auto_review_captures_unhandled_failure():
+    error = RuntimeError("boom")
+    meme = {"id": 12003, "type": MemeType.IMAGE, "telegram_file_id": "raw-file-id"}
+    meme_upload = {"id": 12002, "user_id": 12001, "message_id": 12004}
+
+    with (
+        patch(
+            "src.tgbot.handlers.upload.moderation._uploaded_meme_auto_review",
+            new=AsyncMock(side_effect=error),
+        ),
+        patch("src.tgbot.handlers.upload.moderation.capture_handled_exception") as capture,
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        await uploaded_meme_auto_review(meme, meme_upload, AsyncMock())
+
+    capture.assert_called_once()
+    args, kwargs = capture.call_args
+    assert args == ("user_upload.auto_review_unhandled", error)
+    assert kwargs["user_id"] == 12001
+    assert kwargs["tags"]["ff.module"] == "user_upload"
+    assert kwargs["contexts"]["meme"]["id"] == 12003


### PR DESCRIPTION
## Summary
- enable Sentry structured logs with release metadata and log scrubbing
- attach safe Telegram update and user-upload context to Sentry scopes/events
- capture handled upload-to-storage failures, watermark failures, and upload auto-review task exceptions
- bump sentry-sdk from 2.58.* to 2.60.*

## Notes
- user-facing upload error text is unchanged
- raw Telegram file IDs, file_unique_id, tokens, DSNs, secrets, captions, and full Telegram payloads are not sent
- this is separate from #259, which handles Telegram transport/Sentry noise hardening

## Tests
- ruff check src/observability/sentry.py src/main.py src/tgbot/app.py src/storage/upload.py src/tgbot/handlers/upload/moderation.py tests/test_sentry_observability.py tests/storage/test_upload_observability.py tests/tgbot/test_upload_observability.py
- pytest tests/test_sentry_observability.py tests/storage/test_upload_observability.py tests/tgbot/test_upload_observability.py tests/tgbot/test_upload_moderation.py tests/tgbot/test_process_event.py