### PR TITLE
Fix inline search wildcard escaping

### DIFF
--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -235,20 +235,30 @@ async def promote_source_candidate(
     return promoted
 
 
+def _escape_like_pattern(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 async def search_memes_for_inline_query(search_query: str, limit: int) -> list[dict[str, Any]]:
     limit = max(1, min(limit, 50))
+    search_pattern = f"%{_escape_like_pattern(search_query)}%"
     select_query = """
         SELECT
             M.*,
             GREATEST(
-                CASE WHEN M.ocr_result ->> 'text' ILIKE :search_pattern THEN 1.0 ELSE 0.0 END,
                 CASE
-                    WHEN M.ocr_result -> 'raw_result' ->> 'ocr_text' ILIKE :search_pattern
+                    WHEN M.ocr_result ->> 'text' ILIKE :search_pattern ESCAPE '\\'
                     THEN 1.0
                     ELSE 0.0
                 END,
                 CASE
-                    WHEN M.ocr_result ->> 'description' ILIKE :search_pattern
+                    WHEN M.ocr_result -> 'raw_result' ->> 'ocr_text'
+                        ILIKE :search_pattern ESCAPE '\\'
+                    THEN 1.0
+                    ELSE 0.0
+                END,
+                CASE
+                    WHEN M.ocr_result ->> 'description' ILIKE :search_pattern ESCAPE '\\'
                     THEN 0.9
                     ELSE 0.0
                 END,
@@ -264,9 +274,10 @@ async def search_memes_for_inline_query(search_query: str, limit: int) -> list[d
             AND M.type = :type
             AND M.telegram_file_id IS NOT NULL
             AND (
-                M.ocr_result ->> 'text' ILIKE :search_pattern
-                OR M.ocr_result -> 'raw_result' ->> 'ocr_text' ILIKE :search_pattern
-                OR M.ocr_result ->> 'description' ILIKE :search_pattern
+                M.ocr_result ->> 'text' ILIKE :search_pattern ESCAPE '\\'
+                OR M.ocr_result -> 'raw_result' ->> 'ocr_text'
+                    ILIKE :search_pattern ESCAPE '\\'
+                OR M.ocr_result ->> 'description' ILIKE :search_pattern ESCAPE '\\'
                 OR (M.ocr_result ->> 'text') % :search_query
                 OR (M.ocr_result -> 'raw_result' ->> 'ocr_text') % :search_query
                 OR (M.ocr_result ->> 'description') % :search_query
@@ -280,7 +291,7 @@ async def search_memes_for_inline_query(search_query: str, limit: int) -> list[d
         select_statement,
         {
             "search_query": search_query,
-            "search_pattern": f"%{search_query}%",
+            "search_pattern": search_pattern,
             "status": MemeStatus.OK.value,
             "type": MemeType.IMAGE.value,
             "limit": limit,

--- a/tests/tgbot/test_inline_search.py
+++ b/tests/tgbot/test_inline_search.py
@@ -20,7 +20,7 @@ async def test_inline_search_uses_old_new_ocr_and_openrouter_description(monkeyp
     assert "ocr_result ->> 'text'" in captured["query"]
     assert "ocr_result -> 'raw_result' ->> 'ocr_text'" in captured["query"]
     assert "ocr_result ->> 'description'" in captured["query"]
-    assert "ILIKE :search_pattern" in captured["query"]
+    assert "ILIKE :search_pattern ESCAPE '\\'" in captured["query"]
     assert "% :search_query" in captured["query"]
     assert captured["params"] == {
         "search_query": "деньги",
@@ -44,3 +44,19 @@ async def test_inline_search_clamps_limit(monkeypatch):
     await service.search_memes_for_inline_query("money", limit=1000)
 
     assert captured["params"]["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_inline_search_escapes_like_wildcards(monkeypatch):
+    captured = {}
+
+    async def fake_fetch_all(query, params=None):
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(service, "fetch_all", fake_fetch_all)
+
+    await service.search_memes_for_inline_query(r"%%_\\", limit=10)
+
+    assert captured["params"]["search_query"] == r"%%_\\"
+    assert captured["params"]["search_pattern"] == r"%\%\%\_\\\\%"


### PR DESCRIPTION
## Summary
- Escape `%`, `_`, and backslashes before wrapping inline search input in an `ILIKE` pattern
- Add explicit `ESCAPE '\\'` clauses to the inline-search OCR/description `ILIKE` checks
- Add coverage for wildcard-only inline search input so it no longer broad-matches unrelated rows

Fixes FFM-1283.
Follow-up to staff review on PR #265.

## Verification
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `DATABASE_URL=postgresql+asyncpg://user:pass@localhost/test REDIS_URL=redis://localhost:6379/0 CORS_ORIGINS='["*"]' CORS_HEADERS='["*"]' python3 -m pytest tests/tgbot/test_inline_search.py -q`
- `git diff --check`