### PR TITLE
Fix: neutralize inline quality zero reaction prior

### DIFF
--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -269,7 +269,8 @@ async def search_memes_for_inline_query(search_query: str, limit: int) -> list[d
                 ),
                 word_similarity(:search_query, COALESCE(M.ocr_result ->> 'description', '')) * 0.9
             ) AS inline_search_score,
-            COALESCE((MS.nlikes + 1.) / NULLIF(MS.nlikes + MS.ndislikes + 1, 0), 0.5)
+            (COALESCE(MS.nlikes, 0) + 1.)
+            / (COALESCE(MS.nlikes, 0) + COALESCE(MS.ndislikes, 0) + 2)
             * CASE WHEN COALESCE(MS.raw_impr_rank, 99999) <= 1 THEN 1 ELSE 0.8 END
             * CASE WHEN COALESCE(MS.age_days, 99999) < 90 THEN 1 ELSE 0.8 END
             * CASE

--- a/tests/tgbot/test_inline_search.py
+++ b/tests/tgbot/test_inline_search.py
@@ -29,6 +29,9 @@ async def test_inline_search_uses_old_new_ocr_and_openrouter_description(monkeyp
     assert "% :search_query" in captured["query"]
     assert "LEFT JOIN meme_stats MS" in captured["query"]
     assert "AS inline_quality_score" in captured["query"]
+    assert "(COALESCE(MS.nlikes, 0) + 1.)" in captured["query"]
+    assert "COALESCE(MS.nlikes, 0) + COALESCE(MS.ndislikes, 0) + 2" in captured["query"]
+    assert "NULLIF(MS.nlikes + MS.ndislikes + 1, 0)" not in captured["query"]
     assert "ORDER BY inline_search_score DESC, inline_quality_score DESC" in captured["query"]
     assert captured["params"] == {
         "search_query": "деньги",


### PR DESCRIPTION
## Summary
- keep the merged escaped `ILIKE ... ESCAPE '\\'` inline search path intact
- change the inline quality like-rate factor to use a neutral Bayesian prior for zero-reaction or missing `meme_stats` rows
- assert the ranking SQL no longer uses the old zero-reaction-as-1.0 formula

## Verification
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `DATABASE_URL=postgresql+asyncpg://app:app@app_db:5432/app REDIS_URL=redis://localhost:6379/0 ENVIRONMENT=TESTING CORS_ORIGINS='["http://localhost:3000"]' CORS_HEADERS='["*"]' python3 -m pytest tests/tgbot/test_inline_search.py -q`
- `git diff --check origin/production...HEAD`

Addresses FFM-1287, follow-up to #267.