### PR TITLE
Fix: harden crossposting share ranker

### DIFF
--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -219,7 +219,26 @@ _RU_QUERY = """
             MS.age_days, MS.nmemes_sent, MS.invited_count,
             SQ.signal AS src_signal,
             (SELECT m_signal FROM src_median) AS median_signal,
-            COUNT(*) OVER () AS candidate_pool_size
+            COUNT(*) OVER () AS candidate_pool_size,
+            ROW_NUMBER() OVER (
+                ORDER BY -1
+                    * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
+                    * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.8 END
+                    * CASE WHEN MS.age_days < 7 THEN 1 ELSE 0.8 END
+                    * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
+                    * CASE
+                        WHEN MS.nmemes_sent <= 1 THEN 1
+                        ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
+                      END
+                    * COALESCE(
+                        LEAST(2.0, GREATEST(0.5,
+                            SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
+                        )),
+                        1.0
+                      )
+                    * (1.0 + LEAST(MS.invited_count, 10) * 0.1),
+                    M.id
+            ) AS candidate_rank
         FROM meme M
         INNER JOIN meme_stats MS ON MS.meme_id = M.id
         LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelru'
@@ -246,7 +265,8 @@ _RU_QUERY = """
                 )),
                 1.0
               )
-            * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
+            * (1.0 + LEAST(MS.invited_count, 10) * 0.1),
+            M.id
         LIMIT :limit
     )
     SELECT
@@ -260,10 +280,20 @@ _RU_QUERY = """
             COUNT(*) AS pre_inbot_share_clicks,
             COUNT(DISTINCT user_id) AS pre_inbot_share_click_users
         FROM user_deep_link_log udll
+        CROSS JOIN LATERAL (
+            SELECT substring(
+                udll.deep_link FROM ('^s_([1-9][0-9]{0,18})_' || ranked.id || '$')
+            ) AS sharer_id
+        ) share_link
         WHERE udll.created_at < selected_at.decided_at
-          AND udll.deep_link ~ ('^s_[0-9]+_' || ranked.id || '$')
-          AND udll.user_id::text <> split_part(udll.deep_link, '_', 2)
+          AND CASE
+              WHEN share_link.sharer_id IS NULL THEN false
+              WHEN length(share_link.sharer_id) = 19
+                AND share_link.sharer_id > '9223372036854775807' THEN false
+              ELSE udll.user_id <> share_link.sharer_id::bigint
+          END
     ) share_clicks ON true
+    ORDER BY ranked.candidate_rank
 """
 
 _EN_QUERY = """
@@ -306,7 +336,26 @@ _EN_QUERY = """
             MS.age_days, MS.nmemes_sent, MS.invited_count,
             SQ.signal AS src_signal,
             (SELECT m_signal FROM src_median) AS median_signal,
-            COUNT(*) OVER () AS candidate_pool_size
+            COUNT(*) OVER () AS candidate_pool_size,
+            ROW_NUMBER() OVER (
+                ORDER BY -1
+                    * COALESCE((MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1), 0.5)
+                    * CASE WHEN MS.raw_impr_rank <= 1 THEN 1 ELSE 0.5 END
+                    * CASE WHEN MS.age_days < 90 THEN 1 ELSE 0.8 END
+                    * CASE WHEN M.caption IS NULL THEN 1 ELSE 0.8 END
+                    * CASE
+                        WHEN MS.nmemes_sent <= 1 THEN 1
+                        ELSE (MS.nlikes + MS.ndislikes) * 1. / MS.nmemes_sent
+                      END
+                    * COALESCE(
+                        LEAST(2.0, GREATEST(0.5,
+                            SQ.signal / NULLIF((SELECT m_signal FROM src_median), 0)
+                        )),
+                        1.0
+                      )
+                    * (1.0 + LEAST(MS.invited_count, 10) * 0.1),
+                    M.id
+            ) AS candidate_rank
         FROM meme M
         INNER JOIN meme_stats MS ON MS.meme_id = M.id
         LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = 'tgchannelen'
@@ -333,7 +382,8 @@ _EN_QUERY = """
                 )),
                 1.0
               )
-            * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
+            * (1.0 + LEAST(MS.invited_count, 10) * 0.1),
+            M.id
         LIMIT :limit
     )
     SELECT
@@ -347,10 +397,20 @@ _EN_QUERY = """
             COUNT(*) AS pre_inbot_share_clicks,
             COUNT(DISTINCT user_id) AS pre_inbot_share_click_users
         FROM user_deep_link_log udll
+        CROSS JOIN LATERAL (
+            SELECT substring(
+                udll.deep_link FROM ('^s_([1-9][0-9]{0,18})_' || ranked.id || '$')
+            ) AS sharer_id
+        ) share_link
         WHERE udll.created_at < selected_at.decided_at
-          AND udll.deep_link ~ ('^s_[0-9]+_' || ranked.id || '$')
-          AND udll.user_id::text <> split_part(udll.deep_link, '_', 2)
+          AND CASE
+              WHEN share_link.sharer_id IS NULL THEN false
+              WHEN length(share_link.sharer_id) = 19
+                AND share_link.sharer_id > '9223372036854775807' THEN false
+              ELSE udll.user_id <> share_link.sharer_id::bigint
+          END
     ) share_clicks ON true
+    ORDER BY ranked.candidate_rank
 """
 
 

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -300,6 +300,21 @@ async def test_decision_log_shadow_counts_pre_posting_share_clicks(clean_xpost):
                 },
                 {
                     "user_id": 10054,
+                    "deep_link": "not_a_share_link",
+                    "created_at": now - timedelta(minutes=30),
+                },
+                {
+                    "user_id": 10054,
+                    "deep_link": "s_999999999999999999999_10351",
+                    "created_at": now - timedelta(minutes=30),
+                },
+                {
+                    "user_id": 10054,
+                    "deep_link": "s_10051_99999",
+                    "created_at": now - timedelta(minutes=30),
+                },
+                {
+                    "user_id": 10054,
                     "deep_link": "s_10053_10351",
                     "created_at": now + timedelta(hours=1),
                 },

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -299,6 +299,11 @@ async def test_decision_log_shadow_counts_pre_posting_share_clicks(clean_xpost):
                     "created_at": now - timedelta(hours=1),
                 },
                 {
+                    "user_id": 10051,
+                    "deep_link": "s_00010051_10351",
+                    "created_at": now - timedelta(minutes=45),
+                },
+                {
                     "user_id": 10054,
                     "deep_link": "not_a_share_link",
                     "created_at": now - timedelta(minutes=30),

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -315,6 +315,11 @@ async def test_decision_log_shadow_counts_pre_posting_share_clicks(clean_xpost):
                 },
                 {
                     "user_id": 10054,
+                    "deep_link": "s_9999999999999999999_10351",
+                    "created_at": now - timedelta(minutes=30),
+                },
+                {
+                    "user_id": 10054,
                     "deep_link": "s_10051_99999",
                     "created_at": now - timedelta(minutes=30),
                 },


### PR DESCRIPTION
Fixes FFM-1327. Follow-up to #283 post-merge review findings.

## What changed
- Removed the unsafe `split_part(... )::bigint` parsing path from lateral share-count aggregation.
- Parse share deep links with a bounded canonical numeric regex capture so non-share/malformed/non-canonical rows cannot crash or skew the ranker.
- Added explicit `candidate_rank` ordering with a stable `M.id` tie-breaker and ordered the outer lateral-joined result before Python reads `rows[0]`.
- Added malformed/non-share deep link regression rows to the existing share-count test.
- Addressed Staff Engineer review by rejecting leading-zero sharer IDs in both RU and EN predicates and adding the `s_00010051_<meme_id>` self-click regression row.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `python3 -m py_compile src/crossposting/service.py tests/test_crossposting_meme.py`
- `DATABASE_URL="${DATABASE_URL/postgres:/postgresql+asyncpg:}" TELEGRAM_BOT_TOKEN="123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi" python3 -m pytest tests/test_crossposting_meme.py -q` reached collection/execution: 9 caption tests passed; 8 DB-backed ranker tests errored because the host DB is not migrated (`relation "crossposting" does not exist`). Docker is unavailable in this runner, so the documented `docker compose exec app pytest ...` path could not be run locally.

## Staff Engineer notes
Please review the SQL ordering and canonical share-id parsing in `src/crossposting/service.py`. CI should run the integration tests against a migrated DB.