### PR TITLE
Fix fallback diagnostics reporting

### DIFF
--- a/src/recommendations/pipeline.py
+++ b/src/recommendations/pipeline.py
@@ -453,7 +453,6 @@ class RecommendationBatchPipeline:
         diagnostics: RecommendationBatchDiagnostics,
     ) -> list[Candidate]:
         for fallback in plan.fallback_engines:
-            diagnostics.fallback_used = diagnostics.fallback_used or fallback.engine
             candidates = await self._fetch_engine(
                 fallback.engine,
                 request.user_id,
@@ -463,6 +462,7 @@ class RecommendationBatchPipeline:
                 **dict(fallback.kwargs),
             )
             if candidates:
+                diagnostics.fallback_used = fallback.engine
                 return candidates
         return []
 

--- a/tests/recommendations/test_pipeline.py
+++ b/tests/recommendations/test_pipeline.py
@@ -177,6 +177,27 @@ async def test_cold_start_falls_back_when_primary_engine_is_empty():
 
 
 @pytest.mark.asyncio
+async def test_fallback_diagnostics_record_engine_that_supplied_candidates():
+    retriever = FakeRetriever(
+        {
+            "cold_start_explore": [],
+            "text_light_lr_smoothed": [],
+            "best_uploaded_memes": [_meme(401, "best_uploaded_memes")],
+        }
+    )
+
+    result = await _pipeline(retriever).run(_request(nmemes_sent=3, nsessions=1))
+
+    assert _ids(result.selected) == [401]
+    assert [call["engine"] for call in retriever.calls] == [
+        "cold_start_explore",
+        "text_light_lr_smoothed",
+        "best_uploaded_memes",
+    ]
+    assert result.diagnostics.fallback_used == "best_uploaded_memes"
+
+
+@pytest.mark.asyncio
 async def test_blend_engine_failure_is_recorded_but_other_engines_continue():
     retriever = FakeRetriever(
         {


### PR DESCRIPTION
Fixes FFM-1296.

## Summary
- Record `diagnostics.fallback_used` only after a fallback engine returns candidates
- Add a regression test for the case where `text_light_lr_smoothed` is empty and `best_uploaded_memes` supplies the batch

## Tests
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `python3 -m pytest tests/recommendations/test_pipeline.py -q`

Note: local pytest needed explicit CI-style env vars and a missing host `sentry-sdk`/`pytest-env` install; the test passed after that environment setup.