### PR TITLE
Fix malformed share deep links in crossposting shadow log

### DIFF
--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -262,7 +262,7 @@ _RU_QUERY = """
         FROM user_deep_link_log udll
         WHERE udll.created_at < selected_at.decided_at
           AND udll.deep_link ~ ('^s_[0-9]+_' || ranked.id || '$')
-          AND udll.user_id <> split_part(udll.deep_link, '_', 2)::bigint
+          AND udll.user_id::text <> split_part(udll.deep_link, '_', 2)
     ) share_clicks ON true
 """
 
@@ -349,7 +349,7 @@ _EN_QUERY = """
         FROM user_deep_link_log udll
         WHERE udll.created_at < selected_at.decided_at
           AND udll.deep_link ~ ('^s_[0-9]+_' || ranked.id || '$')
-          AND udll.user_id <> split_part(udll.deep_link, '_', 2)::bigint
+          AND udll.user_id::text <> split_part(udll.deep_link, '_', 2)
     ) share_clicks ON true
 """
 

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -303,6 +303,11 @@ async def test_decision_log_shadow_counts_pre_posting_share_clicks(clean_xpost):
                     "deep_link": "s_10053_10351",
                     "created_at": now + timedelta(hours=1),
                 },
+                {
+                    "user_id": 10054,
+                    "deep_link": "s_lang_10351",
+                    "created_at": now - timedelta(hours=1),
+                },
             ],
         )
         await conn.commit()


### PR DESCRIPTION
## Summary
- avoid bigint-casting the sharer id while excluding self-clicks in crossposting shadow share logging
- add a regression row for malformed legacy `s_*` deep links such as `s_lang_...`

## Why
The production RU canary failed before posting because old/non-canonical deep links can make `split_part(..., 2)::bigint` throw before the regex guard is applied. Comparing `user_id::text` to the parsed text keeps the self-click guard without risking cast errors.

## Checks
- `ruff check src/crossposting/service.py tests/test_crossposting_meme.py`
- `ruff format --check src/crossposting/service.py tests/test_crossposting_meme.py`
- `set -a; source ../ff-backend/.env.test; set +a; python3 -m pytest tests/test_crossposting_meme.py::test_decision_log_shadow_counts_pre_posting_share_clicks tests/test_crossposting_meme.py::test_en_ranker_decision_log_has_shadow_share_fields -q`

## Production note
The failed RU validation happened before `Next meme` / Telegram send. No channel post was emitted by that run.
