### PR TITLE
Refine source-voting poll text and finalize prepared-source dedup path

### DIFF
--- a/src/flows/storage/memes.py
+++ b/src/flows/storage/memes.py
@@ -159,7 +159,9 @@ async def process_cached_telegram_source(meme_source_id: int, limit: int = 100) 
         fresh_only=False,
     )
     await _process_unloaded_memes(unloaded_memes, "prepared Telegram source")
-    await update_meme_status_of_ready_memes()
+    # Run the same finalization path as scheduled pipelines so dedup logic
+    # (file_id exact + OCR fuzzy) is applied before memes become publishable.
+    await final_meme_pipeline()
 
 
 @flow(

--- a/src/storage/source_voting.py
+++ b/src/storage/source_voting.py
@@ -5,6 +5,7 @@ from typing import Any
 from sqlalchemy import select, text
 from sqlalchemy.dialects.postgresql import insert
 from telegram import Bot
+from telegram.error import TelegramError
 
 from src.database import (
     execute,
@@ -538,22 +539,17 @@ async def select_daily_source_candidate() -> dict[str, Any] | None:
 
 def format_source_candidate_poll_message(
     candidate: dict[str, Any],
-    prepared: dict[str, Any],
+    _prepared: dict[str, Any],
 ) -> str:
-    evidence = prepared.get("cyrillic_evidence") or "кириллица найдена в последних постах"
-    first_seen = candidate.get("first_seen_at")
-    last_seen = candidate.get("last_seen_at")
     return "\n".join(
         [
             "Добавляем новый источник мемов?",
             "",
-            f"Источник: {candidate['url']}",
-            f"Форвардов в текущих источниках: {candidate['times_forwarded']}",
-            f"Первый раз видели: {first_seen}",
-            f"Последний раз видели: {last_seen}",
-            f"Русскоязычный сигнал: {evidence}",
+            f"🔗 {candidate['url']}",
             "",
-            "Голосование решает, добавляем ли источник в обычный парсинг и рекомендации.",
+            f"Наши паблики пересылали мемы оттуда {candidate['times_forwarded']} раз.",
+            "Откройте ссылку и проголосуйте ниже.",
+            "Голосование решит, начнем ли брать оттуда мемы на постоянке.",
         ]
     )
 
@@ -677,6 +673,16 @@ async def post_source_candidate_poll_message(
         reply_markup=source_candidate_vote_keyboard(poll["id"]),
         disable_web_page_preview=True,
     )
+    if hasattr(bot, "pin_chat_message"):
+        try:
+            await bot.pin_chat_message(
+                chat_id=poll["chat_id"],
+                message_id=message.message_id,
+                disable_notification=True,
+            )
+        except TelegramError:
+            # Best-effort: poll should still stay open even if bot cannot pin.
+            pass
     opened = await mark_source_candidate_poll_open(
         poll["id"],
         message_id=message.message_id,

--- a/tests/flows/storage/test_cached_telegram_source.py
+++ b/tests/flows/storage/test_cached_telegram_source.py
@@ -10,12 +10,12 @@ async def test_process_cached_telegram_source_promotes_uploaded_memes(monkeypatc
     etl = AsyncMock()
     get_unloaded = AsyncMock(return_value=[{"id": 1}])
     process_unloaded = AsyncMock()
-    promote_ready = AsyncMock(return_value=[{"id": 1, "status": "ok"}])
+    finalize = AsyncMock()
 
     monkeypatch.setattr(memes, "etl_memes_from_raw_telegram_posts", etl)
     monkeypatch.setattr(memes, "get_unloaded_tg_memes", get_unloaded)
     monkeypatch.setattr(memes, "_process_unloaded_memes", process_unloaded)
-    monkeypatch.setattr(memes, "update_meme_status_of_ready_memes", promote_ready)
+    monkeypatch.setattr(memes, "final_meme_pipeline", finalize)
 
     await memes.process_cached_telegram_source(42, limit=5)
 
@@ -29,4 +29,4 @@ async def test_process_cached_telegram_source_promotes_uploaded_memes(monkeypatc
         [{"id": 1}],
         "prepared Telegram source",
     )
-    promote_ready.assert_awaited_once()
+    finalize.assert_awaited_once()

--- a/tests/storage/test_source_voting.py
+++ b/tests/storage/test_source_voting.py
@@ -335,3 +335,38 @@ async def test_post_source_candidate_poll_message_cancels_non_moderator_poll(
     assert result["status"] == "wrong_chat_target"
     bot.send_message.assert_not_awaited()
     assert result["poll"]["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_post_source_candidate_poll_message_pins_silently(conn: AsyncConnection):
+    await _create_candidate(conn)
+    await conn.commit()
+    prepared = await prepare_source_candidate(CANDIDATE_ID, posts=[_post(4012)])
+    poll = await create_source_candidate_poll(
+        CANDIDATE_ID,
+        prepared_meme_source_id=prepared["source"]["id"],
+        chat_id=TELEGRAM_MODERATOR_CHAT_ID,
+        now=datetime.utcnow(),
+    )
+    message = SimpleNamespace(message_id=778)
+    bot = SimpleNamespace(
+        send_message=AsyncMock(return_value=message),
+        pin_chat_message=AsyncMock(),
+    )
+
+    result = await post_source_candidate_poll_message(bot, poll, now=datetime.utcnow())
+
+    assert result["status"] == "posted"
+    sent_text = bot.send_message.await_args.kwargs["text"]
+    assert sent_text == (
+        "Добавляем новый источник мемов?\n\n"
+        f"🔗 {CANDIDATE_URL}\n\n"
+        "Наши паблики пересылали мемы оттуда 5 раз.\n"
+        "Откройте ссылку и проголосуйте ниже.\n"
+        "Голосование решит, начнем ли брать оттуда мемы на постоянке."
+    )
+    bot.pin_chat_message.assert_awaited_once_with(
+        chat_id=TELEGRAM_MODERATOR_CHAT_ID,
+        message_id=778,
+        disable_notification=True,
+    )


### PR DESCRIPTION
## What
- shorten moderator poll message to compact Russian format
- auto-pin poll message silently (`disable_notification=true`)
- keep pinning best-effort (no poll failure on pin errors)
- in prepared-source activation path, run `final_meme_pipeline()` after upload so file_id/OCR dedup executes before memes become publishable
- update tests for silent pinning and prepared-source finalization path

## Why
- message was too long/noisy for moderator chat
- no NotifyAll requirement for pinning
- prepared-source cached ingest should use same dedup/finalization guarantees as regular pipeline

## Verification
- `pytest -q tests/flows/storage/test_cached_telegram_source.py`
- `python -m py_compile src/storage/source_voting.py src/flows/storage/memes.py tests/storage/test_source_voting.py tests/flows/storage/test_cached_telegram_source.py`
- DB-backed storage tests currently blocked locally by unresolved host `app_db` in this shell context
