### PR TITLE
fix: convert watermarked memes to bytes before upload

### DIFF
--- a/src/flows/storage/memes.py
+++ b/src/flows/storage/memes.py
@@ -46,10 +46,13 @@ async def analyse_meme_caption(meme: dict[str, Any]) -> None:
             return
 
 
-async def add_watermark_to_meme_content(meme_content: bytes, meme_type: MemeType) -> bytes:
+async def add_watermark_to_meme_content(meme_content: bytes, meme_type: MemeType) -> bytes | None:
     if meme_type == MemeType.IMAGE:
         # we can add watermark only to photos right now
-        return add_watermark(meme_content)
+        watermarked_content = add_watermark(meme_content)
+        if watermarked_content is None:
+            return None
+        return watermarked_content.getvalue()
     return meme_content
 
 

--- a/tests/storage/test_meme_pipeline_upload.py
+++ b/tests/storage/test_meme_pipeline_upload.py
@@ -1,0 +1,19 @@
+from io import BytesIO
+
+import pytest
+
+from src.flows.storage import memes
+from src.storage.constants import MemeType
+
+
+@pytest.mark.asyncio
+async def test_add_watermark_to_meme_content_returns_bytes_for_images(monkeypatch):
+    watermarked_content = BytesIO(b"watermarked-image")
+    watermarked_content.name = "image.jpeg"
+
+    monkeypatch.setattr(memes, "add_watermark", lambda content: watermarked_content)
+
+    result = await memes.add_watermark_to_meme_content(b"raw-image", MemeType.IMAGE)
+
+    assert result == b"watermarked-image"
+    assert isinstance(result, bytes)


### PR DESCRIPTION
## Summary
- convert watermarked image content from `BytesIO` back to `bytes` before passing it to the Telegram upload wrapper
- keep non-image media unchanged
- add a regression test for the image watermark contract

## Why
Post-deploy monitoring caught `Memes from VK Pipeline` stopping after 5 consecutive upload failures:
`object of type '_io.BytesIO' has no len()`.
The upload wrapper computes `content_size = len(content)`, so it must receive bytes.

## Validation
- `python -m ruff check src/flows/storage/memes.py tests/storage/test_meme_pipeline_upload.py`
- `python -m ruff format --check src/flows/storage/memes.py tests/storage/test_meme_pipeline_upload.py`
- `python -m pytest tests/storage/test_meme_pipeline_upload.py tests/storage/test_upload_observability.py -q` (`2 passed`)
- `git diff --check`
