### PR TITLE
Fix: restore repo-local Paperclip wrapper assets

### DIFF
--- a/.codex/paperclip-tools/paperclipai-ffmemes.sh
+++ b/.codex/paperclip-tools/paperclipai-ffmemes.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repo-local Paperclip entrypoint for FFmemes agent work. This keeps Paperclip
+# usage explicit and task-scoped instead of relying on a global MCP install.
+
+if [[ -n "${PAPERCLIPAI_BIN:-}" ]]; then
+  exec "$PAPERCLIPAI_BIN" "$@"
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+local_bin="$repo_root/node_modules/.bin/paperclipai"
+
+if [[ -x "$local_bin" ]]; then
+  exec "$local_bin" "$@"
+fi
+
+if command -v paperclipai >/dev/null 2>&1; then
+  exec paperclipai "$@"
+fi
+
+version="${PAPERCLIPAI_VERSION:-2026.513.0}"
+exec npx --yes "paperclipai@$version" "$@"

--- a/.codex/paperclip-tools/paperclipai-ffmemes.sh
+++ b/.codex/paperclip-tools/paperclipai-ffmemes.sh
@@ -4,11 +4,28 @@ set -euo pipefail
 # Repo-local Paperclip entrypoint for FFmemes agent work. This keeps Paperclip
 # usage explicit and task-scoped instead of relying on a global MCP install.
 
+tool_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$tool_root/../.." && pwd)"
+env_file="$tool_root/paperclip.env"
+
+if [[ -f "$env_file" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$env_file"
+  set +a
+fi
+
+if [[ -z "${PAPERCLIP_API_URL:-}" && -n "${PAPERCLIP_URL:-}" ]]; then
+  export PAPERCLIP_API_URL="$PAPERCLIP_URL"
+fi
+
+export PAPERCLIP_COMPANY_ID="${PAPERCLIP_COMPANY_ID:-96ee7b2e-6df2-43c8-bbe3-53e19297308a}"
+export PAPERCLIP_CONTEXT="${PAPERCLIP_CONTEXT:-$tool_root/context.json}"
+
 if [[ -n "${PAPERCLIPAI_BIN:-}" ]]; then
   exec "$PAPERCLIPAI_BIN" "$@"
 fi
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 local_bin="$repo_root/node_modules/.bin/paperclipai"
 
 if [[ -x "$local_bin" ]]; then

--- a/.codex/skills/paperclip/SKILL.md
+++ b/.codex/skills/paperclip/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: paperclip
+description: >
+  Use the FFmemes repo-local Paperclip CLI wrapper for task coordination,
+  issue comments, status updates, and other Paperclip control-plane work.
+---
+
+# FFmemes Paperclip Skill
+
+Use this skill only for Paperclip coordination: issue context, comments,
+status updates, child issues, approvals, and runtime/task inspection. Do not
+use it for the domain implementation itself.
+
+## Entrypoint
+
+Run Paperclip through the repo-local wrapper:
+
+```bash
+.codex/paperclip-tools/paperclipai-ffmemes.sh
+```
+
+Pass normal Paperclip CLI arguments after the wrapper. For manual local CLI
+setup, use:
+
+```bash
+.codex/paperclip-tools/paperclipai-ffmemes.sh agent local-cli <agent-id-or-shortname> --company-id <company-id>
+```
+
+The wrapper keeps Paperclip access task-scoped for this repository and avoids
+enabling the Paperclip MCP server globally.
+
+## Heartbeat Rules
+
+- Use `PAPERCLIP_WAKE_PAYLOAD_JSON` first when it is present.
+- For scoped wakes, do not search for other assignments.
+- If the harness already checked out the issue, do not call checkout again.
+- Include `X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID` on all modifying API calls.
+- End every heartbeat with a durable disposition: `done`, `in_review`,
+  `blocked`, delegated child issues, or a real continuation path.
+
+## Status Discipline
+
+- Use `done` only when the requested work is complete and verified.
+- Use `in_review` only when there is a real reviewer, approval, interaction,
+  or monitor path.
+- Use `blocked` only with a named owner/action, and prefer first-class
+  `blockedByIssueIds` when another issue is the blocker.
+- Create child issues for delegated follow-up work instead of leaving a comment
+  as the only handoff.
+
+## API Fallback
+
+If the CLI is unavailable but heartbeat environment variables are present, use
+the Paperclip HTTP API directly:
+
+```bash
+curl -fsS \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID"
+```
+
+Never print secret values or commit local runtime credentials.

--- a/.codex/skills/paperclip/SKILL.md
+++ b/.codex/skills/paperclip/SKILL.md
@@ -29,6 +29,20 @@ setup, use:
 The wrapper keeps Paperclip access task-scoped for this repository and avoids
 enabling the Paperclip MCP server globally.
 
+It sources `.codex/paperclip-tools/paperclip.env` when present, normalizes
+`PAPERCLIP_URL` to `PAPERCLIP_API_URL`, sets `PAPERCLIP_CONTEXT`, and defaults
+`PAPERCLIP_COMPANY_ID` to the FFmemes company. Do not print `paperclip.env`.
+
+Useful read-only commands:
+
+```bash
+.codex/paperclip-tools/paperclipai-ffmemes.sh --version
+.codex/paperclip-tools/paperclipai-ffmemes.sh company list --json
+.codex/paperclip-tools/paperclipai-ffmemes.sh dashboard get -C 96ee7b2e-6df2-43c8-bbe3-53e19297308a --json
+.codex/paperclip-tools/paperclipai-ffmemes.sh issue list -C 96ee7b2e-6df2-43c8-bbe3-53e19297308a --status todo,in_progress,blocked,done --json
+.codex/paperclip-tools/paperclipai-ffmemes.sh issue get FFM-1250 --json
+```
+
 ## Heartbeat Rules
 
 - Use `PAPERCLIP_WAKE_PAYLOAD_JSON` first when it is present.

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,12 @@ backup.dump.gz
 test.py
 .gstack/
 .codex/
+!.codex/
+!.codex/skills/
+!.codex/skills/paperclip/
+!.codex/skills/paperclip/SKILL.md
+!.codex/paperclip-tools/
+!.codex/paperclip-tools/paperclipai-ffmemes.sh
 .agents/
 
 # Per-developer git worktrees (in-progress feature branches)

--- a/.gitignore
+++ b/.gitignore
@@ -151,8 +151,10 @@ test.py
 !.codex/
 !.codex/skills/
 !.codex/skills/paperclip/
+/.codex/skills/paperclip/*
 !.codex/skills/paperclip/SKILL.md
 !.codex/paperclip-tools/
+/.codex/paperclip-tools/*
 !.codex/paperclip-tools/paperclipai-ffmemes.sh
 .agents/
 


### PR DESCRIPTION
Fixes FFM-1308. Unblocks FFM-1306.\n\n## What changed\n- Added the repo-local Paperclip skill at `.codex/skills/paperclip/SKILL.md`.\n- Added executable wrapper `.codex/paperclip-tools/paperclipai-ffmemes.sh` with explicit/local/global/npx fallback.\n- Added narrow `.gitignore` exceptions so only these non-secret `.codex` assets are tracked.\n\n## Verification\n- `ruff check --fix src/ tests/`\n- `ruff format src/ tests/`\n- `python3 scripts/agent_doctor.py --json`\n- `pytest tests/scripts/test_agent_doctor.py`\n- `bash -n .codex/paperclip-tools/paperclipai-ffmemes.sh`\n- `PAPERCLIPAI_BIN=/bin/echo .codex/paperclip-tools/paperclipai-ffmemes.sh agent local-cli cto --company-id test-company`