### PR TITLE
fix: avoid retrying ambiguous Telegram sends

### DIFF
--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -113,38 +113,32 @@ async def send_new_message_with_meme(
     reply_markup: InlineKeyboardMarkup | None = None,
 ) -> Message:
     async def _do_send(parse_mode):
-        async def _send():
-            if meme.type == MemeType.IMAGE:
-                return await bot.send_photo(
-                    chat_id=user_id,
-                    photo=meme.telegram_file_id,
-                    caption=meme.caption,
-                    reply_markup=reply_markup,
-                    parse_mode=parse_mode,
-                )
-            elif meme.type == MemeType.VIDEO:
-                return await bot.send_video(
-                    chat_id=user_id,
-                    video=meme.telegram_file_id,
-                    caption=meme.caption,
-                    reply_markup=reply_markup,
-                    parse_mode=parse_mode,
-                )
-            elif meme.type == MemeType.ANIMATION:
-                return await bot.send_animation(
-                    chat_id=user_id,
-                    animation=meme.telegram_file_id,
-                    caption=meme.caption,
-                    reply_markup=reply_markup,
-                    parse_mode=parse_mode,
-                )
-            else:
-                raise NotImplementedError(f"Can't send meme. Unknown meme type: {meme.type}")
-
-        return await telegram_call_with_retry(
-            _send,
-            action=f"send_meme_{meme.type.value}",
-        )
+        if meme.type == MemeType.IMAGE:
+            return await bot.send_photo(
+                chat_id=user_id,
+                photo=meme.telegram_file_id,
+                caption=meme.caption,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        elif meme.type == MemeType.VIDEO:
+            return await bot.send_video(
+                chat_id=user_id,
+                video=meme.telegram_file_id,
+                caption=meme.caption,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        elif meme.type == MemeType.ANIMATION:
+            return await bot.send_animation(
+                chat_id=user_id,
+                animation=meme.telegram_file_id,
+                caption=meme.caption,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        else:
+            raise NotImplementedError(f"Can't send meme. Unknown meme type: {meme.type}")
 
     try:
         return await _do_send(ParseMode.HTML)

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -63,7 +63,7 @@ async def test_edit_last_message_treats_not_modified_as_success():
 
 
 @pytest.mark.asyncio
-async def test_send_new_message_retries_transient_send_error(monkeypatch):
+async def test_send_new_message_does_not_retry_ambiguous_transport_error(monkeypatch):
     sleep = AsyncMock()
     monkeypatch.setattr("src.tgbot.telegram_retry.asyncio.sleep", sleep)
 
@@ -73,14 +73,12 @@ async def test_send_new_message_retries_transient_send_error(monkeypatch):
 
         async def send_photo(self, **_kwargs):
             self.send_photo_calls += 1
-            if self.send_photo_calls == 1:
-                raise NetworkError("All connection attempts failed")
-            return "sent"
+            raise NetworkError("All connection attempts failed")
 
     bot = Bot()
 
-    result = await send_new_message_with_meme(bot, 12001, _meme())
+    with pytest.raises(NetworkError):
+        await send_new_message_with_meme(bot, 12001, _meme())
 
-    assert result == "sent"
-    assert bot.send_photo_calls == 2
-    sleep.assert_awaited_once()
+    assert bot.send_photo_calls == 1
+    sleep.assert_not_awaited()


### PR DESCRIPTION
## Summary
- remove retry wrapper around fresh Telegram send_photo/send_video/send_animation calls
- keep retry helper for idempotent edit operations
- update meme sender test to assert ambiguous transport errors are not retried for fresh sends

Fixes the staff-engineer review finding on #274 / FFM-1304.

## Tests
- ruff format src/tgbot/senders/meme.py tests/tgbot/test_meme_sender.py
- ruff check src/tgbot/senders/meme.py tests/tgbot/test_meme_sender.py
- python -m pytest tests/tgbot/test_meme_sender.py -q
- python -m pytest tests/tgbot/test_error_handler.py tests/tgbot/test_logs.py tests/tgbot/test_upload_meme.py tests/tgbot/test_utils.py tests/test_sentry_observability.py tests/storage/test_describe_memes_models.py -q
- python -m compileall -q src/tgbot/senders/meme.py src/tgbot/telegram_retry.py