### PR TITLE
Fix: tighten .codex gitignore allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,7 +149,9 @@ test.py
 .gstack/
 .codex/
 !.codex/
+/.codex/*
 !.codex/skills/
+/.codex/skills/*
 !.codex/skills/paperclip/
 /.codex/skills/paperclip/*
 !.codex/skills/paperclip/SKILL.md


### PR DESCRIPTION
Fixes FFM-1311. Follow-up to the Staff Engineer review note on PR #279.

What changed:
- Added deny rules for `/.codex/*` and `/.codex/skills/*` before the narrow allowlist exceptions.
- Kept only `.codex/skills/paperclip/SKILL.md` and `.codex/paperclip-tools/paperclipai-ffmemes.sh` trackable under `.codex`.

Verification:
- `git check-ignore -v --no-index .codex/top-secret.env .codex/skills/other/SKILL.md .codex/skills/paperclip/local.env .codex/paperclip-tools/local.sh .codex/skills/paperclip/SKILL.md .codex/paperclip-tools/paperclipai-ffmemes.sh`
- `git status --short --ignored .codex` after creating the Staff Engineer repro files
- `git diff --check`
- `ruff check --fix src/ tests/ && ruff format src/ tests/`