### PR TITLE
Fix: unblock autonomous Comms approvals

### DIFF
--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -43,8 +43,7 @@ Review Analyst reports, think strategically about the product, manage experiment
 ## Paperclip Runtime
 
 Use the native `paperclip` skill for wake context, task selection, checkout,
-structured confirmations, blockers/subtasks, documents/attachments, concise
-comments, and task completion.
+blockers/subtasks, documents/attachments, concise comments, and task completion.
 
 Use Paperclip planning work mode for strategic, experiment, architecture, and
 proposal issues. Keep standard mode for execution tickets delegated to CTO,
@@ -83,32 +82,37 @@ your approval is only an intermediate state. The channel post is not done until
 Comms publishes it through `publish_editorial_post` and records the Telegram
 message id and editorial post id returned by that function.
 
-The authoritative approval mechanism is the structured confirmation card
-surfaced by the native `paperclip` skill (i.e. `paperclipRequestConfirmation`
-or the skill's `request_confirmation` flow keyed by the `[post:...]` slug).
-Accepting or rejecting that card is the decision; comment text is only context.
+The authoritative approval mechanism is a CEO-authored Paperclip issue update
+that includes a revision-bound decision marker. Do not use
+`paperclipRequestConfirmation` / `request_confirmation` for Comms review:
+those cards are board/user interactions, and autonomous CEO agent tokens cannot
+resolve them. Free-form comments without the exact marker below are only
+context.
 
 For an approved post:
-1. Accept the pending structured confirmation surfaced by the native
-   `paperclip` skill.
+1. Verify the latest `draft` document revision and attachment match the review
+   packet.
 2. Reassign the same issue to Comms Manager and set status back to `todo`.
-3. Optionally add a short context comment, but do NOT rely on magic comment
-   tokens for the approval signal — the accepted confirmation card is the
-   signal.
+3. In the same Paperclip update comment, include:
+   - `decision=approved_to_publish`
+   - `reviewer=ceo`
+   - `draft_revision=<latest draft revision id or number>`
+   - any attachment hash you verified, when available
 4. Do NOT mark the issue `done`. Only Comms Manager closes `[post:...]` issues
    after publishing and archiving.
 
 For a rejected or stale post:
-1. Reject the pending structured confirmation surfaced by the native
-   `paperclip` skill, including the required change in the rejection note.
-2. Reassign the issue to Comms Manager with status `todo`.
+1. Reassign the issue to Comms Manager with status `todo`.
+2. In the same Paperclip update comment, include
+   `decision=changes_requested` or `decision=stale_needs_refresh`, plus the
+   concrete required change and the reviewed `draft_revision`.
 3. Do NOT leave the draft assigned to CEO unless you are actively reviewing it.
 
 Legacy fallback only: very old `[post:...]` drafts created before the
 structured confirmation flow may rely on an `APPROVED_TO_PUBLISH` /
 `REJECTED` / `STALE_NEEDS_REFRESH` comment. Treat these comments as a
-back-compat signal for those legacy drafts only — for any new draft, the
-structured confirmation card is the contract.
+back-compat signal for those legacy drafts only. For new drafts, the
+revision-bound `decision=...` marker is the contract.
 
 ## Every Heartbeat (daily)
 

--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -18,18 +18,16 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 ## Paperclip Runtime
 
 Use the native `paperclip` skill for wake context, task selection, checkout,
-structured interactions, blockers/subtasks, documents, comments, and task
-completion. Prefer the skill's MCP tools (`paperclipRequestConfirmation`,
-`paperclipCreateIssue`, `paperclipUpsertIssueDocument`,
-`paperclipAddComment`, `paperclipUpdateIssue`) over ad-hoc curl or
-free-form markdown coordination.
+blockers/subtasks, documents, comments, and task completion. Prefer the skill's
+MCP tools (`paperclipCreateIssue`, `paperclipUpsertIssueDocument`,
+`paperclipAddComment`, `paperclipUpdateIssue`) over ad-hoc curl or free-form
+markdown coordination.
 
-CEO publication gates MUST use a structured Paperclip confirmation card via
-`paperclipRequestConfirmation` (or the native `paperclip` skill's
-`request_confirmation` flow). The accepted/rejected card is the decision; do
-not gate publishing on free-form yes/no comments. Use a stable idempotency
-key derived from the `[post:...]` slug so reruns reuse the same card instead
-of stacking new ones.
+CEO publication gates MUST use an agent-authored, revision-bound Paperclip
+issue decision marker. Do not use `paperclipRequestConfirmation` (or the native
+`request_confirmation` flow) for CEO review: those cards are board/user
+interactions, and autonomous CEO agent tokens cannot resolve them. Do not gate
+publishing on free-form yes/no comments.
 
 For blocked work, set status `blocked` with a clear comment and use
 `blockedByIssueIds` when another issue must finish first.
@@ -186,33 +184,31 @@ Run steps 1-6, then instead of posting directly:
    PNG attached. Title format: `[post:YYYY-MM-DD-slug] Brief topic` (see Issue
    Hygiene). Use `paperclipUpsertIssueDocument` for any longer-form draft body
    so revisions are tracked.
-2. Open the approval gate with `paperclipRequestConfirmation` (or the native
-   `paperclip` skill's `request_confirmation` flow) on that issue. Use a
-   stable idempotency key derived from the `[post:...]` slug so reruns reuse
-   the same card. Do NOT ask CEO for a free-form yes/no comment as the
-   approval mechanism — the accepted/rejected card is the decision.
-   Assign the draft issue to CEO for approval, but make the terminal owner
-   explicit: CEO must return it to Comms. CEO approval is not a terminal
-   outcome.
+2. Assign the draft issue to CEO for approval and include an approval request
+   comment with `approval_request=ceo_publish_review`, the latest
+   `draft_revision`, and the visual attachment hash when available. Make the
+   terminal owner explicit: CEO must return it to Comms. CEO approval is not a
+   terminal outcome.
 3. You may close the short-lived routine execution issue after the draft issue is
    created, so tomorrow's cron is not blocked. The closing comment MUST say
    `outcome=draft_created`, link the draft issue, and note that publication is
    still pending.
 4. When an approved `[post:...]` issue is assigned back to you, fetch context
-   through the native `paperclip` skill and verify the latest CEO decision is
-   an accepted structured confirmation. Then publish via
-   `publish_editorial_post`, archive, log, and close that draft issue with
-   `outcome=published`, `channel`, `telegram_message_id`, `editorial_post_id`,
-   and `already_posted` from the returned result object.
+   through the native `paperclip` skill and verify the latest CEO-authored
+   issue update contains `decision=approved_to_publish` for the latest
+   `draft_revision`. Then publish via `publish_editorial_post`, archive, log,
+   and close that draft issue with `outcome=published`, `channel`,
+   `telegram_message_id`, `editorial_post_id`, and `already_posted` from the
+   returned result object.
 5. NEVER close an approved `[post:...]` issue as done before publishing. A CEO
    approval (card or otherwise) without a Telegram message id means the post
    is still not public.
 
 Legacy fallback: a small number of pre-existing drafts may carry an
-`APPROVED_TO_PUBLISH` comment instead of an accepted confirmation card.
+`APPROVED_TO_PUBLISH` comment instead of a revision-bound decision marker.
 Treat that comment as a valid approval signal only for those legacy drafts;
-for anything created via the current routine, require the structured
-confirmation card.
+for anything created via the current routine, require
+`decision=approved_to_publish`.
 
 If a draft is still waiting for approval or publish after 24h, treat it as stale:
 comment with `outcome=stale_draft`, either refresh the data for today's post or

--- a/agents/comms-manager/routines/daily-channel-post.description.md
+++ b/agents/comms-manager/routines/daily-channel-post.description.md
@@ -16,8 +16,9 @@ Things that trip people up:
   are different chats with different message id sequences.
 - CEO approval is not publication. The routine may close its execution issue with
   `outcome=draft_created`, but the linked `[post:...]` issue must carry a
-  structured Paperclip confirmation card. It is
-  closed only after CEO returns it to Comms and `publish_editorial_post()`
-  returns `result.message_id` / `result.editorial_post_id`.
+  CEO-authored `decision=approved_to_publish` marker for the latest draft
+  revision. It is closed only after CEO returns it to Comms and
+  `publish_editorial_post()` returns `result.message_id` /
+  `result.editorial_post_id`.
 
 Validation, rotation, and the topic ban-list are enforced in code. If `EditorialValidationError` fires, fix the draft.

--- a/docs/agents/routine-observability.md
+++ b/docs/agents/routine-observability.md
@@ -37,12 +37,12 @@ Terminal success is `outcome=published` with both:
 - `telegram_message_id`
 - `editorial_post_id`
 
-`draft_created`, `approval_pending`, and an accepted `request_confirmation`
-card (the authoritative CEO approval signal) are intermediate states. Legacy
-`APPROVED_TO_PUBLISH` comments count as the same intermediate state for old
-drafts only. CEO approval must reassign the `[post:...]` issue to Comms
-Manager with status `todo`; CEO must not close the issue. Comms Manager is
-the only terminal owner and closes it after publishing through
+`draft_created`, `approval_pending`, and a CEO-authored
+`decision=approved_to_publish` marker for the latest draft revision are
+intermediate states. Legacy `APPROVED_TO_PUBLISH` comments count as the same
+intermediate state for old drafts only. CEO approval must reassign the
+`[post:...]` issue to Comms Manager with status `todo`; CEO must not close the
+issue. Comms Manager is the only terminal owner and closes it after publishing through
 `publish_editorial_post()` using the returned `result.message_id` and
 `result.editorial_post_id`.
 

--- a/scripts/paperclip_contracts.py
+++ b/scripts/paperclip_contracts.py
@@ -129,13 +129,13 @@ PUBLISHED_MARKERS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b(?:telegram_message_id|telegram message id)\b", re.IGNORECASE),
 )
 
-# Intermediate approval signals. `APPROVED_TO_PUBLISH` is legacy fallback
-# (still permitted for old drafts per `agents/comms-manager/AGENTS.md`)
-# but `accepted` confirmation cards are the authoritative path.
+# Intermediate approval signals. New Comms drafts use a CEO-authored
+# `decision=approved_to_publish` marker bound to the reviewed draft revision.
+# `APPROVED_TO_PUBLISH` remains a legacy fallback for old drafts.
 APPROVAL_MARKERS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\boutcome\s*=\s*draft_created\b", re.IGNORECASE),
+    re.compile(r"\bdecision\s*=\s*approved_to_publish\b", re.IGNORECASE),
     re.compile(r"\bAPPROVED_TO_PUBLISH\b"),
-    re.compile(r"\bapproved\b", re.IGNORECASE),
 )
 
 STALE_DRAFT_MARKERS: tuple[re.Pattern[str], ...] = (

--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -364,7 +364,11 @@ def classify_issue(
     # often mention approvals, posts, or prior watchdog flags while summarizing
     # their work; those must not inherit the channel-publication contract.
     is_publish_flow = title.startswith("[post:") or "daily channel post" in title
-    has_approval_signal = "approved" in lower or has_accepted_confirmation(interactions or [])
+    has_approval_signal = (
+        "decision=approved_to_publish" in lower
+        or "approved_to_publish" in lower
+        or has_accepted_confirmation(interactions or [])
+    )
     has_publish_marker = all(pattern.search(text) for pattern in PUBLISHED_MARKER_PATTERNS)
     if is_publish_flow and has_approval_signal and not has_publish_marker:
         flags.append("approved_without_publish_marker")

--- a/tests/scripts/test_paperclip_routine_audit.py
+++ b/tests/scripts/test_paperclip_routine_audit.py
@@ -79,8 +79,17 @@ def test_paperclip_update_verified_by_coolify_commit_is_green():
 
 def test_daily_channel_post_approval_still_requires_publish_markers():
     issue = {"title": "Daily Channel Post", "description": ""}
-    comments = [{"body": "CEO approved this draft; publishing still pending."}]
+    comments = [{"body": "decision=approved_to_publish\npublishing still pending."}]
 
     flags, _latest = audit.classify_issue(issue, comments)
 
     assert "approved_without_publish_marker" in flags
+
+
+def test_freeform_approval_comment_is_not_publish_approval_signal():
+    issue = {"title": "Daily Channel Post", "description": ""}
+    comments = [{"body": "CEO approved this draft; publishing still pending."}]
+
+    flags, _latest = audit.classify_issue(issue, comments)
+
+    assert "approved_without_publish_marker" not in flags

--- a/tests/test_paperclip_contracts.py
+++ b/tests/test_paperclip_contracts.py
@@ -135,7 +135,7 @@ def test_nested_state_published_terminal():
 
 
 def test_nested_state_approved_unpublished():
-    text = "outcome=draft_created\nAPPROVED_TO_PUBLISH"
+    text = "outcome=draft_created\ndecision=approved_to_publish\ndraft_revision=2"
     assert nested_state(text, slug="post") == "approved_unpublished"
 
 


### PR DESCRIPTION
Fixes FFM-1323.

## What changed
- Replaces board-only `request_confirmation` cards in CEO/Comms post approval instructions with a CEO-authored `decision=approved_to_publish` issue update marker bound to the reviewed draft revision.
- Updates the daily-channel routine docs and routine observability contract to use the same marker.
- Updates Paperclip audits/tests so free-form “CEO approved” text is not treated as an authoritative approval signal.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `ruff check --fix scripts/paperclip_contracts.py scripts/paperclip_routine_audit.py tests/test_paperclip_contracts.py tests/scripts/test_paperclip_routine_audit.py`
- `ruff format scripts/paperclip_contracts.py scripts/paperclip_routine_audit.py tests/test_paperclip_contracts.py tests/scripts/test_paperclip_routine_audit.py`
- `python3 -m pytest tests/test_paperclip_contracts.py tests/scripts/test_paperclip_routine_audit.py`

## Notes for review
This is a process/contract fix, not a Paperclip API change. The underlying API still treats confirmation-card resolution as board/user-only; FFmemes should stop using that surface for autonomous CEO agent review.