### PR TITLE
Add pip manifest for GitHub Dependency Graph

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,0 +1,3 @@
+# Aggregate manifest for GitHub Dependency Graph.
+-r prod.txt
+-r dev.txt


### PR DESCRIPTION
## Summary
- add requirements/requirements.txt so GitHub Dependency Graph has the supported pip manifest name in /requirements
- keep existing install entrypoints unchanged by referencing prod.txt and dev.txt

## Context
GitHub Dependency Graph lists pip's recommended manifest as requirements.txt. The production Dependency Graph run was configured for /requirements and failed with: No supported dependency file present.

## Tests
- python -m pip install --dry-run --no-deps -r requirements/requirements.txt