### PR TITLE
Persist replied chat messages for AI context

### DIFF
--- a/src/tgbot/handlers/chat/service.py
+++ b/src/tgbot/handlers/chat/service.py
@@ -121,9 +121,27 @@ def _extract_forward(msg: Message) -> tuple[int | None, int | None, int | None]:
 
 
 async def save_telegram_message(msg: Message) -> None:
+    reply_to_message = getattr(msg, "reply_to_message", None)
+    if reply_to_message is not None:
+        try:
+            await _save_telegram_message_row(reply_to_message)
+        except Exception as e:
+            logger.warning(
+                "Failed to save reply target %s for message %s in chat %s: %s",
+                getattr(reply_to_message, "message_id", None),
+                getattr(msg, "message_id", None),
+                getattr(getattr(msg, "chat", None), "id", None),
+                e,
+            )
+
+    return await _save_telegram_message_row(msg)
+
+
+async def _save_telegram_message_row(msg: Message) -> None:
     # Prefer sender_chat when present (anonymous channel posts)
     sender_chat_id = None
     user_id = None
+    reply_to_message = getattr(msg, "reply_to_message", None)
 
     if getattr(msg, "sender_chat", None):
         sender_chat_id = msg.sender_chat.id
@@ -155,7 +173,7 @@ async def save_telegram_message(msg: Message) -> None:
             user_id=user_id,
             sender_chat_id=sender_chat_id,
             text=msg.text or msg.caption,
-            reply_to_message_id=msg.reply_to_message.message_id if msg.reply_to_message else None,
+            reply_to_message_id=reply_to_message.message_id if reply_to_message else None,
             media_type=media_type,
             file_id=file_id,
             media_group_id=msg.media_group_id,

--- a/tests/tgbot/test_chat_service.py
+++ b/tests/tgbot/test_chat_service.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from sqlalchemy.dialects import postgresql
+
+from src.tgbot.handlers.chat import service
+
+
+def _telegram_message(
+    *,
+    message_id: int,
+    user_id: int,
+    text: str,
+    chat: SimpleNamespace | None = None,
+    reply_to_message: SimpleNamespace | None = None,
+) -> SimpleNamespace:
+    chat = chat or SimpleNamespace(
+        id=-100123,
+        type="supergroup",
+        title="Moderator Chat",
+        username=None,
+    )
+
+    return SimpleNamespace(
+        message_id=message_id,
+        date=datetime(2026, 5, 15, 9, 58, 57, tzinfo=timezone.utc),
+        chat=chat,
+        from_user=SimpleNamespace(id=user_id),
+        sender_chat=None,
+        text=text,
+        caption=None,
+        reply_to_message=reply_to_message,
+        photo=None,
+        video=None,
+        animation=None,
+        document=None,
+        sticker=None,
+        voice=None,
+        video_note=None,
+        media_group_id=None,
+        forward_origin=None,
+    )
+
+
+async def test_save_telegram_message_self_heals_missing_reply_context(monkeypatch):
+    rows = []
+
+    async def fake_execute(query):
+        rows.append(query.compile(dialect=postgresql.dialect()).params)
+
+    async def noop_upsert_chat(_chat):
+        return None
+
+    monkeypatch.setattr(service, "execute", fake_execute)
+    monkeypatch.setattr(service, "upsert_telegram_chat", noop_upsert_chat)
+
+    source_vote = _telegram_message(
+        message_id=100,
+        user_id=999,
+        text="Добавляем новый источник мемов?",
+    )
+    reply = _telegram_message(
+        message_id=101,
+        user_id=123,
+        text="Вроде бы все ок",
+        chat=source_vote.chat,
+        reply_to_message=source_vote,
+    )
+
+    await service.save_telegram_message(reply)
+
+    assert [row["message_id"] for row in rows] == [100, 101]
+    assert rows[0]["text"] == "Добавляем новый источник мемов?"
+    assert rows[0]["reply_to_message_id"] is None
+    assert rows[1]["text"] == "Вроде бы все ок"
+    assert rows[1]["reply_to_message_id"] == 100


### PR DESCRIPTION
## Summary
- persist a replied-to Telegram message before saving the new chat message
- keep current message persistence resilient if the reply target cannot be saved
- add a focused test for self-healing source-vote reply context

## Tests
- pytest tests/tgbot/test_chat_service.py tests/tgbot/test_chat_agent_runner.py tests/tgbot/test_chat_utils.py tests/tgbot/test_chat_reaction.py -q
- ruff check src/tgbot/handlers/chat/service.py tests/tgbot/test_chat_service.py
- ruff format --check src/tgbot/handlers/chat/service.py tests/tgbot/test_chat_service.py

## Notes
- Full local tests/tgbot was attempted, but DB-backed tests cannot resolve the configured Docker hostname app_db in this shell; CI should run them in the project test environment.