### PR TITLE
Rank inline search by meme quality

### DIFF
--- a/src/tgbot/handlers/inline.py
+++ b/src/tgbot/handlers/inline.py
@@ -22,6 +22,7 @@ from src.tgbot.user_info import get_user_info
 
 MIN_SEARCH_QUERY_LENGTH = 3
 MAX_SEARCH_QUERY_LENGTH = 128
+INLINE_SEARCH_RESULT_LIMIT = 20
 INLINE_SEARCH_RESULT_CACHE_SECONDS = 60 * 60 * 12  # 12 hours
 
 
@@ -81,7 +82,7 @@ async def search_inline(update: Update, _: ContextTypes.DEFAULT_TYPE):
             ),
         )
 
-    memes = await search_memes_for_inline_query(query, limit=10)
+    memes = await search_memes_for_inline_query(query, limit=INLINE_SEARCH_RESULT_LIMIT)
 
     if len(memes) == 0:
         no_results_button = InlineQueryResultsButton(

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -258,8 +258,20 @@ async def search_memes_for_inline_query(search_query: str, limit: int) -> list[d
                     COALESCE(M.ocr_result -> 'raw_result' ->> 'ocr_text', '')
                 ),
                 word_similarity(:search_query, COALESCE(M.ocr_result ->> 'description', '')) * 0.9
-            ) AS inline_search_score
+            ) AS inline_search_score,
+            COALESCE((MS.nlikes + 1.) / NULLIF(MS.nlikes + MS.ndislikes + 1, 0), 0.5)
+            * CASE WHEN COALESCE(MS.raw_impr_rank, 99999) <= 1 THEN 1 ELSE 0.8 END
+            * CASE WHEN COALESCE(MS.age_days, 99999) < 90 THEN 1 ELSE 0.8 END
+            * CASE
+                WHEN COALESCE(MS.nmemes_sent, 0) <= 1 THEN 1
+                ELSE (MS.nlikes + MS.ndislikes) * 1. / NULLIF(MS.nmemes_sent, 0)
+              END
+            * (1.0 + LEAST(COALESCE(MS.invited_count, 0), 10) * 0.1)
+            * (1.0 + GREATEST(COALESCE(MS.engagement_score, 0), 0))
+            AS inline_quality_score
         FROM meme M
+        LEFT JOIN meme_stats MS
+            ON MS.meme_id = M.id
         WHERE M.status = :status
             AND M.type = :type
             AND M.telegram_file_id IS NOT NULL
@@ -271,7 +283,7 @@ async def search_memes_for_inline_query(search_query: str, limit: int) -> list[d
                 OR (M.ocr_result -> 'raw_result' ->> 'ocr_text') % :search_query
                 OR (M.ocr_result ->> 'description') % :search_query
             )
-        ORDER BY inline_search_score DESC, M.published_at DESC
+        ORDER BY inline_search_score DESC, inline_quality_score DESC, M.published_at DESC
         LIMIT :limit;
     """
     select_statement = text(select_query)

--- a/tests/tgbot/test_inline_search.py
+++ b/tests/tgbot/test_inline_search.py
@@ -1,6 +1,11 @@
 import pytest
 
 from src.tgbot import service
+from src.tgbot.handlers.inline import INLINE_SEARCH_RESULT_LIMIT
+
+
+def test_inline_search_returns_twenty_results():
+    assert INLINE_SEARCH_RESULT_LIMIT == 20
 
 
 @pytest.mark.asyncio
@@ -22,6 +27,9 @@ async def test_inline_search_uses_old_new_ocr_and_openrouter_description(monkeyp
     assert "ocr_result ->> 'description'" in captured["query"]
     assert "ILIKE :search_pattern" in captured["query"]
     assert "% :search_query" in captured["query"]
+    assert "LEFT JOIN meme_stats MS" in captured["query"]
+    assert "AS inline_quality_score" in captured["query"]
+    assert "ORDER BY inline_search_score DESC, inline_quality_score DESC" in captured["query"]
     assert captured["params"] == {
         "search_query": "деньги",
         "search_pattern": "%деньги%",


### PR DESCRIPTION
## Summary
- return 20 inline search results instead of 10
- rank matched results by relevance, then meme quality/virality signals from meme_stats
- cover the result limit and SQL ordering with focused tests

## Ranking signals
- engagement_score
- smoothed like rate
- raw impression rank
- age
- reaction density
- invited/share count

## Verification
- python -m pytest tests/tgbot/test_inline_search.py -q
- python -m ruff check src/tgbot/service.py src/tgbot/handlers/inline.py tests/tgbot/test_inline_search.py
- python -m ruff format --check src/tgbot/service.py src/tgbot/handlers/inline.py tests/tgbot/test_inline_search.py
- python -m py_compile src/tgbot/service.py src/tgbot/handlers/inline.py tests/tgbot/test_inline_search.py
- git diff --check