### PR TITLE
fix: tighten codex gitignore allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,7 +149,9 @@ test.py
 .gstack/
 .codex/
 !.codex/
+/.codex/*
 !.codex/skills/
+/.codex/skills/*
 !.codex/skills/paperclip/
 /.codex/skills/paperclip/*
 !.codex/skills/paperclip/SKILL.md


### PR DESCRIPTION
## Summary
- add deny rules under `.codex/` before the narrow allowlist exceptions
- keep only the repo-local Paperclip skill and wrapper trackable
- keep local Paperclip env/context/runtime files ignored

Fixes FFM-1311 / post-merge review on #279.

## Checks
- git diff --check
- git check-ignore --no-index for allowed and denied `.codex` paths
- python3 scripts/agent_doctor.py --json