### PR TITLE
Fix inline search across OCR sources

### DIFF
--- a/alembic/versions/2026-05-15_inline_search_ocr_source_indexes.py
+++ b/alembic/versions/2026-05-15_inline_search_ocr_source_indexes.py
@@ -1,0 +1,39 @@
+"""add inline search indexes for OpenRouter OCR fields
+
+Revision ID: 7b2c9f1e4a6d
+Revises: 4f6e8a1b2c3d
+Create Date: 2026-05-15 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7b2c9f1e4a6d"
+down_revision = "4f6e8a1b2c3d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_meme_ocr_description_gin
+            ON meme
+            USING gin ((ocr_result ->> 'description') gin_trgm_ops)
+            """
+        )
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_meme_ocr_raw_ocr_text_gin
+            ON meme
+            USING gin (((ocr_result -> 'raw_result') ->> 'ocr_text') gin_trgm_ops)
+            """
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_meme_ocr_raw_ocr_text_gin")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_meme_ocr_description_gin")

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Sequence
 
-from sqlalchemy import bindparam, exists, select, text
+from sqlalchemy import exists, select, text
 from sqlalchemy.dialects.postgresql import insert
 
 from src.database import (
@@ -236,19 +236,56 @@ async def promote_source_candidate(
 
 
 async def search_memes_for_inline_query(search_query: str, limit: int) -> list[dict[str, Any]]:
-    select_query = f"""
+    limit = max(1, min(limit, 50))
+    select_query = """
         SELECT
-            M.*
+            M.*,
+            GREATEST(
+                CASE WHEN M.ocr_result ->> 'text' ILIKE :search_pattern THEN 1.0 ELSE 0.0 END,
+                CASE
+                    WHEN M.ocr_result -> 'raw_result' ->> 'ocr_text' ILIKE :search_pattern
+                    THEN 1.0
+                    ELSE 0.0
+                END,
+                CASE
+                    WHEN M.ocr_result ->> 'description' ILIKE :search_pattern
+                    THEN 0.9
+                    ELSE 0.0
+                END,
+                word_similarity(:search_query, COALESCE(M.ocr_result ->> 'text', '')),
+                word_similarity(
+                    :search_query,
+                    COALESCE(M.ocr_result -> 'raw_result' ->> 'ocr_text', '')
+                ),
+                word_similarity(:search_query, COALESCE(M.ocr_result ->> 'description', '')) * 0.9
+            ) AS inline_search_score
         FROM meme M
-        WHERE M.status = '{MemeStatus.OK}'
-        AND M.type = '{MemeType.IMAGE}'
-        AND M.ocr_result IS NOT NULL
-        ORDER BY word_similarity(:search_query, M.ocr_result ->> 'text') DESC
-        LIMIT {limit};
+        WHERE M.status = :status
+            AND M.type = :type
+            AND M.telegram_file_id IS NOT NULL
+            AND (
+                M.ocr_result ->> 'text' ILIKE :search_pattern
+                OR M.ocr_result -> 'raw_result' ->> 'ocr_text' ILIKE :search_pattern
+                OR M.ocr_result ->> 'description' ILIKE :search_pattern
+                OR (M.ocr_result ->> 'text') % :search_query
+                OR (M.ocr_result -> 'raw_result' ->> 'ocr_text') % :search_query
+                OR (M.ocr_result ->> 'description') % :search_query
+            )
+        ORDER BY inline_search_score DESC, M.published_at DESC
+        LIMIT :limit;
     """
-    select_statement = text(select_query).bindparams(bindparam("search_query", value=search_query))
+    select_statement = text(select_query)
 
-    return await fetch_all(select_statement)
+    return await fetch_all(
+        select_statement,
+        {
+            "search_query": search_query,
+            "search_pattern": f"%{search_query}%",
+            "status": MemeStatus.OK.value,
+            "type": MemeType.IMAGE.value,
+            "limit": limit,
+        },
+    )
 
 
 async def get_user_languages(

--- a/tests/tgbot/test_inline_search.py
+++ b/tests/tgbot/test_inline_search.py
@@ -1,0 +1,46 @@
+import pytest
+
+from src.tgbot import service
+
+
+@pytest.mark.asyncio
+async def test_inline_search_uses_old_new_ocr_and_openrouter_description(monkeypatch):
+    captured = {}
+
+    async def fake_fetch_all(query, params=None):
+        captured["query"] = str(query)
+        captured["params"] = params
+        return [{"id": 1}]
+
+    monkeypatch.setattr(service, "fetch_all", fake_fetch_all)
+
+    rows = await service.search_memes_for_inline_query("деньги", limit=10)
+
+    assert rows == [{"id": 1}]
+    assert "ocr_result ->> 'text'" in captured["query"]
+    assert "ocr_result -> 'raw_result' ->> 'ocr_text'" in captured["query"]
+    assert "ocr_result ->> 'description'" in captured["query"]
+    assert "ILIKE :search_pattern" in captured["query"]
+    assert "% :search_query" in captured["query"]
+    assert captured["params"] == {
+        "search_query": "деньги",
+        "search_pattern": "%деньги%",
+        "status": "ok",
+        "type": "image",
+        "limit": 10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_inline_search_clamps_limit(monkeypatch):
+    captured = {}
+
+    async def fake_fetch_all(query, params=None):
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(service, "fetch_all", fake_fetch_all)
+
+    await service.search_memes_for_inline_query("money", limit=1000)
+
+    assert captured["params"]["limit"] == 50


### PR DESCRIPTION
## Summary
- search inline meme results across old OCR text, OpenRouter raw OCR text, and OpenRouter descriptions
- add trigram indexes for the OpenRouter JSON fields used by inline search
- cover the inline-search SQL source coverage with focused tests

## Verification
- python -m pytest tests/tgbot/test_inline_search.py -q
- python -m ruff check src/tgbot/service.py tests/tgbot/test_inline_search.py alembic/versions/2026-05-15_inline_search_ocr_source_indexes.py
- python -m ruff format --check src/tgbot/service.py tests/tgbot/test_inline_search.py alembic/versions/2026-05-15_inline_search_ocr_source_indexes.py
- alembic heads
- git diff --check

Production data check is being run via Analyst / FFM-1280.