### PR TITLE
feat: add text-light recommendation experiment

### DIFF
--- a/specs/recommendations.md
+++ b/specs/recommendations.md
@@ -11,7 +11,7 @@ User reacts -> handle_reaction() -> update_user_meme_reaction()
 ```
 
 Key files:
-- [`src/recommendations/candidates.py`](../src/recommendations/candidates.py) — 8 SQL engines + CandidatesRetriever
+- [`src/recommendations/candidates.py`](../src/recommendations/candidates.py) — SQL engines + CandidatesRetriever
 - [`src/recommendations/blender.py`](../src/recommendations/blender.py) — weighted random sampling
 - [`src/recommendations/meme_queue.py`](../src/recommendations/meme_queue.py) — queue check/refill/maturity routing
 - [`src/recommendations/service.py`](../src/recommendations/service.py) — reaction persistence, reaction_exists check
@@ -22,6 +22,7 @@ Key files:
 |--------|-------------|
 | `best_uploaded_memes` | Top user-uploaded memes by like rate |
 | `lr_smoothed` | Global smoothed like rate ranking |
+| `text_light_lr_smoothed` | Same as `lr_smoothed`, but excludes OCR text above 30 words |
 | `like_spread_and_recent_memes` | High like rate + recent + reach diversity |
 | `recently_liked` | Memes from sources the user recently liked |
 | `goat` | All-time best memes by like rate (see [TODOS.md](../TODOS.md) for per-user recency filter) |
@@ -35,12 +36,12 @@ Removed engines: `fast_dopamine`, `classic`, `multiply_all_scores`, `selected_so
 
 | Stage | Trigger | Engines | Source |
 |-------|---------|---------|--------|
-| Cold start | nmemes_sent < 30 | 3-phase adaptive: explore -> adapt -> transition | [`meme_queue.py`](../src/recommendations/meme_queue.py) |
-| Growing | 30-100 | best_uploaded:0.1, lr_smoothed:0.3, recently_liked:0.2, goat:0.1, es_ranked:0.1, like_spread:0.2 | [`meme_queue.py`](../src/recommendations/meme_queue.py) |
-| Mature | 100+ | best_uploaded:0.3, like_spread:0.3, lr_smoothed:0.4, recently_liked:0.2, goat:0.1, es_ranked:0.1 | [`meme_queue.py`](../src/recommendations/meme_queue.py) |
+| Cold start | nmemes_sent < 30 | 3-phase adaptive with text-light guards: explore/adapt/fallback avoid OCR text above 30 words | [`meme_queue.py`](../src/recommendations/meme_queue.py) |
+| Growing | 30-100 | A/B: control uses `lr_smoothed`; treatment swaps that slot to `text_light_lr_smoothed` | [`meme_queue.py`](../src/recommendations/meme_queue.py) |
+| Mature | 100+ | Recently-liked blender v2, then A/B text-light overlay can swap `lr_smoothed` to `text_light_lr_smoothed` | [`meme_queue.py`](../src/recommendations/meme_queue.py) |
 | Moderator/Admin | user_type check | 75% low_sent_pool + 25% regular (by maturity) | [`meme_queue.py`](../src/recommendations/meme_queue.py) |
 
-`fixed_pos={0: "lr_smoothed"}` forces first position to lr_smoothed in blended mode.
+`fixed_pos={0: "lr_smoothed"}` forces first position to `lr_smoothed` in blended mode. In the `text_light_blender_v1` treatment, that fixed slot becomes `text_light_lr_smoothed`.
 
 ## Known Bugs
 

--- a/src/feed_turn/planner.py
+++ b/src/feed_turn/planner.py
@@ -40,7 +40,10 @@ class CandidateSelectionPlan:
         object.__setattr__(self, "fallback_engines", tuple(self.fallback_engines))
 
 
-LR_SMOOTHED_COLD_FALLBACK = EngineFallback("lr_smoothed", {"min_sends": 10})
+TEXT_LIGHT_LR_SMOOTHED_COLD_FALLBACK = EngineFallback(
+    "text_light_lr_smoothed",
+    {"min_sends": 10},
+)
 BEST_UPLOADED_FALLBACK = EngineFallback("best_uploaded_memes")
 
 
@@ -49,14 +52,14 @@ def plan_candidate_selection(nmemes_sent: int) -> CandidateSelectionPlan:
         return CandidateSelectionPlan(
             maturity_stage=COLD_START_1,
             primary_engine="cold_start_explore",
-            fallback_engines=(LR_SMOOTHED_COLD_FALLBACK, BEST_UPLOADED_FALLBACK),
+            fallback_engines=(TEXT_LIGHT_LR_SMOOTHED_COLD_FALLBACK, BEST_UPLOADED_FALLBACK),
         )
 
     if nmemes_sent < 16:
         return CandidateSelectionPlan(
             maturity_stage=COLD_START_2,
             primary_engine="cold_start_adapt",
-            fallback_engines=(LR_SMOOTHED_COLD_FALLBACK, BEST_UPLOADED_FALLBACK),
+            fallback_engines=(TEXT_LIGHT_LR_SMOOTHED_COLD_FALLBACK, BEST_UPLOADED_FALLBACK),
         )
 
     if nmemes_sent < 30:
@@ -65,13 +68,13 @@ def plan_candidate_selection(nmemes_sent: int) -> CandidateSelectionPlan:
             primary_engine=None,
             blend_weights={
                 "cold_start_adapt": 0.5,
-                "lr_smoothed": 0.3,
+                "text_light_lr_smoothed": 0.3,
                 "like_spread_and_recent_memes": 0.2,
             },
             fixed_pos={0: "cold_start_adapt"},
             fallback_engines=(
                 EngineFallback("cold_start_adapt"),
-                LR_SMOOTHED_COLD_FALLBACK,
+                TEXT_LIGHT_LR_SMOOTHED_COLD_FALLBACK,
                 BEST_UPLOADED_FALLBACK,
             ),
         )

--- a/src/recommendations/blender_experiments.py
+++ b/src/recommendations/blender_experiments.py
@@ -33,6 +33,11 @@ RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_KEY = (
 )
 RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_TTL_SECONDS = 15 * 60
 RECENTLY_LIKED_BLENDER_V2_QUARTILE_BOUNDARIES_LOCK_SECONDS = 30
+TEXT_LIGHT_BLENDER_V1_EXPERIMENT_ID = "text_light_blender_v1"
+TEXT_LIGHT_BLENDER_V1_CONTROL = "control"
+TEXT_LIGHT_BLENDER_V1_TREATMENT = "treatment_text_light_lr_smoothed"
+TEXT_LIGHT_BLENDER_V1_MAX_OCR_WORDS = 30
+TEXT_LIGHT_BLENDER_V1_SAMPLE_GATE_PER_VARIANT = 1000
 
 MATURE_BLENDER_CONTROL_WEIGHTS = {
     "best_uploaded_memes": 0.3,
@@ -64,6 +69,21 @@ def _weights_for_variant(variant: str) -> dict[str, float]:
     if variant == RECENTLY_LIKED_BLENDER_V2_TREATMENT:
         return dict(MATURE_BLENDER_TREATMENT_WEIGHTS)
     return dict(MATURE_BLENDER_CONTROL_WEIGHTS)
+
+
+def _text_light_weights(base_weights: dict[str, float]) -> dict[str, float]:
+    weights = dict(base_weights)
+    lr_weight = weights.pop("lr_smoothed", 0.0)
+    weights["text_light_lr_smoothed"] = lr_weight
+    return weights
+
+
+def _text_light_variant_for_user(user_id: int) -> str:
+    key = f"{TEXT_LIGHT_BLENDER_V1_EXPERIMENT_ID}:{user_id}"
+    bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 2
+    if bucket == 0:
+        return TEXT_LIGHT_BLENDER_V1_CONTROL
+    return TEXT_LIGHT_BLENDER_V1_TREATMENT
 
 
 def _coerce_lr_quartile_boundaries(raw_boundaries: Any) -> tuple[float, float, float] | None:
@@ -350,3 +370,73 @@ async def get_recently_liked_blender_v2_weights(user_id: int) -> dict[str, float
         return dict(MATURE_BLENDER_CONTROL_WEIGHTS)
 
     return _weights_for_variant(variant)
+
+
+def build_text_light_blender_v1_assignment(
+    user_id: int,
+    base_weights: dict[str, float],
+) -> tuple[str, dict[str, Any]]:
+    variant = _text_light_variant_for_user(user_id)
+    treatment_weights = _text_light_weights(base_weights)
+    assignment_metadata = {
+        "assignment_strategy": "sha256(experiment_id:user_id)%2",
+        "max_ocr_words": TEXT_LIGHT_BLENDER_V1_MAX_OCR_WORDS,
+        "filtered_engine": "text_light_lr_smoothed",
+        "control_engine": "lr_smoothed",
+        "sample_gate_per_variant": TEXT_LIGHT_BLENDER_V1_SAMPLE_GATE_PER_VARIANT,
+        "primary_read": "compare post-assignment like_rate, session depth, fast-skip rate",
+        "base_weights": dict(base_weights),
+        "assigned_weights": (
+            treatment_weights if variant == TEXT_LIGHT_BLENDER_V1_TREATMENT else dict(base_weights)
+        ),
+    }
+    return variant, assignment_metadata
+
+
+async def get_or_assign_text_light_blender_v1_variant(
+    user_id: int,
+    base_weights: dict[str, float],
+) -> str:
+    assignment = await get_experiment_assignment(
+        user_id,
+        TEXT_LIGHT_BLENDER_V1_EXPERIMENT_ID,
+    )
+    if assignment is not None:
+        return assignment["variant"]
+
+    proposed_variant, assignment_metadata = build_text_light_blender_v1_assignment(
+        user_id,
+        base_weights,
+    )
+    inserted = await assign_experiment(
+        user_id,
+        TEXT_LIGHT_BLENDER_V1_EXPERIMENT_ID,
+        proposed_variant,
+        assignment_metadata,
+    )
+    if inserted:
+        return proposed_variant
+
+    return (
+        await get_experiment_variant(user_id, TEXT_LIGHT_BLENDER_V1_EXPERIMENT_ID)
+        or TEXT_LIGHT_BLENDER_V1_CONTROL
+    )
+
+
+async def get_text_light_blender_v1_weights(
+    user_id: int,
+    base_weights: dict[str, float],
+) -> dict[str, float]:
+    try:
+        variant = await get_or_assign_text_light_blender_v1_variant(user_id, base_weights)
+    except Exception:
+        logger.warning(
+            "text-light blender v1 assignment failed for user %d",
+            user_id,
+            exc_info=True,
+        )
+        return dict(base_weights)
+
+    if variant == TEXT_LIGHT_BLENDER_V1_TREATMENT:
+        return _text_light_weights(base_weights)
+    return dict(base_weights)

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -14,6 +14,17 @@ logger = logging.getLogger(__name__)
 GOAT_MIN_REACTIONS = 10  # (nlikes + ndislikes) — enough statistical signal
 GOAT_MIN_LR = 0.20  # lr_smoothed — minimum proven like rate
 GOAT_MIN_AGE_DAYS = 3  # days since created_at — must have aged enough to accumulate reactions
+TEXT_LIGHT_MAX_OCR_WORDS = 30
+
+_OCR_TEXT_SQL = "trim(coalesce(M.ocr_result->>'text', M.ocr_result->'raw_result'->>'ocr_text', ''))"
+TEXT_LIGHT_OCR_FILTER_SQL = f"""
+            AND (
+                CASE
+                    WHEN {_OCR_TEXT_SQL} = '' THEN 0
+                    ELSE cardinality(regexp_split_to_array({_OCR_TEXT_SQL}, '[[:space:]]+'))
+                END
+            ) <= :text_light_max_ocr_words
+"""
 
 
 def _build_params(
@@ -113,11 +124,13 @@ async def like_spread_and_recent_memes(
     return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))
 
 
-async def get_lr_smoothed(
+async def _get_lr_smoothed_candidates(
     user_id: int,
     limit: int = 10,
     exclude_meme_ids: list[int] = [],
     min_sends: int = 0,
+    recommended_by: str = "lr_smoothed",
+    text_light: bool = False,
 ):
     """
     Uses the following score to rank memes
@@ -130,12 +143,13 @@ async def get_lr_smoothed(
     """
 
     min_sends_filter = "AND MS.nmemes_sent >= :min_sends" if min_sends > 0 else ""
+    text_light_filter = TEXT_LIGHT_OCR_FILTER_SQL if text_light else ""
 
     query = f"""
         SELECT
             M.id
             , M.type, M.telegram_file_id, M.caption
-            , 'lr_smoothed' AS recommended_by
+            , :recommended_by AS recommended_by
             , COALESCE(MS.nlikes, 0) AS nlikes
 
         FROM meme M
@@ -159,6 +173,7 @@ async def get_lr_smoothed(
             AND R.meme_id IS NULL
             AND MS.nlikes > 1
             {min_sends_filter}
+            {text_light_filter}
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
 
         ORDER BY -1
@@ -166,10 +181,44 @@ async def get_lr_smoothed(
             * MS.lr_smoothed
         LIMIT :limit
     """
-    params = _build_params(user_id, limit, exclude_meme_ids)
+    params = _build_params(user_id, limit, exclude_meme_ids, recommended_by=recommended_by)
     if min_sends > 0:
         params["min_sends"] = int(min_sends)
+    if text_light:
+        params["text_light_max_ocr_words"] = TEXT_LIGHT_MAX_OCR_WORDS
     return await fetch_all(text(query), params)
+
+
+async def get_lr_smoothed(
+    user_id: int,
+    limit: int = 10,
+    exclude_meme_ids: list[int] = [],
+    min_sends: int = 0,
+):
+    return await _get_lr_smoothed_candidates(
+        user_id,
+        limit,
+        exclude_meme_ids,
+        min_sends=min_sends,
+        recommended_by="lr_smoothed",
+        text_light=False,
+    )
+
+
+async def get_text_light_lr_smoothed(
+    user_id: int,
+    limit: int = 10,
+    exclude_meme_ids: list[int] = [],
+    min_sends: int = 0,
+):
+    return await _get_lr_smoothed_candidates(
+        user_id,
+        limit,
+        exclude_meme_ids,
+        min_sends=min_sends,
+        recommended_by="text_light_lr_smoothed",
+        text_light=True,
+    )
 
 
 async def get_es_ranked(
@@ -396,13 +445,22 @@ async def cold_start_explore(
             AND R.meme_id IS NULL
             AND (MS.nlikes + MS.ndislikes) >= 20
             AND MS.lr_smoothed >= 0.10
+            {TEXT_LIGHT_OCR_FILTER_SQL}
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
 
         ORDER BY (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0)) DESC,
                  (MS.nlikes + MS.ndislikes) DESC
         LIMIT :limit
     """
-    return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))
+    return await fetch_all(
+        text(query),
+        _build_params(
+            user_id,
+            limit,
+            exclude_meme_ids,
+            text_light_max_ocr_words=TEXT_LIGHT_MAX_OCR_WORDS,
+        ),
+    )
 
 
 async def cold_start_adapt(
@@ -462,6 +520,7 @@ async def cold_start_adapt(
             AND R.meme_id IS NULL
             AND MS.nlikes > 1
             AND MS.nmemes_sent >= 10
+            {TEXT_LIGHT_OCR_FILTER_SQL}
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
 
         ORDER BY -1
@@ -469,7 +528,15 @@ async def cold_start_adapt(
             * MS.lr_smoothed
         LIMIT :limit
     """
-    return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))
+    return await fetch_all(
+        text(query),
+        _build_params(
+            user_id,
+            limit,
+            exclude_meme_ids,
+            text_light_max_ocr_words=TEXT_LIGHT_MAX_OCR_WORDS,
+        ),
+    )
 
 
 class CandidatesRetriever:
@@ -478,6 +545,7 @@ class CandidatesRetriever:
     engine_map = {
         "best_uploaded_memes": best_uploaded_memes,
         "lr_smoothed": get_lr_smoothed,
+        "text_light_lr_smoothed": get_text_light_lr_smoothed,
         "like_spread_and_recent_memes": like_spread_and_recent_memes,
         "recently_liked": get_recently_liked,
         "goat": goat,

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -12,6 +12,7 @@ from src.recommendations.blender import blend
 from src.recommendations.blender_experiments import (
     MATURE_BLENDER_CONTROL_WEIGHTS,
     get_recently_liked_blender_v2_weights,
+    get_text_light_blender_v1_weights,
 )
 from src.recommendations.candidates import (
     CandidatesRetriever,
@@ -146,7 +147,12 @@ async def generate_recommendations(
 
         return await fetch_all(text(query), params)
 
-    async def get_candidates(user_id, limit, use_recently_liked_blender_v2: bool = True):
+    async def get_candidates(
+        user_id,
+        limit,
+        use_recently_liked_blender_v2: bool = True,
+        use_text_light_blender_v1: bool = True,
+    ):
         """Route to the right engine mix based on user maturity.
 
         Cold start (<30 memes) uses 3-phase adaptive approach:
@@ -179,7 +185,7 @@ async def generate_recommendations(
                 # Phase 3: transition — blend adapt with growing engines
                 weights = {
                     "cold_start_adapt": 0.5,
-                    "lr_smoothed": 0.3,
+                    "text_light_lr_smoothed": 0.3,
                     "like_spread_and_recent_memes": 0.2,
                 }
                 candidates_dict = await retriever.get_candidates_dict(
@@ -199,12 +205,12 @@ async def generate_recommendations(
             # Fallback chain: -> lr_smoothed -> best_uploaded_memes
             if len(candidates) == 0:
                 logging.info(
-                    "Cold start %s empty for user %s, falling back to lr_smoothed",
+                    "Cold start %s empty for user %s, falling back to text_light_lr_smoothed",
                     engine,
                     user_id,
                 )
                 candidates = await retriever.get_candidates(
-                    "lr_smoothed",
+                    "text_light_lr_smoothed",
                     user_id,
                     limit,
                     exclude_mem_ids=meme_ids_in_queue,
@@ -227,12 +233,17 @@ async def generate_recommendations(
                 "es_ranked": 0.1,
                 "like_spread_and_recent_memes": 0.2,
             }
+            if use_text_light_blender_v1:
+                weights = await get_text_light_blender_v1_weights(user_id, weights)
 
             candidates_dict = await retriever.get_candidates_dict(
                 weights.keys(), user_id, limit, exclude_mem_ids=meme_ids_in_queue
             )
 
-            fixed_pos = {0: "lr_smoothed"}
+            fixed_engine = (
+                "text_light_lr_smoothed" if "text_light_lr_smoothed" in weights else "lr_smoothed"
+            )
+            fixed_pos = {0: fixed_engine}
             return blend(candidates_dict, weights, fixed_pos, limit, random_seed)
 
         # >=100. Regular mature users enter the LR-stratified recently_liked
@@ -240,6 +251,8 @@ async def generate_recommendations(
         # their low_sent_pool quota would confound the experiment read.
         if use_recently_liked_blender_v2:
             weights = await get_recently_liked_blender_v2_weights(user_id)
+            if use_text_light_blender_v1:
+                weights = await get_text_light_blender_v1_weights(user_id, weights)
         else:
             weights = dict(MATURE_BLENDER_CONTROL_WEIGHTS)
 
@@ -247,7 +260,10 @@ async def generate_recommendations(
             weights.keys(), user_id, limit, exclude_mem_ids=meme_ids_in_queue
         )
 
-        fixed_pos = {0: "lr_smoothed"}
+        fixed_engine = (
+            "text_light_lr_smoothed" if "text_light_lr_smoothed" in weights else "lr_smoothed"
+        )
+        fixed_pos = {0: fixed_engine}
         candidates = blend(candidates_dict, weights, fixed_pos, limit, random_seed)
 
         return candidates
@@ -282,6 +298,7 @@ async def generate_recommendations(
                 user_id,
                 remaining_limit,
                 use_recently_liked_blender_v2=False,
+                use_text_light_blender_v1=False,
             )
             candidates.extend(extra_candidates)
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -77,6 +77,7 @@ async def create_meme(
     raw_meme_id: int | None = None,
     published_at: datetime | None = None,
     created_at: datetime | None = None,
+    ocr_result: dict | None = None,
 ) -> dict:
     if raw_meme_id is None:
         raw_meme_id = id
@@ -93,6 +94,7 @@ async def create_meme(
         "language_code": language_code,
         "telegram_file_id": telegram_file_id,
         "caption": caption,
+        "ocr_result": ocr_result,
         "published_at": published_at,
         "created_at": created_at,
     }

--- a/tests/feed_turn/test_planner.py
+++ b/tests/feed_turn/test_planner.py
@@ -39,7 +39,7 @@ def test_stage_boundaries(nmemes_sent, stage, primary_engine):
 @pytest.mark.parametrize("nmemes_sent", [0, 5, 6, 15])
 def test_cold_start_fallback_order_and_min_sends(nmemes_sent):
     assert _fallbacks(nmemes_sent) == (
-        ("lr_smoothed", {"min_sends": 10}),
+        ("text_light_lr_smoothed", {"min_sends": 10}),
         ("best_uploaded_memes", {}),
     )
 
@@ -49,13 +49,13 @@ def test_transition_blend_and_empty_blend_fallback_order():
 
     assert dict(plan.blend_weights) == {
         "cold_start_adapt": 0.5,
-        "lr_smoothed": 0.3,
+        "text_light_lr_smoothed": 0.3,
         "like_spread_and_recent_memes": 0.2,
     }
     assert dict(plan.fixed_pos) == {0: "cold_start_adapt"}
     assert _fallbacks(16) == (
         ("cold_start_adapt", {}),
-        ("lr_smoothed", {"min_sends": 10}),
+        ("text_light_lr_smoothed", {"min_sends": 10}),
         ("best_uploaded_memes", {}),
     )
 
@@ -142,6 +142,6 @@ def test_engine_fallback_kwargs_are_read_only():
     cold_plan = plan_candidate_selection(0)
     lr_fallback = cold_plan.fallback_engines[0]
 
-    assert lr_fallback.engine == "lr_smoothed"
+    assert lr_fallback.engine == "text_light_lr_smoothed"
     with pytest.raises(TypeError):
         lr_fallback.kwargs["min_sends"] = 1

--- a/tests/recommendations/test_blender_experiments.py
+++ b/tests/recommendations/test_blender_experiments.py
@@ -10,12 +10,19 @@ from src.recommendations.blender_experiments import (
     RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID,
     RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT,
     RECENTLY_LIKED_BLENDER_V2_TREATMENT,
+    TEXT_LIGHT_BLENDER_V1_CONTROL,
+    TEXT_LIGHT_BLENDER_V1_EXPERIMENT_ID,
+    TEXT_LIGHT_BLENDER_V1_MAX_OCR_WORDS,
+    TEXT_LIGHT_BLENDER_V1_TREATMENT,
     _lr_quartile_from_boundaries,
     build_recently_liked_blender_v2_assignment,
+    build_text_light_blender_v1_assignment,
     get_or_assign_recently_liked_blender_v2_variant,
+    get_or_assign_text_light_blender_v1_variant,
     get_recent_7d_lr_assignment_metrics,
     get_recent_7d_lr_quartile_boundaries,
     get_recently_liked_blender_v2_weights,
+    get_text_light_blender_v1_weights,
 )
 
 
@@ -68,6 +75,25 @@ def test_assignment_is_stable_within_lr_quartile():
 
     assert first == second
     assert first_metadata == second_metadata
+
+
+def test_text_light_assignment_replaces_lr_engine_only_for_treatment():
+    base_weights = {
+        "best_uploaded_memes": 0.1,
+        "lr_smoothed": 0.3,
+        "recently_liked": 0.2,
+    }
+
+    variant, metadata = build_text_light_blender_v1_assignment(404, base_weights)
+
+    assert variant in {TEXT_LIGHT_BLENDER_V1_CONTROL, TEXT_LIGHT_BLENDER_V1_TREATMENT}
+    assert metadata["max_ocr_words"] == TEXT_LIGHT_BLENDER_V1_MAX_OCR_WORDS
+    assert metadata["filtered_engine"] == "text_light_lr_smoothed"
+    if variant == TEXT_LIGHT_BLENDER_V1_TREATMENT:
+        assert "lr_smoothed" not in metadata["assigned_weights"]
+        assert metadata["assigned_weights"]["text_light_lr_smoothed"] == 0.3
+    else:
+        assert metadata["assigned_weights"] == base_weights
 
 
 def test_lr_quartile_uses_cached_boundaries():
@@ -237,3 +263,44 @@ async def test_recently_liked_blender_v2_treatment_increases_recently_liked_weig
     assert weights == MATURE_BLENDER_TREATMENT_WEIGHTS
     assert weights["recently_liked"] > MATURE_BLENDER_CONTROL_WEIGHTS["recently_liked"]
     assert weights["lr_smoothed"] < MATURE_BLENDER_CONTROL_WEIGHTS["lr_smoothed"]
+
+
+@pytest.mark.asyncio
+async def test_existing_text_light_blender_v1_assignment_wins():
+    with patch(
+        "src.recommendations.blender_experiments.get_experiment_assignment",
+        new_callable=AsyncMock,
+        return_value={"variant": TEXT_LIGHT_BLENDER_V1_TREATMENT},
+    ) as get_assignment:
+        variant = await get_or_assign_text_light_blender_v1_variant(
+            101,
+            MATURE_BLENDER_CONTROL_WEIGHTS,
+        )
+
+    assert variant == TEXT_LIGHT_BLENDER_V1_TREATMENT
+    get_assignment.assert_awaited_once_with(101, TEXT_LIGHT_BLENDER_V1_EXPERIMENT_ID)
+
+
+@pytest.mark.asyncio
+async def test_text_light_blender_v1_treatment_replaces_lr_weight():
+    with patch(
+        "src.recommendations.blender_experiments.get_or_assign_text_light_blender_v1_variant",
+        new_callable=AsyncMock,
+        return_value=TEXT_LIGHT_BLENDER_V1_TREATMENT,
+    ):
+        weights = await get_text_light_blender_v1_weights(100, MATURE_BLENDER_CONTROL_WEIGHTS)
+
+    assert "lr_smoothed" not in weights
+    assert weights["text_light_lr_smoothed"] == MATURE_BLENDER_CONTROL_WEIGHTS["lr_smoothed"]
+
+
+@pytest.mark.asyncio
+async def test_text_light_blender_v1_control_keeps_base_weights():
+    with patch(
+        "src.recommendations.blender_experiments.get_or_assign_text_light_blender_v1_variant",
+        new_callable=AsyncMock,
+        return_value=TEXT_LIGHT_BLENDER_V1_CONTROL,
+    ):
+        weights = await get_text_light_blender_v1_weights(100, MATURE_BLENDER_TREATMENT_WEIGHTS)
+
+    assert weights == MATURE_BLENDER_TREATMENT_WEIGHTS

--- a/tests/recommendations/test_engine_contracts.py
+++ b/tests/recommendations/test_engine_contracts.py
@@ -99,6 +99,7 @@ async def base_data():
 ENGINES_LEFT_JOIN_UMSS = [
     "best_uploaded_memes",
     "lr_smoothed",
+    "text_light_lr_smoothed",
     "like_spread_and_recent_memes",
     "es_ranked",
 ]

--- a/tests/recommendations/test_lr_smoothed.py
+++ b/tests/recommendations/test_lr_smoothed.py
@@ -16,7 +16,7 @@ from src.database import (
     user_meme_reaction,
     user_meme_source_stats,
 )
-from src.recommendations.candidates import get_lr_smoothed
+from src.recommendations.candidates import get_lr_smoothed, get_text_light_lr_smoothed
 
 
 @pytest_asyncio.fixture()
@@ -125,3 +125,21 @@ async def test_calculate_meme_reactions_stats(conn: AsyncConnection):
     res = await get_lr_smoothed(1)
 
     assert len(res) == 4
+
+
+@pytest.mark.asyncio
+async def test_text_light_lr_smoothed_excludes_memes_over_30_ocr_words(conn: AsyncConnection):
+    long_text = " ".join(f"word{i}" for i in range(31))
+    await conn.execute(
+        meme.update()
+        .where(meme.c.id == 5)
+        .values(ocr_result={"text": long_text, "calculated_at": "2026-05-15T00:00:00Z"})
+    )
+    await conn.commit()
+
+    res = await get_text_light_lr_smoothed(1)
+    result_ids = {row["id"] for row in res}
+
+    assert 5 not in result_ids
+    # Memes without OCR are unknown text-density, so the text-light filter must keep them.
+    assert {2, 3, 4}.issubset(result_ids)

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -41,6 +41,11 @@ def mock_redis():
             "src.recommendations.meme_queue.redis.add_memes_to_queue_by_key",
             new_callable=AsyncMock,
         ),
+        patch(
+            "src.recommendations.meme_queue.get_text_light_blender_v1_weights",
+            new_callable=AsyncMock,
+            side_effect=lambda user_id, weights: weights,
+        ),
     ):
         yield
 
@@ -80,13 +85,13 @@ async def test_cold_start_phase1_uses_explore():
 
 
 @pytest.mark.asyncio
-async def test_cold_start_phase1_fallback_to_lr_smoothed():
-    """Phase 1 empty → fallback to lr_smoothed"""
+async def test_cold_start_phase1_fallback_to_text_light_lr_smoothed():
+    """Phase 1 empty → fallback to text_light_lr_smoothed"""
 
     async def empty(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return []
 
-    async def lr_smoothed(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+    async def text_light_lr_smoothed(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return [{"id": 301}, {"id": 302}]
 
     async def best_uploaded(self, user_id, limit=10, exclude_meme_ids=[], **kw):
@@ -96,7 +101,7 @@ async def test_cold_start_phase1_fallback_to_lr_smoothed():
         engine_map = {
             "cold_start_explore": empty,
             "cold_start_adapt": empty,
-            "lr_smoothed": lr_smoothed,
+            "text_light_lr_smoothed": text_light_lr_smoothed,
             "best_uploaded_memes": best_uploaded,
         }
 
@@ -109,7 +114,7 @@ async def test_cold_start_phase1_fallback_to_lr_smoothed():
 
 @pytest.mark.asyncio
 async def test_cold_start_phase1_fallback_to_uploaded():
-    """Phase 1 + lr_smoothed both empty → fallback to best_uploaded_memes"""
+    """Phase 1 + text_light_lr_smoothed both empty → fallback to best_uploaded_memes"""
 
     async def empty(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return []
@@ -121,7 +126,7 @@ async def test_cold_start_phase1_fallback_to_uploaded():
         engine_map = {
             "cold_start_explore": empty,
             "cold_start_adapt": empty,
-            "lr_smoothed": empty,
+            "text_light_lr_smoothed": empty,
             "best_uploaded_memes": best_uploaded,
         }
 
@@ -168,12 +173,12 @@ async def test_cold_start_phase2_uses_adapt():
 
 @pytest.mark.asyncio
 async def test_cold_start_phase2_fallback():
-    """Phase 2 empty → fallback to lr_smoothed"""
+    """Phase 2 empty → fallback to text_light_lr_smoothed"""
 
     async def empty(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return []
 
-    async def lr_smoothed(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+    async def text_light_lr_smoothed(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return [{"id": 301}]
 
     async def best_uploaded(self, user_id, limit=10, exclude_meme_ids=[], **kw):
@@ -183,7 +188,7 @@ async def test_cold_start_phase2_fallback():
         engine_map = {
             "cold_start_explore": empty,
             "cold_start_adapt": empty,
-            "lr_smoothed": lr_smoothed,
+            "text_light_lr_smoothed": text_light_lr_smoothed,
             "best_uploaded_memes": best_uploaded,
         }
 
@@ -216,6 +221,7 @@ async def test_cold_start_phase3_blends():
     class TestRetriever(CandidatesRetriever):
         engine_map = {
             "cold_start_adapt": cold_start_adapt,
+            "text_light_lr_smoothed": lr_smoothed,
             "lr_smoothed": lr_smoothed,
             "like_spread_and_recent_memes": like_spread,
             "best_uploaded_memes": best_uploaded,
@@ -370,6 +376,59 @@ async def test_generate_above_100_treatment_uses_recently_liked_weights():
 
 
 @pytest.mark.asyncio
+async def test_text_light_blender_v1_treatment_pins_text_light_engine():
+    captured_weights = None
+    captured_fixed_pos = None
+
+    async def one_candidate(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 4, "recommended_by": "generic"}]
+
+    async def text_light_candidate(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 7, "recommended_by": "text_light_lr_smoothed"}]
+
+    class TestRetriever(CandidatesRetriever):
+        engine_map = {
+            "best_uploaded_memes": one_candidate,
+            "like_spread_and_recent_memes": one_candidate,
+            "text_light_lr_smoothed": text_light_candidate,
+            "recently_liked": one_candidate,
+            "goat": one_candidate,
+            "es_ranked": one_candidate,
+        }
+
+    treatment_weights = dict(MATURE_BLENDER_CONTROL_WEIGHTS)
+    lr_weight = treatment_weights.pop("lr_smoothed")
+    treatment_weights["text_light_lr_smoothed"] = lr_weight
+
+    def capture_blend(candidates_dict, weights_dict, fixed_pos=None, limit=0, random_seed=None):
+        nonlocal captured_weights, captured_fixed_pos
+        captured_weights = weights_dict
+        captured_fixed_pos = fixed_pos
+        return [{"id": 7, "recommended_by": "text_light_lr_smoothed"}]
+
+    with (
+        patch(
+            "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+            new_callable=AsyncMock,
+            return_value=MATURE_BLENDER_CONTROL_WEIGHTS,
+        ),
+        patch(
+            "src.recommendations.meme_queue.get_text_light_blender_v1_weights",
+            new_callable=AsyncMock,
+            return_value=treatment_weights,
+        ),
+        patch("src.recommendations.meme_queue.blend", side_effect=capture_blend),
+    ):
+        candidates = await generate_recommendations(
+            TEST_USER_ID, 10, 200, TestRetriever(), random_seed=102
+        )
+
+    assert candidates == [{"id": 7, "recommended_by": "text_light_lr_smoothed"}]
+    assert "lr_smoothed" not in captured_weights
+    assert captured_fixed_pos == {0: "text_light_lr_smoothed"}
+
+
+@pytest.mark.asyncio
 async def test_recently_liked_blender_v2_assignment_is_mature_only():
     async def empty(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return []
@@ -384,6 +443,7 @@ async def test_recently_liked_blender_v2_assignment_is_mature_only():
             "es_ranked": empty,
             "cold_start_explore": empty,
             "cold_start_adapt": empty,
+            "text_light_lr_smoothed": empty,
         }
 
     with patch(
@@ -489,6 +549,7 @@ async def test_cold_start_all_empty():
         engine_map = {
             "cold_start_explore": empty,
             "cold_start_adapt": empty,
+            "text_light_lr_smoothed": empty,
             "lr_smoothed": empty,
             "best_uploaded_memes": empty,
             "like_spread_and_recent_memes": empty,
@@ -514,6 +575,9 @@ def _growing_retriever_class():
     async def lr_smoothed(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return [{"id": 301, "recommended_by": "lr_smoothed"}]
 
+    async def text_light_lr_smoothed(self, user_id, limit=10, exclude_meme_ids=[], **kw):
+        return [{"id": 302, "recommended_by": "text_light_lr_smoothed"}]
+
     async def best_uploaded_memes(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return [{"id": 401, "recommended_by": "best_uploaded_memes"}]
 
@@ -533,6 +597,7 @@ def _growing_retriever_class():
         engine_map = {
             "cold_start_explore": cold_start_explore,
             "cold_start_adapt": cold_start_adapt,
+            "text_light_lr_smoothed": text_light_lr_smoothed,
             "lr_smoothed": lr_smoothed,
             "best_uploaded_memes": best_uploaded_memes,
             "like_spread_and_recent_memes": like_spread_and_recent_memes,

--- a/tests/recommendations/test_queue_correctness.py
+++ b/tests/recommendations/test_queue_correctness.py
@@ -36,7 +36,13 @@ def _make_stub_retriever(candidates_by_engine: dict[str, list[dict]]):
             exclude_mem_ids: list[int] = [],
             **kwargs,
         ) -> list[dict[str, Any]]:
-            all_candidates = candidates_by_engine.get(engine_name, [])
+            fallback_engine = (
+                "lr_smoothed" if engine_name == "text_light_lr_smoothed" else engine_name
+            )
+            all_candidates = candidates_by_engine.get(
+                engine_name,
+                candidates_by_engine.get(fallback_engine, []),
+            )
             exclude_set = set(exclude_mem_ids)
             filtered = [c for c in all_candidates if c["id"] not in exclude_set]
             return filtered[:limit]


### PR DESCRIPTION
## Summary
- add `text_light_lr_smoothed`, an LR-smoothed recommendation engine that excludes only OCR-known memes with more than 30 words
- keep memes with no OCR result, empty OCR text, or no recognized text eligible because we do not know that they are long-text memes
- route cold-start phase 3 and cold-start fallbacks through the text-light engine, and add `text_light_blender_v1` A/B overlay for growing/mature users
- document the experiment and add tests for assignment behavior, engine contracts, queue routing, and the no-OCR guardrail

## Validation
- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m ruff check ...` after rebase onto fresh `production`
- targeted recommendation/planner tests: `112 passed, 2 skipped`
- full suite on equivalent branch state with the now-merged #269 changes: `490 passed, 2 skipped`
- analyst DB sanity check: no-OCR memes kept by filter (`139586`), known text-light kept (`56322`), known >30-word OCR excluded (`15749`)
