### PR TITLE
Shadow-log crossposting share signals

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -17,6 +17,7 @@ override current Codex or Paperclip decisions.
 | PR review automation | [PR review cycle](pr-review-cycle.md) | Keep GitHub payloads narrow and Paperclip issue links explicit. |
 | Moderator source scouting | [Moderator community loop spec](../../specs/moderator-community-loop.md), [CONTEXT.md](../../CONTEXT.md), and [ADR-0003](../adr/0003-prepared-source-etl-guard.md) | Use the Russian domain vocabulary; prepared sources stay parked until enabled. |
 | Describe Memes / vision OCR | [AGENTS.md](../../AGENTS.md) and [Describe Memes spec](../../specs/describe-memes.md) | Free OpenRouter vision models only. |
+| Crossposting / channel shares | [Crossposting share readout](../../specs/crossposting-share-optimization-2026-05-18.md), [Analyst crossposting SQL](../analyst/crossposting.sql), and [CONTEXT.md](../../CONTEXT.md) | Separate in-bot share clicks, channel deep links, and Telegram channel forwards/views. |
 
 ## Authority Boundaries
 

--- a/docs/analyst/README.md
+++ b/docs/analyst/README.md
@@ -10,6 +10,8 @@ The Analyst agent monitors product health, tracks experiments, and produces dail
 
 ## Key Files
 - `docs/analyst/metrics.sql` — SQL queries organized by section (health, north star, engines, retention, etc.)
+- `docs/analyst/crossposting.sql` — reusable read-only queries for Telegram channel views/forwards, 24h labels, and pre-posting share signals.
+- `specs/crossposting-share-optimization-2026-05-18.md` — current compact crossposting readout and next experiment gate.
 - `experiments/active/` — Currently running experiments to monitor
 - `experiments/completed/` — Historical experiments for context
 - `experiments/reports/` — Daily report output
@@ -39,6 +41,17 @@ Key tables for analytics:
 - `reaction_id IS NULL` → Sent but no reaction yet (skip/abandon)
 
 **Critical context**: Dislike = "next meme" skip, not negative signal. Fast dislikes (<2s) on text memes = "didn't bother reading", not "bad content."
+
+## Share Attribution
+
+Telegram bot shares and Telegram channel shares are different signals:
+
+- In-bot share clicks use `s_{sharer_user_id}_{meme_id}` in `user_deep_link_log`.
+- Channel post deep links use `sc_{meme_id}_{channel}` in `user_deep_link_log`.
+- Telegram channel forwards/views live in `crossposting` and `crossposting_snapshots`, collected by Telethon.
+
+For channel-growth work, read `docs/analyst/crossposting.sql` and
+`specs/crossposting-share-optimization-2026-05-18.md` before writing new SQL.
 
 ## Engine Names (recommended_by column)
 | Engine | Description | Expected LR |

--- a/docs/analyst/crossposting.sql
+++ b/docs/analyst/crossposting.sql
@@ -1,0 +1,307 @@
+-- =============================================================================
+-- CROSSPOSTING CHANNEL GROWTH ANALYTICS
+-- =============================================================================
+-- Usage: run against prod DB via ANALYST_DATABASE_URL.
+-- Safety: read-only queries. Keep statement_timeout enabled.
+--
+-- Domain vocabulary:
+-- - In-bot share clicks: user_deep_link_log.deep_link LIKE 's_%_%'
+-- - Channel deep links: user_deep_link_log.deep_link LIKE 'sc_%_%'
+-- - Channel forwards/views: crossposting + crossposting_snapshots
+--
+-- Reference:
+-- - specs/crossposting-share-optimization-2026-05-18.md
+-- - specs/channel-growth-optimization.md
+-- - CONTEXT.md "Share Attribution"
+-- =============================================================================
+
+
+-- =============================================
+-- SECTION: STATS FRESHNESS
+-- =============================================
+
+SELECT
+  channel,
+  count(*) AS snapshots_7d,
+  max(snapshot_at) AS latest_snapshot
+FROM crossposting_snapshots
+WHERE snapshot_at > now() - interval '7 days'
+GROUP BY channel
+ORDER BY channel;
+
+
+-- =============================================
+-- SECTION: 24H CHANNEL POST LABELS
+-- =============================================
+-- One row per crossposted meme with the snapshot nearest posted_at + 24h.
+-- Use this as the canonical target for offline evaluation.
+
+WITH labels AS (
+  SELECT
+    cp.channel,
+    cp.meme_id,
+    cp.score_version,
+    cp.created_at AS posted_at,
+    m.type AS meme_type,
+    s24.snapshot_at,
+    s24.views AS views_24h,
+    s24.forwards AS forwards_24h,
+    s24.reactions AS reactions_24h,
+    1000.0 * s24.forwards / NULLIF(s24.views, 0) AS fwd_per_1k_24h,
+    abs(extract(epoch FROM s24.snapshot_at - (cp.created_at + interval '24 hours')))
+      AS snapshot_lag_sec
+  FROM crossposting cp
+  JOIN meme m ON m.id = cp.meme_id
+  JOIN LATERAL (
+    SELECT cps.snapshot_at, cps.views, cps.forwards, cps.reactions
+    FROM crossposting_snapshots cps
+    WHERE cps.channel = cp.channel
+      AND cps.meme_id = cp.meme_id
+      AND cps.snapshot_at BETWEEN cp.created_at + interval '20 hours'
+                              AND cp.created_at + interval '36 hours'
+      AND cps.views > 0
+      AND cps.forwards IS NOT NULL
+    ORDER BY abs(extract(epoch FROM cps.snapshot_at - (cp.created_at + interval '24 hours')))
+    LIMIT 1
+  ) s24 ON true
+  WHERE cp.channel IN ('tgchannelru', 'tgchannelen')
+    AND cp.created_at < now() - interval '36 hours'
+)
+SELECT *
+FROM labels
+ORDER BY posted_at DESC
+LIMIT 100;
+
+
+-- =============================================
+-- SECTION: SCORE VERSION IMAGE READOUT
+-- =============================================
+-- Fair v2 readout: image-only, 24h target. All-content comparisons are
+-- confounded by the Apr 13 video boost.
+
+WITH bounds AS (
+  SELECT channel, min(created_at) FILTER (WHERE score_version = 2) AS v2_ship
+  FROM crossposting
+  WHERE channel IN ('tgchannelru', 'tgchannelen')
+  GROUP BY channel
+),
+labels AS (
+  SELECT
+    cp.channel,
+    CASE
+      WHEN cp.created_at >= timestamp '2026-04-13 00:00:00'
+       AND cp.created_at < b.v2_ship THEN 'phase1_image'
+      WHEN cp.score_version = 2
+       AND cp.created_at >= b.v2_ship THEN 'phase2_v2_image'
+    END AS period,
+    s24.views AS views_24h,
+    s24.forwards AS forwards_24h,
+    1000.0 * s24.forwards / NULLIF(s24.views, 0) AS fwd_per_1k_24h
+  FROM crossposting cp
+  JOIN bounds b ON b.channel = cp.channel
+  JOIN meme m ON m.id = cp.meme_id
+  JOIN LATERAL (
+    SELECT cps.views, cps.forwards, cps.snapshot_at
+    FROM crossposting_snapshots cps
+    WHERE cps.channel = cp.channel
+      AND cps.meme_id = cp.meme_id
+      AND cps.snapshot_at BETWEEN cp.created_at + interval '20 hours'
+                              AND cp.created_at + interval '36 hours'
+      AND cps.views > 0
+      AND cps.forwards IS NOT NULL
+    ORDER BY abs(extract(epoch FROM cps.snapshot_at - (cp.created_at + interval '24 hours')))
+    LIMIT 1
+  ) s24 ON true
+  WHERE cp.channel IN ('tgchannelru', 'tgchannelen')
+    AND cp.created_at < now() - interval '36 hours'
+    AND m.type = 'image'
+)
+SELECT
+  channel,
+  period,
+  count(*) AS n_image_posts,
+  round(avg(views_24h), 1) AS avg_views_24h,
+  percentile_cont(0.5) WITHIN GROUP (ORDER BY views_24h) AS med_views_24h,
+  round(avg(forwards_24h), 2) AS avg_forwards_24h,
+  percentile_cont(0.5) WITHIN GROUP (ORDER BY forwards_24h) AS med_forwards_24h,
+  round(sum(forwards_24h)::numeric / NULLIF(sum(views_24h), 0) * 1000, 2)
+    AS agg_fwd_per_1k_24h,
+  round(avg(fwd_per_1k_24h), 2) AS avg_post_fwd_per_1k_24h
+FROM labels
+WHERE period IS NOT NULL
+GROUP BY channel, period
+ORDER BY channel, period;
+
+
+-- =============================================
+-- SECTION: PRE-POSTING SIGNAL FEATURES
+-- =============================================
+-- Reconstruct signals available before each channel post. Do not use current
+-- all-time meme_stats.invited_count for offline evaluation.
+
+WITH labels AS (
+  SELECT
+    cp.channel,
+    cp.meme_id,
+    cp.created_at AS posted_at,
+    s24.views AS views_24h,
+    s24.forwards AS forwards_24h,
+    1000.0 * s24.forwards / NULLIF(s24.views, 0) AS fwd_per_1k_24h
+  FROM crossposting cp
+  JOIN meme m ON m.id = cp.meme_id
+  JOIN LATERAL (
+    SELECT cps.views, cps.forwards, cps.snapshot_at
+    FROM crossposting_snapshots cps
+    WHERE cps.channel = cp.channel
+      AND cps.meme_id = cp.meme_id
+      AND cps.snapshot_at BETWEEN cp.created_at + interval '20 hours'
+                              AND cp.created_at + interval '36 hours'
+      AND cps.views > 0
+      AND cps.forwards IS NOT NULL
+    ORDER BY abs(extract(epoch FROM cps.snapshot_at - (cp.created_at + interval '24 hours')))
+    LIMIT 1
+  ) s24 ON true
+  WHERE cp.channel IN ('tgchannelru', 'tgchannelen')
+    AND cp.created_at < now() - interval '36 hours'
+    AND m.type = 'image'
+),
+reaction_features AS (
+  SELECT
+    l.channel,
+    l.meme_id,
+    count(*) FILTER (WHERE r.reaction_id = 1) AS pre_likes,
+    count(*) FILTER (WHERE r.reaction_id = 2) AS pre_skips,
+    count(*) AS pre_reactions
+  FROM labels l
+  LEFT JOIN user_meme_reaction r
+    ON r.meme_id = l.meme_id
+   AND r.reacted_at IS NOT NULL
+   AND r.reacted_at < l.posted_at
+   AND r.reaction_id IN (1, 2)
+  GROUP BY l.channel, l.meme_id
+),
+parsed_share_clicks AS (
+  SELECT
+    CAST(split_part(deep_link, '_', 3) AS integer) AS meme_id,
+    user_id,
+    created_at
+  FROM user_deep_link_log
+  WHERE deep_link ~ '^s_[0-9]+_[0-9]+$'
+),
+share_features AS (
+  SELECT
+    l.channel,
+    l.meme_id,
+    count(DISTINCT psc.user_id) AS pre_inbot_share_click_users
+  FROM labels l
+  LEFT JOIN parsed_share_clicks psc
+    ON psc.meme_id = l.meme_id
+   AND psc.created_at < l.posted_at
+  GROUP BY l.channel, l.meme_id
+)
+SELECT
+  l.*,
+  rf.pre_likes,
+  rf.pre_skips,
+  rf.pre_reactions,
+  100.0 * rf.pre_likes / NULLIF(rf.pre_reactions, 0) AS pre_like_rate_pct,
+  sf.pre_inbot_share_click_users
+FROM labels l
+JOIN reaction_features rf ON rf.channel = l.channel AND rf.meme_id = l.meme_id
+JOIN share_features sf ON sf.channel = l.channel AND sf.meme_id = l.meme_id
+ORDER BY l.posted_at DESC
+LIMIT 100;
+
+
+-- =============================================
+-- SECTION: SHADOW DECISION LOG SHARE FEATURES
+-- =============================================
+-- Production shadow experiment crossposting-pre-share-shadow-v1:
+-- the live ranker still uses score_version=2, but top-N decision-log candidates
+-- include pre_inbot_share_clicks and pre_inbot_share_click_users.
+
+SELECT
+  dl.decided_at,
+  dl.channel,
+  dl.picked_meme_id,
+  dl.score_version,
+  candidate->>'rank' AS rank,
+  (candidate->>'meme_id')::int AS candidate_meme_id,
+  (candidate->>'pre_inbot_share_clicks')::int AS pre_inbot_share_clicks,
+  (candidate->>'pre_inbot_share_click_users')::int AS pre_inbot_share_click_users,
+  (candidate->>'final_score')::numeric AS live_v2_score
+FROM crossposting_decision_log dl
+CROSS JOIN LATERAL jsonb_array_elements(dl.candidates) AS candidate
+WHERE dl.channel IN ('tgchannelru', 'tgchannelen')
+  AND dl.decided_at > now() - interval '14 days'
+  AND candidate ? 'pre_inbot_share_click_users'
+ORDER BY dl.decided_at DESC, (candidate->>'rank')::int
+LIMIT 100;
+
+
+-- =============================================
+-- SECTION: SOURCE QUALITY 30D
+-- =============================================
+-- Mirrors the hot ranker formula. Use only mature posts available before the
+-- simulated decision time when backtesting.
+
+SELECT
+  cp.channel,
+  m.meme_source_id,
+  src.url,
+  count(*) AS posts,
+  round(avg(cp.views), 1) AS avg_views,
+  round(avg(cp.forwards), 2) AS avg_forwards,
+  round(1000.0 * sum(cp.forwards) / NULLIF(sum(cp.views), 0), 2) AS fwd_per_1k,
+  round(avg(cp.forwards * sqrt(greatest(cp.views, 1) / 100.0)), 2) AS source_signal
+FROM crossposting cp
+JOIN meme m ON m.id = cp.meme_id
+JOIN meme_source src ON src.id = m.meme_source_id
+WHERE cp.channel IN ('tgchannelru', 'tgchannelen')
+  AND cp.created_at > now() - interval '30 days'
+  AND cp.created_at < now() - interval '48 hours'
+  AND cp.views IS NOT NULL
+  AND cp.views > 0
+  AND cp.forwards IS NOT NULL
+  AND m.type = 'image'
+GROUP BY cp.channel, m.meme_source_id, src.url
+HAVING count(*) >= 5
+ORDER BY cp.channel, source_signal DESC;
+
+
+-- =============================================
+-- SECTION: SOURCE CONCENTRATION GUARDRAIL
+-- =============================================
+
+SELECT
+  cp.channel,
+  m.meme_source_id,
+  src.url,
+  count(*) AS posts_7d
+FROM crossposting cp
+JOIN meme m ON m.id = cp.meme_id
+JOIN meme_source src ON src.id = m.meme_source_id
+WHERE cp.channel IN ('tgchannelru', 'tgchannelen')
+  AND cp.created_at > now() - interval '7 days'
+GROUP BY cp.channel, m.meme_source_id, src.url
+ORDER BY cp.channel, posts_7d DESC
+LIMIT 30;
+
+
+-- =============================================
+-- SECTION: CHANNEL DEEP LINK STARTS
+-- =============================================
+-- sc_{meme_id}_{channel}: channel post -> bot starts/clicks.
+
+SELECT
+  split_part(deep_link, '_', 3) AS channel,
+  split_part(deep_link, '_', 2)::int AS meme_id,
+  count(*) AS clicks,
+  count(DISTINCT user_id) AS unique_clickers,
+  min(created_at) AS first_click_at,
+  max(created_at) AS last_click_at
+FROM user_deep_link_log
+WHERE deep_link ~ '^sc_[0-9]+_[a-z]+'
+GROUP BY 1, 2
+ORDER BY unique_clickers DESC, clicks DESC
+LIMIT 100;

--- a/docs/analyst/metrics.sql
+++ b/docs/analyst/metrics.sql
@@ -71,13 +71,15 @@ FROM session_lengths;
 -- =============================================
 -- SECTION: GROWTH — SHARES & REFERRALS
 -- =============================================
--- Share tracking: user clicks link under meme → logged in user_deep_link_log
--- This is the only proxy for "shares" (TG Bot API doesn't expose forward counts)
+-- In-bot share tracking: user clicks an s_{sharer_user_id}_{meme_id} link
+-- under a forwarded bot meme → logged in user_deep_link_log.
+-- Telegram channel post forwards/views are separate; see docs/analyst/crossposting.sql.
 
 SELECT
   count(*) AS deep_link_clicks_7d,
   count(DISTINCT user_id) AS unique_clickers_7d,
-  count(*) FILTER (WHERE deep_link LIKE 'meme_%') AS meme_share_clicks_7d
+  count(*) FILTER (WHERE deep_link ~ '^s_[0-9]+_[0-9]+$') AS inbot_share_clicks_7d,
+  count(*) FILTER (WHERE deep_link ~ '^sc_[0-9]+_[a-z]+') AS channel_deep_link_clicks_7d
 FROM user_deep_link_log
 WHERE created_at > now() - interval '7 days';
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -15,6 +15,7 @@ Detailed specifications for each subsystem. See root [SPEC.md](../SPEC.md) for p
 | [error-profile.md](error-profile.md) | Production error analysis from logs |
 | [data-hypotheses.md](data-hypotheses.md) | Data analysis findings (H1-H7) |
 | [cohort-analysis-2026-03-29.md](cohort-analysis-2026-03-29.md) | Super users vs churned: cohort analysis, 6 experiments |
+| [crossposting-share-optimization-2026-05-18.md](crossposting-share-optimization-2026-05-18.md) | Current Telegram channel share readout, v2 results, next experiment gate |
 | [experiment-2026-03-14.md](experiment-2026-03-14.md) | Experiment: queue refill threshold + removed fast_dopamine |
 | [experiment-2026-03-16-es-ranked.md](experiment-2026-03-16-es-ranked.md) | Experiment: engagement_score ranked engine |
 | [experiment-2026-03-20-adaptive-cold-start.md](experiment-2026-03-20-adaptive-cold-start.md) | Experiment: adaptive cold start (3-phase) |

--- a/specs/crossposting-share-optimization-2026-05-18.md
+++ b/specs/crossposting-share-optimization-2026-05-18.md
@@ -1,0 +1,163 @@
+# Crossposting Share Optimization Readout (2026-05-18)
+
+## Why this exists
+
+Future agents should not need to rediscover the Telegram channel share baseline
+from scratch. This file is the compact, repo-tracked summary of the May 2026
+crossposting analysis. Generated `experiments/` files may be local/ignored.
+
+## Data sources
+
+- `crossposting`: current per-post Telegram channel stats.
+- `crossposting_snapshots`: Telethon time-series snapshots, collected every 6h.
+- `user_meme_reaction`: bot reactions before channel posting.
+- `user_deep_link_log`: in-bot share clicks (`s_...`) and channel deep links
+  (`sc_...`).
+
+Read-only prod analysis was run through `ANALYST_DATABASE_URL`.
+
+## Current system
+
+`score_version=2` shipped on 2026-04-28. The ranker in
+`src/crossposting/service.py` uses:
+
+- image-only channel posts;
+- source-quality multiplier:
+  `AVG(forwards * SQRT(GREATEST(views, 1) / 100.0))`;
+- one source per channel per 24h diversity cap;
+- bot quality floor `meme_stats.nlikes >= 5`;
+- `meme_stats.invited_count` boost for in-bot share clicks.
+
+## Main readout
+
+Stats collector was healthy during analysis. Latest observed snapshots were
+2026-05-18 05:00 UTC.
+
+All-content comparisons are misleading because the Apr 13 video boost made the
+pre-v2 phase video-heavy. Videos had higher forwards per 1k views, but reduced
+reach and caused a video-heavy feed. They were later hard-filtered out.
+
+Image-only 24h forward-rate comparison:
+
+| Channel | Phase 1 image avg fwd/1k | Phase 2 v2 image avg fwd/1k | Lift |
+| --- | ---: | ---: | ---: |
+| RU | 18.34 | 24.97 | +36% |
+| EN | 11.88 | 18.98 | +60% |
+
+Image-only 24h views were stable:
+
+- RU: 394.7 -> 406.4 avg views.
+- EN: 72.9 -> 77.2 avg views.
+
+Conclusion: v2 improved image post share rate without lowering image reach.
+
+Subscriber counts did not show RU growth:
+
+- RU: 2182 on 2026-04-13 -> 2158 on 2026-05-17.
+- EN: 627 on 2026-04-13 -> 654 on 2026-05-17.
+
+Better meme selection alone is not yet enough to grow RU subscribers.
+
+## Superuser-like hypothesis
+
+Hypothesis: likes from a subset of bot users might predict channel forwards even
+if all-user likes do not.
+
+Strict offline check:
+
+- target = nearest 24h channel snapshot after posting;
+- image posts only;
+- only reactions with `reacted_at < crossposting.created_at`;
+- train before 2026-05-05, test after 2026-05-05;
+- candidate users ranked by train lift:
+  `avg(fwd/1k | liked) - avg(fwd/1k | skipped)`.
+
+Result:
+
+| Channel | Test posts | All-likes corr | Top-25 likes corr | Top-25 like-rate corr | Top-25 any-like lift |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| RU | 81 | -0.117 | -0.023 | 0.155 | 0.98x |
+| EN | 70 | -0.228 | -0.170 | -0.182 | 0.98x |
+
+Conclusion: superuser-like signal failed the offline gate. Do not ship it to
+online A/B yet. Shadow-log only.
+
+## In-bot share signal
+
+Prior in-bot share clicks before channel posting are a more promising RU signal:
+
+| Channel | Posts | Posts with prior share | Avg fwd/1k | Avg when shared | Lift |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| RU | 144 | 24 | 23.97 | 27.88 | 1.16x |
+| EN | 145 | 39 | 17.45 | 16.38 | 0.94x |
+
+Conclusion: in-bot share clicks are a candidate RU signal. However, the current
+ranker uses all-time `meme_stats.invited_count`, which is not timestamp-safe for
+offline evaluation and can include clicks after a simulated channel decision.
+The next test should compare current v2 against a timestamp-safe prior-share
+replacement. Do not copy the RU weight to EN.
+
+## Next experiment gate
+
+Do not launch `score_version=3` immediately. First build an offline evaluator
+and shadow score.
+
+Production shadow experiment:
+
+- Name: `crossposting-pre-share-shadow-v1`.
+- Hypothesis: for RU, timestamp-safe in-bot share clicks observed before the
+  channel decision improve prediction of 24h channel forwards. EN remains
+  report-only because the prior offline lift was negative.
+- Implementation: keep the live ranker at `score_version=2` and do not change
+  selected memes. Add `pre_inbot_share_clicks` and
+  `pre_inbot_share_click_users` to `crossposting_decision_log.candidates` for
+  the already logged top-N candidates. Count only rows created before the
+  decision timestamp and exclude self-clicks where the clicker is also the
+  sharer encoded in `s_{sharer_user_id}_{meme_id}`.
+- Rollback: revert the logging-only change or ignore the JSON fields. There is
+  no schema migration, no score-version bump, and no posting-behavior change.
+- First production check: after deploy, trigger one RU and one EN crossposting
+  run, then verify their newest decision-log rows contain the two shadow fields.
+
+Offline evaluator requirements:
+
+1. Label channel posts using 24h snapshots.
+2. Use only pre-posting bot reactions and share clicks.
+3. Split per channel by time: train, validation, test.
+4. Include random same-size user subsets as placebo.
+5. Compare against all-user likes, all-user like rate, current v2 score, and
+   source-only score.
+6. Reconstruct source-quality and share features as of the simulated decision
+   time; do not use current all-time aggregates when backtesting.
+
+Online A/B is allowed only if the fresh test split shows:
+
+- coverage >= 35% of candidate posts;
+- Spearman correlation beats all-likes and all-like-rate by >= 0.05;
+- top-20% shadow-ranked posts beat all-likes top-20% lift by >= 15%;
+- selected signal beats 95th percentile of random subsets;
+- absolute `forwards_24h` and `views_24h` do not drop.
+
+Minimum next experiment: RU-only offline evaluator for a timestamp-safe
+prior-share feature, with superuser features measured but coefficient fixed at
+zero. EN stays report-only until it shows a positive offline signal.
+
+## Architecture follow-up
+
+The current ranker SQL and analysis queries are too expensive to rediscover and
+too easy to subtly change. High-leverage follow-ups:
+
+- Create a channel outcome labeling Module for 24h/48h snapshots.
+- Create a pre-posting signal Module for likes, like rates, in-bot share clicks,
+  and future predictor-user weights. Its Interface must accept `posted_at` and
+  guarantee no post-after-post leakage.
+- Keep the hot crossposting ranker from computing predictor users inline.
+  Materialize predictor weights separately if the offline gate passes.
+- Add an index before routine evaluator work:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  ix_user_meme_reaction_meme_id_reacted_at
+ON user_meme_reaction (meme_id, reacted_at)
+INCLUDE (user_id, reaction_id, sent_at);
+```

--- a/specs/crossposting-source-quality.md
+++ b/specs/crossposting-source-quality.md
@@ -245,7 +245,7 @@ WHERE 1=1
   AND M.status = 'ok'
   AND M.language_code = :lang
   AND M.type = 'image'
-  AND MS.nlikes >= 2                                    -- lowered from 5 (codex #1)
+  AND MS.nlikes >= 5                                    -- kept quality floor
   AND M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
 ORDER BY -1
     * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -123,6 +123,8 @@ def _build_decision_log(
                 "age_days": row.get("age_days"),
                 "nmemes_sent": row.get("nmemes_sent"),
                 "invited_count": row.get("invited_count"),
+                "pre_inbot_share_clicks": row.get("pre_inbot_share_clicks") or 0,
+                "pre_inbot_share_click_users": row.get("pre_inbot_share_click_users") or 0,
                 "caption_present": row.get("caption") is not None,
                 "src_signal": (
                     round(float(row["src_signal"]), 4)
@@ -178,7 +180,10 @@ def _picked_meme_dict(candidate: dict[str, Any]) -> dict[str, Any]:
 
 
 _RU_QUERY = """
-    WITH src_quality AS (
+    WITH selected_at AS (
+        SELECT NOW() AS decided_at
+    ),
+    src_quality AS (
         SELECT
             m.meme_source_id,
             AVG(cp.forwards * SQRT(GREATEST(cp.views, 1) / 100.0)) AS signal,
@@ -205,47 +210,67 @@ _RU_QUERY = """
         WHERE cp2.channel = 'tgchannelru'
           AND cp2.created_at > NOW() - INTERVAL '24 hours'
           AND cp2.telegram_message_id IS NOT NULL
+    ),
+    ranked AS (
+        SELECT
+            M.id, M.type, M.telegram_file_id, M.caption,
+            M.meme_source_id,
+            MS.nlikes, MS.ndislikes, MS.raw_impr_rank,
+            MS.age_days, MS.nmemes_sent, MS.invited_count,
+            SQ.signal AS src_signal,
+            (SELECT m_signal FROM src_median) AS median_signal,
+            COUNT(*) OVER () AS candidate_pool_size
+        FROM meme M
+        INNER JOIN meme_stats MS ON MS.meme_id = M.id
+        LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelru'
+        LEFT JOIN src_quality SQ ON SQ.meme_source_id = M.meme_source_id
+        WHERE 1=1
+          AND CP.meme_id IS NULL
+          AND M.status = 'ok'
+          AND M.language_code = 'ru'
+          AND M.type = 'image'
+          AND MS.nlikes >= 5
+          AND M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
+        ORDER BY -1
+            * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
+            * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.8 END
+            * CASE WHEN MS.age_days < 7 THEN 1 ELSE 0.8 END
+            * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
+            * CASE
+                WHEN MS.nmemes_sent <= 1 THEN 1
+                ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
+              END
+            * COALESCE(
+                LEAST(2.0, GREATEST(0.5,
+                    SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
+                )),
+                1.0
+              )
+            * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
+        LIMIT :limit
     )
     SELECT
-        M.id, M.type, M.telegram_file_id, M.caption,
-        M.meme_source_id,
-        MS.nlikes, MS.ndislikes, MS.raw_impr_rank,
-        MS.age_days, MS.nmemes_sent, MS.invited_count,
-        SQ.signal AS src_signal,
-        (SELECT m_signal FROM src_median) AS median_signal,
-        COUNT(*) OVER () AS candidate_pool_size
-    FROM meme M
-    INNER JOIN meme_stats MS ON MS.meme_id = M.id
-    LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelru'
-    LEFT JOIN src_quality SQ ON SQ.meme_source_id = M.meme_source_id
-    WHERE 1=1
-      AND CP.meme_id IS NULL
-      AND M.status = 'ok'
-      AND M.language_code = 'ru'
-      AND M.type = 'image'
-      AND MS.nlikes >= 5
-      AND M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
-    ORDER BY -1
-        * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
-        * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.8 END
-        * CASE WHEN MS.age_days < 7 THEN 1 ELSE 0.8 END
-        * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
-        * CASE
-            WHEN MS.nmemes_sent <= 1 THEN 1
-            ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
-          END
-        * COALESCE(
-            LEAST(2.0, GREATEST(0.5,
-                SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
-            )),
-            1.0
-          )
-        * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
-    LIMIT :limit
+        ranked.*,
+        COALESCE(share_clicks.pre_inbot_share_clicks, 0) AS pre_inbot_share_clicks,
+        COALESCE(share_clicks.pre_inbot_share_click_users, 0) AS pre_inbot_share_click_users
+    FROM ranked
+    CROSS JOIN selected_at
+    LEFT JOIN LATERAL (
+        SELECT
+            COUNT(*) AS pre_inbot_share_clicks,
+            COUNT(DISTINCT user_id) AS pre_inbot_share_click_users
+        FROM user_deep_link_log udll
+        WHERE udll.created_at < selected_at.decided_at
+          AND udll.deep_link ~ ('^s_[0-9]+_' || ranked.id || '$')
+          AND udll.user_id <> split_part(udll.deep_link, '_', 2)::bigint
+    ) share_clicks ON true
 """
 
 _EN_QUERY = """
-    WITH src_quality AS (
+    WITH selected_at AS (
+        SELECT NOW() AS decided_at
+    ),
+    src_quality AS (
         SELECT
             m.meme_source_id,
             AVG(cp.forwards * SQRT(GREATEST(cp.views, 1) / 100.0)) AS signal,
@@ -272,43 +297,60 @@ _EN_QUERY = """
         WHERE cp2.channel = 'tgchannelen'
           AND cp2.created_at > NOW() - INTERVAL '24 hours'
           AND cp2.telegram_message_id IS NOT NULL
+    ),
+    ranked AS (
+        SELECT
+            M.id, M.type, M.telegram_file_id, M.caption,
+            M.meme_source_id,
+            MS.nlikes, MS.ndislikes, MS.raw_impr_rank,
+            MS.age_days, MS.nmemes_sent, MS.invited_count,
+            SQ.signal AS src_signal,
+            (SELECT m_signal FROM src_median) AS median_signal,
+            COUNT(*) OVER () AS candidate_pool_size
+        FROM meme M
+        INNER JOIN meme_stats MS ON MS.meme_id = M.id
+        LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelen'
+        LEFT JOIN src_quality SQ ON SQ.meme_source_id = M.meme_source_id
+        WHERE 1=1
+          AND CP.meme_id IS NULL
+          AND M.status = 'ok'
+          AND M.language_code = 'en'
+          AND M.type = 'image'
+          AND MS.nlikes >= 5
+          AND M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
+        ORDER BY -1
+            * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
+            * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.5 END
+            * CASE WHEN MS.age_days < 90 THEN 1 ELSE 0.8 END
+            * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
+            * CASE
+                WHEN MS.nmemes_sent <= 1 THEN 1
+                ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
+              END
+            * COALESCE(
+                LEAST(2.0, GREATEST(0.5,
+                    SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
+                )),
+                1.0
+              )
+            * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
+        LIMIT :limit
     )
     SELECT
-        M.id, M.type, M.telegram_file_id, M.caption,
-        M.meme_source_id,
-        MS.nlikes, MS.ndislikes, MS.raw_impr_rank,
-        MS.age_days, MS.nmemes_sent, MS.invited_count,
-        SQ.signal AS src_signal,
-        (SELECT m_signal FROM src_median) AS median_signal,
-        COUNT(*) OVER () AS candidate_pool_size
-    FROM meme M
-    INNER JOIN meme_stats MS ON MS.meme_id = M.id
-    LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelen'
-    LEFT JOIN src_quality SQ ON SQ.meme_source_id = M.meme_source_id
-    WHERE 1=1
-      AND CP.meme_id IS NULL
-      AND M.status = 'ok'
-      AND M.language_code = 'en'
-      AND M.type = 'image'
-      AND MS.nlikes >= 5
-      AND M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
-    ORDER BY -1
-        * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
-        * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.5 END
-        * CASE WHEN MS.age_days < 90 THEN 1 ELSE 0.8 END
-        * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
-        * CASE
-            WHEN MS.nmemes_sent <= 1 THEN 1
-            ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
-          END
-        * COALESCE(
-            LEAST(2.0, GREATEST(0.5,
-                SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
-            )),
-            1.0
-          )
-        * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
-    LIMIT :limit
+        ranked.*,
+        COALESCE(share_clicks.pre_inbot_share_clicks, 0) AS pre_inbot_share_clicks,
+        COALESCE(share_clicks.pre_inbot_share_click_users, 0) AS pre_inbot_share_click_users
+    FROM ranked
+    CROSS JOIN selected_at
+    LEFT JOIN LATERAL (
+        SELECT
+            COUNT(*) AS pre_inbot_share_clicks,
+            COUNT(DISTINCT user_id) AS pre_inbot_share_click_users
+        FROM user_deep_link_log udll
+        WHERE udll.created_at < selected_at.decided_at
+          AND udll.deep_link ~ ('^s_[0-9]+_' || ranked.id || '$')
+          AND udll.user_id <> split_part(udll.deep_link, '_', 2)::bigint
+    ) share_clicks ON true
 """
 
 

--- a/src/database.py
+++ b/src/database.py
@@ -588,7 +588,8 @@ crossposting_decision_log = Table(
     Column("median_signal", Float),
     Column("candidate_pool_size", Integer),
     # candidates JSONB: list of {meme_id, source_id, rank, nlikes, ndislikes,
-    # raw_impr_rank, age_days, nmemes_sent, invited_count, caption_present,
+    # raw_impr_rank, age_days, nmemes_sent, invited_count,
+    # pre_inbot_share_clicks, pre_inbot_share_click_users, caption_present,
     # src_signal, src_quality_mult, lr_factor, impr_factor, age_factor,
     # caption_factor, sent_factor, invited_boost, final_score}
     Column("candidates", JSONB, nullable=False),

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -1,12 +1,16 @@
+from datetime import UTC, datetime, timedelta
+
 import pytest
 import pytest_asyncio
 from sqlalchemy import delete, text
+from sqlalchemy.dialects.postgresql import insert
 
 from src.crossposting.service import (
+    get_next_meme_for_tgchannelen,
     get_next_meme_for_tgchannelru,
     log_ranker_decision,
 )
-from src.database import crossposting, crossposting_decision_log, engine
+from src.database import crossposting, crossposting_decision_log, engine, user_deep_link_log
 from src.flows.crossposting.meme import _clean_caption
 from tests.factories import (
     TEST_ID_START,
@@ -14,6 +18,7 @@ from tests.factories import (
     create_meme,
     create_meme_source,
     create_meme_stats,
+    create_user,
 )
 
 
@@ -258,6 +263,79 @@ async def test_source_quality_neutral_when_no_snapshots(clean_xpost):
 
 
 @pytest.mark.asyncio
+async def test_decision_log_shadow_counts_pre_posting_share_clicks(clean_xpost):
+    async with engine.connect() as conn:
+        await create_meme_source(conn, id=10350, language_code="ru")
+        await create_meme(
+            conn, id=10351, meme_source_id=10350, language_code="ru", type="image", status="ok"
+        )
+        await create_meme_stats(conn, meme_id=10351, nlikes=10, ndislikes=2)
+
+        for user_id in (10051, 10052, 10053, 10054):
+            await create_user(conn, id=user_id)
+
+        now = datetime.now(UTC).replace(tzinfo=None)
+        await conn.execute(
+            insert(user_deep_link_log),
+            [
+                {
+                    "user_id": 10052,
+                    "deep_link": "s_10051_10351",
+                    "created_at": now - timedelta(hours=2),
+                },
+                {
+                    "user_id": 10052,
+                    "deep_link": "s_10051_10351",
+                    "created_at": now - timedelta(hours=1),
+                },
+                {
+                    "user_id": 10053,
+                    "deep_link": "s_10051_10351",
+                    "created_at": now - timedelta(hours=1),
+                },
+                {
+                    "user_id": 10051,
+                    "deep_link": "s_10051_10351",
+                    "created_at": now - timedelta(hours=1),
+                },
+                {
+                    "user_id": 10054,
+                    "deep_link": "s_10053_10351",
+                    "created_at": now + timedelta(hours=1),
+                },
+            ],
+        )
+        await conn.commit()
+
+    picked, decision = await get_next_meme_for_tgchannelru()
+    assert picked is not None
+    assert picked["id"] == 10351
+    assert decision is not None
+    only_candidate = decision["candidates"][0]
+    assert only_candidate["pre_inbot_share_clicks"] == 3
+    assert only_candidate["pre_inbot_share_click_users"] == 2
+
+
+@pytest.mark.asyncio
+async def test_en_ranker_decision_log_has_shadow_share_fields(clean_xpost):
+    async with engine.connect() as conn:
+        await create_meme_source(conn, id=10360, language_code="en")
+        await create_meme(
+            conn, id=10361, meme_source_id=10360, language_code="en", type="image", status="ok"
+        )
+        await create_meme_stats(conn, meme_id=10361, nlikes=10, ndislikes=2)
+        await conn.commit()
+
+    picked, decision = await get_next_meme_for_tgchannelen()
+    assert picked is not None
+    assert picked["id"] == 10361
+    assert decision is not None
+    only_candidate = decision["candidates"][0]
+    assert only_candidate["pre_inbot_share_clicks"] == 0
+    assert only_candidate["pre_inbot_share_click_users"] == 0
+
+
+@pytest.mark.asyncio
 async def test_ranker_decision_log_records_top5(clean_xpost):
     """Decision log persists top-N candidates with full score breakdown for retro analysis."""
     async with engine.connect() as conn:
@@ -317,6 +395,8 @@ async def test_ranker_decision_log_records_top5(clean_xpost):
         "age_days",
         "nmemes_sent",
         "invited_count",
+        "pre_inbot_share_clicks",
+        "pre_inbot_share_click_users",
         "caption_present",
         "src_signal",
         "src_quality_mult",


### PR DESCRIPTION
## Summary
- add shadow-only in-bot share click fields to crossposting decision-log candidates
- keep live selection at score_version=2; no ranking formula, schema, or posting behavior change
- add reusable crossposting analytics SQL and a compact experiment readout with gate/rollback notes

## Hypothesis
RU memes with timestamp-safe pre-decision in-bot share clicks will better predict 24h Telegram channel forwards than aggregate likes alone. EN remains report-only until it shows a positive offline signal.

## Rollback
Revert this PR or ignore the new JSON fields in crossposting_decision_log.candidates. There is no migration, no score-version bump, and no changed selection behavior.

## Checks
- ruff check src/crossposting/service.py src/database.py tests/test_crossposting_meme.py
- ruff format --check src/crossposting/service.py src/database.py tests/test_crossposting_meme.py
- set -a; source ../ff-backend/.env.test; set +a; python3 -m pytest tests/test_crossposting_meme.py -q

## Production validation plan
After deploy health is green and not close to a scheduled channel slot:
1. Trigger Collect Channel Stats if stats freshness is stale.
2. Trigger one RU and one EN crossposting run.
3. Verify newest crossposting_decision_log rows contain pre_inbot_share_clicks and pre_inbot_share_click_users in candidates JSON.
4. Watch app/prefect logs and channel stats snapshots for the triggered posts.