### PR TITLE
Gate Telegram intake by top views

### DIFF
--- a/src/storage/etl.py
+++ b/src/storage/etl.py
@@ -236,6 +236,10 @@ async def etl_memes_from_raw_telegram_posts(
                             NOT :filter_meme_source_ids
                             OR MRT.meme_source_id = ANY(:meme_source_ids)
                         )
+                        AND (
+                            NOT :fresh_only
+                            OR COALESCE(MRT.updated_at, MRT.created_at) >= NOW() - INTERVAL '24 hours'
+                        )
                 ),
                 top_viewed_recent_posts AS (
                     SELECT id

--- a/src/storage/etl.py
+++ b/src/storage/etl.py
@@ -20,6 +20,8 @@ from src.storage.parsers.schemas import (
 )
 
 _TG_FORWARD_URL_PATTERN = re.compile(r"^https?://t\.me/(?:s/)?([a-zA-Z0-9_]+)(?:/\d+)?/?$")
+TG_RECENT_POSTS_WINDOW = 10
+TG_TOP_VIEWED_POSTS_LIMIT = 5
 
 
 def normalize_telegram_channel_url(forwarded_url: str) -> Optional[str]:
@@ -201,9 +203,12 @@ async def etl_memes_from_raw_telegram_posts(
     # find ones that are already in the database
     # create rows and update rows
     #
-    # Engagement filter: skip posts with views < 30% of their source's median.
-    # This filters low-quality posts (likely ads or junk) before they enter the
-    # meme table. Posts with 0 views (views not available) are kept.
+    # Engagement filters before raw posts enter the meme table:
+    # 1. From each source's latest 10 posts, only promote the top 5 by views.
+    #    Raw rows are still stored, so this threshold can be replayed later.
+    # 2. Skip posts with views < 30% of their source's median.
+    #    This filters low-quality posts (likely ads or junk). Posts with 0
+    #    views (views not available) are kept if they survive the top-view gate.
     transformed_memes = await fetch_all(
         text(
             """
@@ -215,6 +220,38 @@ async def etl_memes_from_raw_telegram_posts(
                     WHERE COALESCE(updated_at, created_at) >= NOW() - INTERVAL '24 hours'
                       AND views > 0
                     GROUP BY meme_source_id
+                ),
+                latest_source_posts AS (
+                    SELECT
+                        MRT.id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY MRT.meme_source_id
+                            ORDER BY MRT.date DESC, MRT.post_id DESC, MRT.id DESC
+                        ) AS recent_rank
+                    FROM meme_raw_telegram MRT
+                    INNER JOIN meme_source MS
+                        ON MS.id = MRT.meme_source_id
+                    WHERE MS.status = 'parsing_enabled'
+                        AND (
+                            NOT :filter_meme_source_ids
+                            OR MRT.meme_source_id = ANY(:meme_source_ids)
+                        )
+                ),
+                top_viewed_recent_posts AS (
+                    SELECT id
+                    FROM (
+                        SELECT
+                            MRT.id,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY MRT.meme_source_id
+                                ORDER BY MRT.views DESC, MRT.date DESC, MRT.post_id DESC, MRT.id DESC
+                            ) AS views_rank
+                        FROM meme_raw_telegram MRT
+                        INNER JOIN latest_source_posts LSP
+                            ON LSP.id = MRT.id
+                        WHERE LSP.recent_rank <= :recent_posts_window
+                    ) ranked_recent
+                    WHERE views_rank <= :top_viewed_posts_limit
                 )
                 SELECT
                     DISTINCT ON (COALESCE(MRT.forwarded_url, random()::text))
@@ -234,6 +271,8 @@ async def etl_memes_from_raw_telegram_posts(
                     ON MS.id = MRT.meme_source_id
                 LEFT JOIN source_medians SM
                     ON SM.meme_source_id = MRT.meme_source_id
+                INNER JOIN top_viewed_recent_posts TVRP
+                    ON TVRP.id = MRT.id
                 WHERE 1=1
                     AND MS.status = 'parsing_enabled'
                     AND (
@@ -274,6 +313,8 @@ async def etl_memes_from_raw_telegram_posts(
             "filter_meme_source_ids": meme_source_ids is not None,
             "meme_source_ids": meme_source_ids or [],
             "fresh_only": fresh_only,
+            "recent_posts_window": TG_RECENT_POSTS_WINDOW,
+            "top_viewed_posts_limit": TG_TOP_VIEWED_POSTS_LIMIT,
         },
     )
 

--- a/tests/storage/test_telegram_etl_source_status.py
+++ b/tests/storage/test_telegram_etl_source_status.py
@@ -7,6 +7,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from src.database import engine, fetch_one, meme, meme_raw_telegram, meme_source
+from src.storage import etl as telegram_etl
 from src.storage.constants import MemeSourceStatus
 from src.storage.etl import etl_memes_from_raw_telegram_posts, insert_parsed_posts_from_telegram
 from src.storage.parsers.schemas import TgChannelPostParsingResult
@@ -53,6 +54,34 @@ async def conn():
         )
         await conn.commit()
         await cleanup_test_data(conn)
+
+
+@pytest.mark.asyncio
+async def test_telegram_etl_applies_freshness_before_top_view_ranking(monkeypatch):
+    captured_queries = []
+
+    async def fake_fetch_all(query, params=None):
+        captured_queries.append((str(query), params))
+        return []
+
+    async def fake_update_or_create_memes(transformed_memes, memes_not_in_memes_table):
+        return None
+
+    monkeypatch.setattr(telegram_etl, "fetch_all", fake_fetch_all)
+    monkeypatch.setattr(telegram_etl, "update_or_create_memes", fake_update_or_create_memes)
+
+    await etl_memes_from_raw_telegram_posts(fresh_only=True)
+
+    transform_query, transform_params = captured_queries[0]
+    latest_source_posts_query = transform_query.split("latest_source_posts AS (", 1)[1].split(
+        "),\n                top_viewed_recent_posts", 1
+    )[0]
+
+    assert transform_params["fresh_only"] is True
+    assert "NOT :fresh_only" in latest_source_posts_query
+    assert "COALESCE(MRT.updated_at, MRT.created_at) >= NOW() - INTERVAL '24 hours'" in (
+        latest_source_posts_query
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_telegram_etl_source_status.py
+++ b/tests/storage/test_telegram_etl_source_status.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 import pytest_asyncio
@@ -15,16 +15,23 @@ from tests.factories import TEST_ID_START, cleanup_test_data, create_meme_source
 IN_MODERATION_SOURCE_ID = TEST_ID_START + 2100
 ENABLED_SOURCE_ID = TEST_ID_START + 2101
 MALFORMED_SOURCE_ID = TEST_ID_START + 2102
+TOP_VIEWED_SOURCE_ID = TEST_ID_START + 2103
 
 
-def _post(source_id: int, post_id: int) -> TgChannelPostParsingResult:
+def _post(
+    source_id: int,
+    post_id: int,
+    *,
+    views: int = 100,
+    date: datetime | None = None,
+) -> TgChannelPostParsingResult:
     return TgChannelPostParsingResult(
         post_id=post_id,
         url=f"https://t.me/test_source_{source_id}/{post_id}",
         content="мем дня",
         media=[{"url": "https://example.com/meme.jpg"}],
-        views=100,
-        date=datetime.utcnow(),
+        views=views,
+        date=date or datetime.utcnow(),
     )
 
 
@@ -34,7 +41,14 @@ async def conn():
         yield conn
         await conn.execute(
             delete(meme_source).where(
-                meme_source.c.id.in_([IN_MODERATION_SOURCE_ID, ENABLED_SOURCE_ID])
+                meme_source.c.id.in_(
+                    [
+                        IN_MODERATION_SOURCE_ID,
+                        ENABLED_SOURCE_ID,
+                        MALFORMED_SOURCE_ID,
+                        TOP_VIEWED_SOURCE_ID,
+                    ]
+                )
             )
         )
         await conn.commit()
@@ -115,3 +129,60 @@ async def test_telegram_etl_ignores_malformed_media_rows(conn: AsyncConnection):
 
     created = await fetch_one(select(meme).where(meme.c.meme_source_id == MALFORMED_SOURCE_ID))
     assert created is None
+
+
+@pytest.mark.asyncio
+async def test_telegram_etl_promotes_top_five_views_from_latest_ten_posts(
+    conn: AsyncConnection,
+):
+    await create_meme_source(
+        conn,
+        id=TOP_VIEWED_SOURCE_ID,
+        status=MemeSourceStatus.PARSING_ENABLED.value,
+    )
+    await conn.commit()
+
+    base_date = datetime(2026, 1, 1, 12, 0, 0)
+    posts = [
+        # Older than the latest-10 window: high views must not matter.
+        _post(TOP_VIEWED_SOURCE_ID, 4001, views=9999, date=base_date),
+        _post(TOP_VIEWED_SOURCE_ID, 4002, views=8888, date=base_date + timedelta(minutes=1)),
+        # Latest 10 posts: only the top 5 by views should enter `meme`.
+        _post(TOP_VIEWED_SOURCE_ID, 4003, views=10, date=base_date + timedelta(minutes=2)),
+        _post(TOP_VIEWED_SOURCE_ID, 4004, views=900, date=base_date + timedelta(minutes=3)),
+        _post(TOP_VIEWED_SOURCE_ID, 4005, views=30, date=base_date + timedelta(minutes=4)),
+        _post(TOP_VIEWED_SOURCE_ID, 4006, views=800, date=base_date + timedelta(minutes=5)),
+        _post(TOP_VIEWED_SOURCE_ID, 4007, views=40, date=base_date + timedelta(minutes=6)),
+        _post(TOP_VIEWED_SOURCE_ID, 4008, views=700, date=base_date + timedelta(minutes=7)),
+        _post(TOP_VIEWED_SOURCE_ID, 4009, views=50, date=base_date + timedelta(minutes=8)),
+        _post(TOP_VIEWED_SOURCE_ID, 4010, views=600, date=base_date + timedelta(minutes=9)),
+        _post(TOP_VIEWED_SOURCE_ID, 4011, views=60, date=base_date + timedelta(minutes=10)),
+        _post(TOP_VIEWED_SOURCE_ID, 4012, views=500, date=base_date + timedelta(minutes=11)),
+    ]
+
+    await insert_parsed_posts_from_telegram(
+        TOP_VIEWED_SOURCE_ID,
+        posts,
+        discover_candidates=False,
+    )
+    await etl_memes_from_raw_telegram_posts([TOP_VIEWED_SOURCE_ID], fresh_only=False)
+
+    created = await fetch_one(
+        select(func.count().label("n"))
+        .select_from(meme)
+        .where(meme.c.meme_source_id == TOP_VIEWED_SOURCE_ID)
+    )
+    rows = await conn.execute(
+        select(meme_raw_telegram.c.post_id)
+        .select_from(meme)
+        .join(
+            meme_raw_telegram,
+            (meme_raw_telegram.c.id == meme.c.raw_meme_id)
+            & (meme_raw_telegram.c.meme_source_id == meme.c.meme_source_id),
+        )
+        .where(meme.c.meme_source_id == TOP_VIEWED_SOURCE_ID)
+        .order_by(meme_raw_telegram.c.post_id)
+    )
+
+    assert created["n"] == 5
+    assert [row.post_id for row in rows] == [4004, 4006, 4008, 4010, 4012]


### PR DESCRIPTION
## Summary
- keep saving all parsed Telegram raw posts, but only promote the top 5 by views from each source's latest 10 raw posts into the meme table
- keep the existing median-view and ad-style filters after the new top-view gate
- add an integration test covering old high-view posts being ignored and only the top-viewed posts from the latest-10 window being promoted

## Verification
- ruff check src/storage/etl.py tests/storage/test_telegram_etl_source_status.py
- ruff format --check src/storage/etl.py tests/storage/test_telegram_etl_source_status.py
- python -m compileall src/storage/etl.py tests/storage/test_telegram_etl_source_status.py

## Could not run
- docker compose exec app pytest tests/storage/test_telegram_etl_source_status.py: Docker daemon unavailable at ~/.orbstack/run/docker.sock
- python -m pytest tests/storage/test_telegram_etl_source_status.py -q: local environment cannot resolve app_db outside docker compose
