### PR TITLE
Fix agent doctor Paperclip runtime adapter

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -9,8 +9,8 @@ override current Codex or Paperclip decisions.
 | Task type | Read first | Notes |
 |-----------|------------|-------|
 | General repo work | [AGENTS.md](../../AGENTS.md) | Current Codex operating notes and hard constraints. |
-| Paperclip inspection or agent ops | [ADR-0001](../adr/0001-local-paperclip-cli.md) and `.codex/skills/paperclip/SKILL.md` | Use the project-local CLI skill/wrapper; do not enable global Paperclip MCP. |
-| Local agent readiness check | [`scripts/agent_doctor.py`](../../scripts/agent_doctor.py) | Read-only checks for local commands, Describe Memes free-model contract, Paperclip wrapper, and agent-doc workflow invariants. |
+| Paperclip inspection or agent ops | [ADR-0001](../adr/0001-local-paperclip-cli.md) and `.codex/skills/paperclip/SKILL.md` | Local Codex sessions use the project-local wrapper; Paperclip-managed runs use native Paperclip CLI/env. Do not enable global Paperclip MCP. |
+| Local agent readiness check | [`scripts/agent_doctor.py`](../../scripts/agent_doctor.py) | Read-only checks for local commands, Describe Memes free-model contract, Paperclip access adapter, and agent-doc workflow invariants. |
 | Paperclip runtime migration or auth | [Paperclip-native migration](../paperclip-native-migration.md) and [ADR-0002](../adr/0002-codex-oauth-agent-auth.md) | Codex agents are OAuth/subscription-only; no `OPENAI_API_KEY` binding. |
 | Agent skill catalog or generated exports | [Paperclip skill catalog](../paperclip-skill-catalog.md) and [ADR-0004](../adr/0004-generated-agent-readme.md) | Generated README snapshots are reference only. |
 | Routine health and outcomes | [Routine observability](routine-observability.md) and [Outcome ledger](outcome-ledger.md) | Prefer business outcome checks over generic liveness checks. |

--- a/scripts/agent_doctor.py
+++ b/scripts/agent_doctor.py
@@ -3,7 +3,7 @@
 
 Checks command availability and repo contracts that should be true before an
 agent starts Paperclip/architecture work. This script never reads secret files,
-requires no env vars, and does not call network services.
+does not print secret values, and does not call network services.
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import ast
 import json
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -87,15 +88,46 @@ def check_describe_memes_models(root: Path = ROOT) -> CheckResult:
     return CheckResult("describe_memes:free_models", True, f"{len(model_ids)} free model(s)")
 
 
-def check_paperclip_local_wrapper(root: Path = ROOT) -> CheckResult:
+def check_paperclip_access_adapter(
+    root: Path = ROOT,
+    env: dict[str, str] | None = None,
+    command_resolver=shutil.which,
+) -> CheckResult:
+    """Verify a Paperclip access path exists for this runtime.
+
+    Codex desktop uses the repo-local `.codex` wrapper. Paperclip-managed
+    agents run inside a different checkout where `.codex` is intentionally not
+    tracked; there the native `paperclipai` CLI plus Paperclip env bindings are
+    the valid adapter.
+    """
+    env = dict(os.environ if env is None else env)
     skill = root / ".codex" / "skills" / "paperclip" / "SKILL.md"
     wrapper = root / ".codex" / "paperclip-tools" / "paperclipai-ffmemes.sh"
     missing = [str(path.relative_to(root)) for path in (skill, wrapper) if not path.exists()]
+    if not missing and wrapper.stat().st_mode & 0o111:
+        return CheckResult("paperclip:access_adapter", True, "repo-local wrapper present")
+
+    native_cli = command_resolver("paperclipai")
+    native_url = bool(env.get("PAPERCLIP_URL") or env.get("PAPERCLIP_API_URL"))
+    native_key = bool(env.get("PAPERCLIP_API_KEY"))
+    if native_cli and native_url and native_key:
+        return CheckResult("paperclip:access_adapter", True, "native Paperclip CLI/env present")
+
+    adapter_gaps: list[str] = []
     if missing:
-        return CheckResult("paperclip:local_wrapper", False, "missing: " + ", ".join(missing))
-    if not wrapper.stat().st_mode & 0o111:
-        return CheckResult("paperclip:local_wrapper", False, "wrapper is not executable")
-    return CheckResult("paperclip:local_wrapper", True, "skill and wrapper present")
+        adapter_gaps.append("repo-local wrapper missing: " + ", ".join(missing))
+    elif not wrapper.stat().st_mode & 0o111:
+        adapter_gaps.append("repo-local wrapper is not executable")
+    native_missing = []
+    if not native_cli:
+        native_missing.append("paperclipai")
+    if not native_url:
+        native_missing.append("PAPERCLIP_URL|PAPERCLIP_API_URL")
+    if not native_key:
+        native_missing.append("PAPERCLIP_API_KEY")
+    if native_missing:
+        adapter_gaps.append("native adapter missing: " + ", ".join(native_missing))
+    return CheckResult("paperclip:access_adapter", False, "; ".join(adapter_gaps))
 
 
 def check_paperclip_contracts_importable() -> CheckResult:
@@ -150,7 +182,7 @@ def run_checks(commands: Iterable[str] = ("git", "python3", "rg", "pytest")) -> 
     results.extend(
         [
             check_describe_memes_models(),
-            check_paperclip_local_wrapper(),
+            check_paperclip_access_adapter(),
             check_paperclip_contracts_importable(),
             check_agent_workflow_invariants(),
         ]

--- a/tests/scripts/test_agent_doctor.py
+++ b/tests/scripts/test_agent_doctor.py
@@ -40,7 +40,7 @@ def test_real_describe_memes_models_are_free() -> None:
     assert result.name == "describe_memes:free_models"
 
 
-def test_paperclip_wrapper_check_is_read_only_and_present(tmp_path: Path) -> None:
+def test_paperclip_access_adapter_accepts_repo_local_wrapper(tmp_path: Path) -> None:
     skill = tmp_path / ".codex" / "skills" / "paperclip"
     tools = tmp_path / ".codex" / "paperclip-tools"
     skill.mkdir(parents=True)
@@ -50,10 +50,35 @@ def test_paperclip_wrapper_check_is_read_only_and_present(tmp_path: Path) -> Non
     wrapper.write_text("#!/bin/sh\n", encoding="utf-8")
     wrapper.chmod(0o700)
 
-    result = doctor.check_paperclip_local_wrapper(tmp_path)
+    result = doctor.check_paperclip_access_adapter(
+        tmp_path, env={}, command_resolver=lambda _: None
+    )
 
     assert result.ok is True
-    assert result.name == "paperclip:local_wrapper"
+    assert result.name == "paperclip:access_adapter"
+
+
+def test_paperclip_access_adapter_accepts_native_runtime(tmp_path: Path) -> None:
+    result = doctor.check_paperclip_access_adapter(
+        tmp_path,
+        env={"PAPERCLIP_URL": "https://paperclip.test", "PAPERCLIP_API_KEY": "set"},
+        command_resolver=lambda command: (
+            "/usr/local/bin/paperclipai" if command == "paperclipai" else None
+        ),
+    )
+
+    assert result.ok is True
+    assert "native Paperclip CLI/env present" in result.detail
+
+
+def test_paperclip_access_adapter_reports_missing_paths(tmp_path: Path) -> None:
+    result = doctor.check_paperclip_access_adapter(
+        tmp_path, env={}, command_resolver=lambda _: None
+    )
+
+    assert result.ok is False
+    assert "repo-local wrapper missing" in result.detail
+    assert "native adapter missing" in result.detail
 
 
 def test_render_text_marks_failures() -> None:


### PR DESCRIPTION
## Summary
- allow agent doctor to pass with either the repo-local Paperclip wrapper or native Paperclip CLI/env bindings
- keep Paperclip secret values out of doctor output while reporting missing adapter names
- update tests and agent docs for the two supported runtime paths

## Verification
- ruff format scripts/agent_doctor.py tests/scripts/test_agent_doctor.py
- ruff check scripts/agent_doctor.py tests/scripts/test_agent_doctor.py
- python3 -m pytest tests/scripts/test_agent_doctor.py tests/test_paperclip_contracts.py -q
- simulated native Paperclip adapter: python3 scripts/agent_doctor.py --json