### PR TITLE
fix: port useful fixes from stale PRs

### DIFF
--- a/specs/describe-memes.md
+++ b/specs/describe-memes.md
@@ -46,10 +46,12 @@ Current production chain:
 [
     "google/gemma-4-31b-it:free",
     "google/gemma-4-26b-a4b-it:free",
-    "google/gemma-3-27b-it:free",
-    "google/gemma-3-12b-it:free",
 ]
 ```
+
+Gemma 3 free vision model IDs are intentionally excluded: they are no longer
+listed by OpenRouter and create avoidable failed attempts under the daily free
+quota.
 
 Do not add paid fallbacks. A paid fallback can spend the account below zero, after which OpenRouter returns 402 for all models, including free models.
 

--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -56,14 +56,13 @@ OPENROUTER_FORBIDDEN_MODEL_COOLDOWN_SECONDS = 60 * 60 * 6
 # lifetime purchases for 1,000 req/day (vs 50/day without).
 # See specs/describe-memes.md for full OpenRouter constraints.
 #
-# Verified available on OpenRouter API as of 2026-05-04.
+# Verified available on OpenRouter API as of 2026-05-17.
 # Ordered by preference. Falls back to next model on 429/403/timeout/bad response.
 # Transient failures set Redis cooldowns so later memes/runs try other free models.
 VISION_MODELS = [
     "google/gemma-4-31b-it:free",  # 262k context, primary
     "google/gemma-4-26b-a4b-it:free",  # 262k context, MoE variant
-    "google/gemma-3-27b-it:free",  # 131k context, re-listed on OpenRouter ~2026-04-20
-    "google/gemma-3-12b-it:free",  # 32k context, re-listed on OpenRouter ~2026-04-20
+    # Gemma 3 free vision fallbacks are no longer listed by OpenRouter.
     # nvidia/nemotron-nano-12b-v2-vl:free removed — returns 504s and invalid
     # JSON/empty content (see specs/describe-memes.md).
 ]

--- a/src/observability/sentry.py
+++ b/src/observability/sentry.py
@@ -41,6 +41,9 @@ HIGH_ENTROPY_TOKEN_PATTERN = re.compile(
 
 def before_send(event: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any] | None:
     """Remove sensitive exception payloads before Sentry stores an event."""
+    if _is_expected_chat_agent_max_turns_event(event):
+        return None
+
     _drop_exception_frame_vars(event)
     return event
 
@@ -344,6 +347,55 @@ def _drop_exception_frame_vars(event: dict[str, Any]) -> None:
         for frame in frames:
             if isinstance(frame, dict):
                 frame.pop("vars", None)
+
+
+def _is_expected_chat_agent_max_turns_event(event: dict[str, Any]) -> bool:
+    """Drop handled chat-agent fallbacks that Sentry may still receive."""
+    exception = event.get("exception")
+    if not isinstance(exception, dict):
+        return False
+
+    values = exception.get("values")
+    if not isinstance(values, list):
+        return False
+
+    for exception_value in values:
+        if not isinstance(exception_value, dict):
+            continue
+        if (
+            exception_value.get("type") != "MaxTurnsExceeded"
+            or exception_value.get("module") != "agents.exceptions"
+        ):
+            continue
+
+        if event.get("logger") == "src.tgbot.handlers.chat.agent.runner":
+            return True
+        if _exception_has_chat_agent_frame(exception_value):
+            return True
+
+    return False
+
+
+def _exception_has_chat_agent_frame(exception_value: dict[str, Any]) -> bool:
+    stacktrace = exception_value.get("stacktrace")
+    if not isinstance(stacktrace, dict):
+        return False
+
+    frames = stacktrace.get("frames")
+    if not isinstance(frames, list):
+        return False
+
+    for frame in frames:
+        if not isinstance(frame, dict):
+            continue
+        filename = str(frame.get("filename") or "")
+        abs_path = str(frame.get("abs_path") or "")
+        if "tgbot/handlers/chat/agent/runner.py" in filename:
+            return True
+        if "tgbot/handlers/chat/agent/runner.py" in abs_path:
+            return True
+
+    return False
 
 
 def _scrub_log_attribute(key: str, value: Any) -> Any:

--- a/src/storage/source_voting.py
+++ b/src/storage/source_voting.py
@@ -174,10 +174,8 @@ async def prepare_source_candidate(
         )
         return {"status": "unsupported_type", "candidate": candidate, "source": None}
 
-    source = await _create_or_reuse_prepared_source(candidate, added_by_user_id)
-    if source is None:
-        return {"status": "source_create_failed", "candidate": candidate, "source": None}
-    if source["status"] == MemeSourceStatus.PARSING_ENABLED.value:
+    source = await _get_meme_source_by_url(candidate["url"])
+    if source and source["status"] == MemeSourceStatus.PARSING_ENABLED.value:
         await _mark_candidate(
             candidate_id,
             status=CANDIDATE_STATUS_PROMOTED,
@@ -187,7 +185,23 @@ async def prepare_source_candidate(
         return {"status": "already_enabled", "candidate": candidate, "source": source}
 
     if posts is None:
-        posts = await fetch_telegram_candidate_posts(candidate["url"], nposts=nposts)
+        try:
+            posts = await fetch_telegram_candidate_posts(candidate["url"], nposts=nposts)
+        except Exception:
+            return {"status": "prepare_failed", "candidate": candidate, "source": source}
+
+    if source is None:
+        source = await _create_or_reuse_prepared_source(candidate, added_by_user_id)
+        if source is None:
+            return {"status": "source_create_failed", "candidate": candidate, "source": None}
+    if source["status"] == MemeSourceStatus.PARSING_ENABLED.value:
+        await _mark_candidate(
+            candidate_id,
+            status=CANDIDATE_STATUS_PROMOTED,
+            promoted_meme_source_id=source["id"],
+            expected_status=CANDIDATE_STATUS_DISCOVERED,
+        )
+        return {"status": "already_enabled", "candidate": candidate, "source": source}
 
     evidence = extract_cyrillic_evidence(posts)
     if not posts:
@@ -529,6 +543,12 @@ async def select_daily_source_candidate() -> dict[str, Any] | None:
                   OR NOT EXISTS (
                       SELECT 1 FROM meme_source ms WHERE ms.url = c.url
                   )
+                  OR EXISTS (
+                      SELECT 1
+                      FROM meme_source ms
+                      WHERE ms.url = c.url
+                        AND ms.status = 'in_moderation'
+                  )
               )
             ORDER BY c.times_forwarded DESC, c.last_seen_at DESC
             LIMIT 1
@@ -611,6 +631,7 @@ async def mark_source_candidate_poll_open(
         .values(
             message_id=message_id,
             opened_at=opened_at,
+            closes_at=opened_at + SOURCE_VOTE_WINDOW,
             status=POLL_STATUS_OPEN,
             updated_at=_utcnow(),
         )

--- a/src/tgbot/handlers/block.py
+++ b/src/tgbot/handlers/block.py
@@ -5,7 +5,7 @@ Handles user blocking / unblocking the bot.
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from src.tgbot.logs import log
+from src.tgbot.logs import html_escape, log
 from src.tgbot.service import mark_user_blocked, mark_user_unblocked
 
 
@@ -31,10 +31,10 @@ async def handle_user_blocked_bot(update: Update, context: ContextTypes.DEFAULT_
 
     # Lightweight admin log: fields we already have, no stats recompute.
     message = (
-        f"⛔️ <b>BLOCKED</b> by {user_tg.name} / #{user_id}\n"
+        f"⛔️ <b>BLOCKED</b> by {html_escape(user_tg.name)} / #{user_id}\n"
         f"<b>registered</b>: {updated['created_at']}\n"
-        f"<b>tg lang</b>: {user_tg.language_code}\n"
-        f"<b>nickname</b>: {updated.get('nickname') or '—'}"
+        f"<b>tg lang</b>: {html_escape(user_tg.language_code or '—')}\n"
+        f"<b>nickname</b>: {html_escape(updated.get('nickname') or '—')}"
     )
     await log(message, context.bot)
 

--- a/src/tgbot/handlers/error.py
+++ b/src/tgbot/handlers/error.py
@@ -3,7 +3,7 @@ import logging
 import traceback
 
 from telegram import Update
-from telegram.error import Forbidden, TimedOut
+from telegram.error import Forbidden, NetworkError, TimedOut
 from telegram.ext import ContextTypes
 
 from src.tgbot.constants import (
@@ -21,14 +21,22 @@ async def send_stacktrace_to_tg_chat(update: Update, context: ContextTypes.DEFAU
 
     user_id = update.effective_user.id
 
-    logging.error("Exception while handling an update:", exc_info=context.error)
-
     # if the error is that we can't send them a message,
     #  then handle it as not a real error.
     if isinstance(context.error, Forbidden):
         await log(f"User #{user_id} blocked the bot", context.bot)
         await mark_user_blocked(user_id, source="forbidden_global_error")
         return
+
+    if isinstance(context.error, (NetworkError, TimedOut)):
+        logging.warning(
+            "Transient Telegram transport error while handling update for user %s: %s",
+            user_id,
+            context.error,
+        )
+        return
+
+    logging.error("Exception while handling an update:", exc_info=context.error)
 
     tb_list = traceback.format_exception(None, context.error, context.error.__traceback__)
     tb_string = html.escape("".join(tb_list))
@@ -65,12 +73,23 @@ Wait for 2 minutes and press /start.
             text=f"{base_message}\n\n{channel_message}",
             chat_id=user_id,
         )
+    except Forbidden:
+        await mark_user_blocked(user_id, source="forbidden_crash_notification")
+    except (NetworkError, TimedOut) as error:
+        logging.warning("Failed to send crash message due to Telegram transport error: %s", error)
     except Exception:  # noqa: BLE001
         logging.exception("Failed to send crash message with channel link")
         try:
             await context.bot.send_message(
                 text=base_message,
                 chat_id=user_id,
+            )
+        except Forbidden:
+            await mark_user_blocked(user_id, source="forbidden_crash_notification_fallback")
+        except (NetworkError, TimedOut) as error:
+            logging.warning(
+                "Failed to send crash message fallback due to Telegram transport error: %s",
+                error,
             )
         except Exception:  # noqa: BLE001
             logging.exception("Failed to send crash message fallback")

--- a/src/tgbot/handlers/upload/upload_meme.py
+++ b/src/tgbot/handlers/upload/upload_meme.py
@@ -5,11 +5,13 @@ Methods for Meme uploading via bot:
 """
 
 import asyncio
+import logging
 import re
 from datetime import datetime
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ChatType, ParseMode
+from telegram.error import BadRequest
 from telegram.ext import ContextTypes
 
 from src import localizer
@@ -41,6 +43,7 @@ from src.tgbot.user_info import get_user_info
 from src.tgbot.utils import (
     check_if_user_follows_related_channel,
     get_related_channel_link,
+    safe_answer_callback_query,
 )
 
 RULES_ACCEPTED_CALLBACK_DATA_PATTERN = "upload:{upload_id}:rules:accepted"
@@ -53,6 +56,8 @@ LANGUAGE_SELECTED_OTHER_CALLBACK_DATA_PATTERN = "upload:{upload_id}:lang:other"
 LANGUAGE_SELECTED_OTHER_CALLBACK_DATA_REGEXP = r"upload:(\d+):lang:other"
 
 UPLOAD_BAN_INVITES_TO_UNLOCK = 20
+
+logger = logging.getLogger(__name__)
 
 
 def get_upload_banned_message(invited_users: int) -> str:
@@ -272,14 +277,15 @@ async def handle_rules_accepted_callback(
     _: ContextTypes.DEFAULT_TYPE,
 ) -> None:
     # user accepted the rules. Next, we need to ask to specify the language of a meme
-    await update.callback_query.answer()
+    await safe_answer_callback_query(update.callback_query)
     user_info = await get_user_info(update.effective_user.id)
 
     upload_id = int(
         re.match(RULES_ACCEPTED_CALLBACK_DATA_REGEXP, update.callback_query.data).group(1)
     )
 
-    await update.callback_query.message.edit_caption(
+    await _edit_upload_callback_caption(
+        update.callback_query.message,
         localizer.t("upload.select_language", user_info["interface_lang"]),
         reply_markup=InlineKeyboardMarkup(get_meme_language_selector_keyboard(upload_id)),
         parse_mode=ParseMode.HTML,
@@ -291,7 +297,7 @@ async def handle_meme_upload_lang_other(
     update: Update,
     _: ContextTypes.DEFAULT_TYPE,
 ) -> None:
-    await update.callback_query.answer()
+    await safe_answer_callback_query(update.callback_query)
     user_info = await get_user_info(update.effective_user.id)
     await update.effective_user.send_message(
         localizer.t("upload.we_can_add_language_you_need", user_info["interface_lang"]),
@@ -303,7 +309,7 @@ async def handle_meme_upload_lang_selected(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
 ) -> None:
-    await update.callback_query.answer()
+    await safe_answer_callback_query(update.callback_query)
     user_info = await get_user_info(update.effective_user.id)
 
     reg = re.match(LANGUAGE_SELECTED_CALLBACK_DATA_REGEXP, update.callback_query.data)
@@ -316,7 +322,8 @@ async def handle_meme_upload_lang_selected(
 
     # TODO: create a meme object from meme_raw_upload
 
-    await update.callback_query.message.edit_caption(
+    await _edit_upload_callback_caption(
+        update.callback_query.message,
         localizer.t("upload.submitted", user_info["interface_lang"]),
         reply_markup=None,
         parse_mode=ParseMode.HTML,
@@ -326,3 +333,12 @@ async def handle_meme_upload_lang_selected(
     await check_queue(update.effective_user.id)  # to ensure user has memes in queue
     await asyncio.sleep(5)
     await next_message(context.bot, update.effective_user.id, update)
+
+
+async def _edit_upload_callback_caption(message, caption: str, **kwargs) -> None:
+    try:
+        await message.edit_caption(caption, **kwargs)
+    except BadRequest as error:
+        if "message is not modified" not in str(error).lower():
+            raise
+        logger.info("Upload callback caption already matched the requested state")

--- a/src/tgbot/logs.py
+++ b/src/tgbot/logs.py
@@ -1,12 +1,36 @@
+import logging
+from html import escape
+
 from telegram import Bot
+from telegram.error import BadRequest, NetworkError, TimedOut
 
 from src.config import settings
 from src.tgbot.bot import bot as default_bot
 
+logger = logging.getLogger(__name__)
+
+
+def html_escape(value: object) -> str:
+    return escape(str(value), quote=False)
+
 
 async def log(text: str, bot: Bot | None = None) -> None:
-    await (bot or default_bot).send_message(
-        chat_id=settings.ADMIN_LOGS_CHAT_ID,
-        text=text[:4000],
-        parse_mode="HTML",
-    )
+    tg_bot = bot or default_bot
+    message = text[:4000]
+    try:
+        await tg_bot.send_message(
+            chat_id=settings.ADMIN_LOGS_CHAT_ID,
+            text=message,
+            parse_mode="HTML",
+        )
+    except BadRequest as error:
+        if "can't parse entities" not in str(error).lower():
+            raise
+        logger.warning("Admin log contained invalid Telegram HTML; retrying as plain text")
+        await tg_bot.send_message(
+            chat_id=settings.ADMIN_LOGS_CHAT_ID,
+            text=message,
+            parse_mode=None,
+        )
+    except (NetworkError, TimedOut) as error:
+        logger.warning("Admin log delivery failed: %s", error)

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -24,6 +24,7 @@ from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
 from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
 from src.tgbot.senders.utils import collect_user_languages, has_russian_language
 from src.tgbot.service import mark_user_blocked
+from src.tgbot.telegram_retry import telegram_call_with_retry
 from src.tgbot.user_info import get_user_info
 
 logger = logging.getLogger(__name__)
@@ -112,32 +113,38 @@ async def send_new_message_with_meme(
     reply_markup: InlineKeyboardMarkup | None = None,
 ) -> Message:
     async def _do_send(parse_mode):
-        if meme.type == MemeType.IMAGE:
-            return await bot.send_photo(
-                chat_id=user_id,
-                photo=meme.telegram_file_id,
-                caption=meme.caption,
-                reply_markup=reply_markup,
-                parse_mode=parse_mode,
-            )
-        elif meme.type == MemeType.VIDEO:
-            return await bot.send_video(
-                chat_id=user_id,
-                video=meme.telegram_file_id,
-                caption=meme.caption,
-                reply_markup=reply_markup,
-                parse_mode=parse_mode,
-            )
-        elif meme.type == MemeType.ANIMATION:
-            return await bot.send_animation(
-                chat_id=user_id,
-                animation=meme.telegram_file_id,
-                caption=meme.caption,
-                reply_markup=reply_markup,
-                parse_mode=parse_mode,
-            )
-        else:
-            raise NotImplementedError(f"Can't send meme. Unknown meme type: {meme.type}")
+        async def _send():
+            if meme.type == MemeType.IMAGE:
+                return await bot.send_photo(
+                    chat_id=user_id,
+                    photo=meme.telegram_file_id,
+                    caption=meme.caption,
+                    reply_markup=reply_markup,
+                    parse_mode=parse_mode,
+                )
+            elif meme.type == MemeType.VIDEO:
+                return await bot.send_video(
+                    chat_id=user_id,
+                    video=meme.telegram_file_id,
+                    caption=meme.caption,
+                    reply_markup=reply_markup,
+                    parse_mode=parse_mode,
+                )
+            elif meme.type == MemeType.ANIMATION:
+                return await bot.send_animation(
+                    chat_id=user_id,
+                    animation=meme.telegram_file_id,
+                    caption=meme.caption,
+                    reply_markup=reply_markup,
+                    parse_mode=parse_mode,
+                )
+            else:
+                raise NotImplementedError(f"Can't send meme. Unknown meme type: {meme.type}")
+
+        return await telegram_call_with_retry(
+            _send,
+            action=f"send_meme_{meme.type.value}",
+        )
 
     try:
         return await _do_send(ParseMode.HTML)
@@ -161,16 +168,34 @@ async def edit_last_message_with_meme(
     reply_markup: InlineKeyboardMarkup | None = None,
 ) -> Message | None:
     try:
-        await message.edit_media(
-            media=get_input_media(meme),
-            reply_markup=reply_markup,
-        )
-        return await message.edit_caption(
-            caption=meme.caption,
-            parse_mode=ParseMode.HTML,
-            reply_markup=reply_markup,
+        try:
+            await telegram_call_with_retry(
+                lambda: message.edit_media(
+                    media=get_input_media(meme),
+                    reply_markup=reply_markup,
+                ),
+                action="edit_media",
+            )
+        except BadRequest as error:
+            if not _is_message_not_modified_error(error):
+                raise
+            logger.info("Telegram media for meme %s was already current", meme.id)
+        return await telegram_call_with_retry(
+            lambda: message.edit_caption(
+                caption=meme.caption,
+                parse_mode=ParseMode.HTML,
+                reply_markup=reply_markup,
+            ),
+            action="edit_caption",
         )
     except BadRequest as error:
         if "Message to edit not found" in str(error):
             return None
+        if _is_message_not_modified_error(error):
+            logger.info("Telegram message for meme %s was already current", meme.id)
+            return message
         raise
+
+
+def _is_message_not_modified_error(error: BadRequest) -> bool:
+    return "message is not modified" in str(error).lower()

--- a/src/tgbot/senders/next_message.py
+++ b/src/tgbot/senders/next_message.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from telegram import Bot, InlineKeyboardMarkup, Message, Update
-from telegram.error import BadRequest, Forbidden, TimedOut
+from telegram.error import BadRequest, Forbidden, NetworkError, TimedOut
 
 from src.recommendations import meme_queue
 from src.recommendations.service import (
@@ -123,9 +123,9 @@ async def next_message(
             await _disable_broken_meme(meme, error)
             attempt += 1
             continue
-        except TimedOut:
+        except (NetworkError, TimedOut):
             logger.warning(
-                "Telegram API timed out delivering meme %s to user %s, retrying",
+                "Telegram API transport error delivering meme %s to user %s, retrying",
                 meme.id,
                 user_id,
             )
@@ -168,6 +168,13 @@ async def _replace_previous_message(
 ) -> Message:
     try:
         edited_message = await edit_last_message_with_meme(previous_message, meme, reply_markup)
+    except NetworkError as error:
+        logger.warning(
+            "Failed to edit previous message for meme %s: %s. Sending new message instead.",
+            meme.id,
+            error,
+        )
+        edited_message = None
     except BadRequest as error:
         if _is_missing_message_error(error):
             logger.info(

--- a/src/tgbot/telegram_retry.py
+++ b/src/tgbot/telegram_retry.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from telegram.error import NetworkError, TimedOut
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+TRANSIENT_TELEGRAM_ERRORS = (NetworkError, TimedOut)
+
+
+async def telegram_call_with_retry(
+    call: Callable[[], Awaitable[T]],
+    *,
+    action: str,
+    attempts: int = 2,
+    initial_delay: float = 0.3,
+) -> T:
+    """Run one Telegram Bot API call with a tiny retry for transport failures."""
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+
+    delay = initial_delay
+    for attempt in range(1, attempts + 1):
+        try:
+            return await call()
+        except TRANSIENT_TELEGRAM_ERRORS as error:
+            if attempt == attempts:
+                logger.warning(
+                    "Telegram %s failed after %s attempts: %s",
+                    action,
+                    attempts,
+                    error,
+                )
+                raise
+            logger.warning(
+                "Transient Telegram %s failure on attempt %s/%s: %s",
+                action,
+                attempt,
+                attempts,
+                error,
+            )
+            await asyncio.sleep(delay)
+            delay *= 2
+
+    raise RuntimeError("unreachable")

--- a/src/tgbot/utils.py
+++ b/src/tgbot/utils.py
@@ -1,7 +1,9 @@
 import asyncio
+import logging
 
 import telegram
 from telegram.constants import ChatMemberStatus
+from telegram.error import BadRequest
 
 from src.localizer import ALMOST_CIS_LANGUAGES
 from src.tgbot.constants import (
@@ -12,6 +14,8 @@ from src.tgbot.constants import (
 )
 from src.tgbot.schemas import UserTg
 from src.tgbot.service import add_user_tg_chat_membership
+
+logger = logging.getLogger(__name__)
 
 
 def remove_buttons_with_callback(reply_markup: dict) -> dict:
@@ -34,6 +38,20 @@ def remove_buttons_with_callback(reply_markup: dict) -> dict:
 
 def tg_user_repr(tg_user: UserTg) -> str:
     return f"@{tg_user.username}" if tg_user.username else f"#{tg_user.id}"
+
+
+async def safe_answer_callback_query(callback_query, *args, **kwargs) -> None:
+    try:
+        await callback_query.answer(*args, **kwargs)
+    except BadRequest as error:
+        if not _is_stale_callback_query_error(error):
+            raise
+        logger.info("Skipping stale callback query answer: %s", error)
+
+
+def _is_stale_callback_query_error(error: BadRequest) -> bool:
+    message = str(error).lower()
+    return "query is too old" in message or "query id is invalid" in message
 
 
 # TODO: move to telegram utils?

--- a/tests/storage/test_describe_memes_models.py
+++ b/tests/storage/test_describe_memes_models.py
@@ -1,0 +1,10 @@
+from src.flows.storage.describe_memes import VISION_MODELS
+
+
+def test_describe_memes_vision_models_are_free_only():
+    assert VISION_MODELS
+    assert all(model_id.endswith(":free") for model_id in VISION_MODELS)
+
+
+def test_describe_memes_does_not_use_removed_gemma_3_free_models():
+    assert all("google/gemma-3-" not in model_id for model_id in VISION_MODELS)

--- a/tests/storage/test_source_voting.py
+++ b/tests/storage/test_source_voting.py
@@ -20,6 +20,7 @@ from src.database import (
 from src.storage.constants import MemeSourceStatus
 from src.storage.parsers.schemas import TgChannelPostParsingResult
 from src.storage.source_voting import (
+    CANDIDATE_STATUS_DISCOVERED,
     POLL_STATUS_OPEN,
     POLL_STATUS_PASSED,
     VOTE_ADD_SOURCE,
@@ -27,10 +28,12 @@ from src.storage.source_voting import (
     advance_daily_source_cycle,
     close_source_candidate_poll,
     create_source_candidate_poll,
+    mark_source_candidate_poll_open,
     post_new_source_candidate_poll,
     post_source_candidate_poll_message,
     prepare_source_candidate,
     record_source_candidate_vote,
+    select_daily_source_candidate,
 )
 from src.tgbot.constants import TELEGRAM_MODERATOR_CHAT_ID
 from tests.factories import TEST_ID_START, cleanup_test_data
@@ -130,6 +133,32 @@ async def test_prepare_source_candidate_dismisses_non_russian_candidate(
     )
     assert candidate["status"] == "dismissed"
     assert candidate["dismissed_reason"] == "non_ru_no_cyrillic"
+
+
+@pytest.mark.asyncio
+async def test_prepare_source_candidate_handles_scrape_failure_without_stranding_candidate(
+    conn: AsyncConnection,
+):
+    await _create_candidate(conn)
+    await conn.commit()
+
+    with patch(
+        "src.storage.source_voting.fetch_telegram_candidate_posts",
+        new=AsyncMock(side_effect=RuntimeError("scrape failed")),
+    ):
+        result = await prepare_source_candidate(CANDIDATE_ID)
+
+    assert result["status"] == "prepare_failed"
+
+    candidate = await fetch_one(
+        select(meme_source_candidate).where(meme_source_candidate.c.id == CANDIDATE_ID)
+    )
+    assert candidate["status"] == CANDIDATE_STATUS_DISCOVERED
+    assert candidate["promoted_meme_source_id"] is None
+
+    picked = await select_daily_source_candidate()
+    assert picked is not None
+    assert picked["id"] == CANDIDATE_ID
 
 
 @pytest.mark.asyncio
@@ -312,6 +341,33 @@ async def test_daily_source_cycle_resumes_existing_draft_poll(conn: AsyncConnect
     assert result["new_poll"]["poll"]["message_id"] == 556
     assert result["new_poll"]["poll"]["status"] == POLL_STATUS_OPEN
     bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_opening_draft_poll_refreshes_vote_window(conn: AsyncConnection):
+    now = datetime.utcnow()
+    await _create_candidate(conn)
+    await conn.commit()
+    prepared = await prepare_source_candidate(CANDIDATE_ID, posts=[_post(4007)])
+    poll = await create_source_candidate_poll(
+        CANDIDATE_ID,
+        prepared_meme_source_id=prepared["source"]["id"],
+        chat_id=TELEGRAM_MODERATOR_CHAT_ID,
+        now=now - timedelta(days=1),
+    )
+    await conn.commit()
+
+    opened = await mark_source_candidate_poll_open(
+        poll["id"],
+        message_id=555,
+        opened_at=now,
+    )
+
+    assert opened is not None
+    assert opened["status"] == POLL_STATUS_OPEN
+    assert opened["opened_at"] == now
+    assert opened["closes_at"] == now + timedelta(hours=24)
+    assert opened["message_id"] == 555
 
 
 @pytest.mark.asyncio

--- a/tests/test_sentry_observability.py
+++ b/tests/test_sentry_observability.py
@@ -125,3 +125,34 @@ def test_before_send_drops_exception_frame_vars():
     assert scrubbed is event
     frame = scrubbed["exception"]["values"][0]["stacktrace"]["frames"][0]
     assert "vars" not in frame
+
+
+def test_before_send_drops_handled_chat_agent_max_turns_event():
+    event = {
+        "logger": "src.tgbot.handlers.chat.agent.runner",
+        "exception": {
+            "values": [
+                {
+                    "type": "MaxTurnsExceeded",
+                    "module": "agents.exceptions",
+                }
+            ]
+        },
+    }
+
+    assert before_send(event, {}) is None
+
+
+def test_before_send_keeps_unexpected_max_turns_events():
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "MaxTurnsExceeded",
+                    "module": "agents.exceptions",
+                }
+            ]
+        },
+    }
+
+    assert before_send(event, {}) is event

--- a/tests/tgbot/test_block_tracking.py
+++ b/tests/tgbot/test_block_tracking.py
@@ -7,6 +7,7 @@ import pytest
 
 from src.tgbot import service
 from src.tgbot.constants import UserType
+from src.tgbot.handlers import block
 
 
 def test_blocked_bot_at_timestamp_converts_aware_datetime_to_naive_utc() -> None:
@@ -50,3 +51,39 @@ async def test_mark_user_blocked_sends_naive_timestamp_to_db(monkeypatch) -> Non
     blocked_bot_at = update_user.await_args.kwargs["blocked_bot_at"]
     assert blocked_bot_at == datetime(2026, 4, 27, 20, 0, 27)
     assert blocked_bot_at.tzinfo is None
+
+
+@pytest.mark.asyncio
+async def test_handle_user_blocked_bot_escapes_admin_log_html(monkeypatch) -> None:
+    messages = []
+    user = SimpleNamespace(id=10002, name="<3", language_code="<en>")
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=10002),
+        my_chat_member=SimpleNamespace(
+            from_user=user,
+            date=datetime(2026, 5, 11, 7, 18, 19, tzinfo=timezone.utc),
+        ),
+    )
+    context = SimpleNamespace(bot=object())
+
+    monkeypatch.setattr(
+        block,
+        "mark_user_blocked",
+        AsyncMock(
+            return_value={
+                "created_at": datetime(2024, 2, 18, 12, 57, 50),
+                "nickname": "<boss>",
+            }
+        ),
+    )
+
+    async def fake_log(message, _bot):
+        messages.append(message)
+
+    monkeypatch.setattr(block, "log", fake_log)
+
+    await block.handle_user_blocked_bot(update, context)
+
+    assert "&lt;3" in messages[0]
+    assert "&lt;en&gt;" in messages[0]
+    assert "&lt;boss&gt;" in messages[0]

--- a/tests/tgbot/test_error_handler.py
+++ b/tests/tgbot/test_error_handler.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from telegram.error import NetworkError
+
+from src.tgbot.handlers.error import send_stacktrace_to_tg_chat
+
+
+async def test_error_handler_does_not_report_transient_telegram_errors_to_telegram():
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=12001, language_code="en"),
+    )
+    context = SimpleNamespace(
+        error=NetworkError("All connection attempts failed"),
+        bot=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await send_stacktrace_to_tg_chat(update, context)
+
+    context.bot.send_message.assert_not_awaited()

--- a/tests/tgbot/test_logs.py
+++ b/tests/tgbot/test_logs.py
@@ -1,0 +1,32 @@
+from telegram.error import BadRequest, TimedOut
+
+from src.tgbot.logs import log
+
+
+class _BotWithHtmlFailure:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def send_message(self, **kwargs):
+        self.calls.append(kwargs)
+        if len(self.calls) == 1:
+            raise BadRequest("Can't parse entities: unsupported start tag")
+
+
+async def test_log_retries_invalid_html_as_plain_text():
+    bot = _BotWithHtmlFailure()
+
+    await log("⛔️ <b>BLOCKED</b> by <3", bot)
+
+    assert len(bot.calls) == 2
+    assert bot.calls[0]["parse_mode"] == "HTML"
+    assert bot.calls[1]["parse_mode"] is None
+    assert bot.calls[1]["text"] == "⛔️ <b>BLOCKED</b> by <3"
+
+
+async def test_log_swallow_admin_chat_timeout():
+    class Bot:
+        async def send_message(self, **_kwargs):
+            raise TimedOut("Timed out")
+
+    await log("non-critical admin note", Bot())

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -1,0 +1,86 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.error import BadRequest, NetworkError
+
+from src.storage.constants import MemeType
+from src.storage.schemas import MemeData
+from src.tgbot.senders.meme import edit_last_message_with_meme, send_new_message_with_meme
+
+
+def _meme() -> MemeData:
+    return MemeData(
+        id=123,
+        type=MemeType.IMAGE,
+        telegram_file_id="photo-file-id",
+        caption="<b>caption</b>",
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_last_message_retries_transient_edit_media_error(monkeypatch):
+    sleep = AsyncMock()
+    monkeypatch.setattr("src.tgbot.telegram_retry.asyncio.sleep", sleep)
+
+    class Message:
+        def __init__(self) -> None:
+            self.edit_media_calls = 0
+
+        async def edit_media(self, **_kwargs):
+            self.edit_media_calls += 1
+            if self.edit_media_calls == 1:
+                raise NetworkError("Server disconnected without sending a response")
+
+        async def edit_caption(self, **_kwargs):
+            return "edited"
+
+    message = Message()
+
+    result = await edit_last_message_with_meme(message, _meme())
+
+    assert result == "edited"
+    assert message.edit_media_calls == 2
+    sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_edit_last_message_treats_not_modified_as_success():
+    class Message:
+        async def edit_media(self, **_kwargs):
+            raise BadRequest(
+                "Message is not modified: specified new message content and reply markup "
+                "are exactly the same"
+            )
+
+        async def edit_caption(self, **_kwargs):
+            return self
+
+    message = Message()
+
+    result = await edit_last_message_with_meme(message, _meme())
+
+    assert result is message
+
+
+@pytest.mark.asyncio
+async def test_send_new_message_retries_transient_send_error(monkeypatch):
+    sleep = AsyncMock()
+    monkeypatch.setattr("src.tgbot.telegram_retry.asyncio.sleep", sleep)
+
+    class Bot:
+        def __init__(self) -> None:
+            self.send_photo_calls = 0
+
+        async def send_photo(self, **_kwargs):
+            self.send_photo_calls += 1
+            if self.send_photo_calls == 1:
+                raise NetworkError("All connection attempts failed")
+            return "sent"
+
+    bot = Bot()
+
+    result = await send_new_message_with_meme(bot, 12001, _meme())
+
+    assert result == "sent"
+    assert bot.send_photo_calls == 2
+    sleep.assert_awaited_once()

--- a/tests/tgbot/test_upload_meme.py
+++ b/tests/tgbot/test_upload_meme.py
@@ -1,0 +1,22 @@
+from unittest.mock import AsyncMock
+
+from telegram.error import BadRequest
+
+from src.tgbot.handlers.upload.upload_meme import _edit_upload_callback_caption
+
+
+async def test_edit_upload_callback_caption_ignores_not_modified():
+    class Message:
+        def __init__(self) -> None:
+            self.edit_caption = AsyncMock(
+                side_effect=BadRequest(
+                    "Message is not modified: specified new message content and reply markup "
+                    "are exactly the same"
+                )
+            )
+
+    message = Message()
+
+    await _edit_upload_callback_caption(message, "caption", reply_markup=None)
+
+    message.edit_caption.assert_awaited_once()

--- a/tests/tgbot/test_utils.py
+++ b/tests/tgbot/test_utils.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.error import BadRequest
+
+from src.tgbot.utils import safe_answer_callback_query
+
+
+@pytest.mark.asyncio
+async def test_safe_answer_callback_query_ignores_stale_query():
+    callback_query = SimpleNamespace(
+        answer=AsyncMock(side_effect=BadRequest("Query is too old and response timeout expired"))
+    )
+
+    await safe_answer_callback_query(callback_query, "ok")
+
+    callback_query.answer.assert_awaited_once_with("ok")
+
+
+@pytest.mark.asyncio
+async def test_safe_answer_callback_query_reraises_other_bad_request():
+    callback_query = SimpleNamespace(answer=AsyncMock(side_effect=BadRequest("other error")))
+
+    with pytest.raises(BadRequest):
+        await safe_answer_callback_query(callback_query)


### PR DESCRIPTION
## Summary
- port Telegram transport retry, upload callback, admin-log, and Sentry noise fixes from #259 without reverting the current Sentry observability setup
- keep source-voting candidates retryable after scrape failures and refresh poll close windows when draft polls open
- remove removed Gemma 3 free vision IDs from Describe Memes and document the current free-only model chain

Supersedes #259, #257, and #230.

## Tests
- ruff format targeted files
- ruff check targeted files
- python -m compileall -q targeted src files
- python -m pytest tests/test_sentry_observability.py tests/tgbot/test_error_handler.py tests/tgbot/test_logs.py tests/tgbot/test_meme_sender.py tests/tgbot/test_upload_meme.py tests/tgbot/test_utils.py tests/storage/test_describe_memes_models.py -q
- python -m pytest tests/tgbot/test_block_tracking.py -q

## Not run
- python -m pytest tests/storage/test_source_voting.py -q: local DB hostname app_db is not resolvable outside docker-compose in this worktree