### PR TITLE
Document burger tokenomics and localize treasury commands

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -14,6 +14,7 @@ Detailed specifications for each subsystem. See root [SPEC.md](../SPEC.md) for p
 | [issues.md](issues.md) | Prioritized backlog of known bugs and improvements |
 | [error-profile.md](error-profile.md) | Production error analysis from logs |
 | [data-hypotheses.md](data-hypotheses.md) | Data analysis findings (H1-H7) |
+| [burger-tokenomics.md](burger-tokenomics.md) | Current burger ledger, payouts, commands, reports, and refactor questions |
 | [cohort-analysis-2026-03-29.md](cohort-analysis-2026-03-29.md) | Super users vs churned: cohort analysis, 6 experiments |
 | [crossposting-share-optimization-2026-05-18.md](crossposting-share-optimization-2026-05-18.md) | Current Telegram channel share readout, v2 results, next experiment gate |
 | [experiment-2026-03-14.md](experiment-2026-03-14.md) | Experiment: queue refill threshold + removed fast_dopamine |

--- a/specs/burger-tokenomics.md
+++ b/specs/burger-tokenomics.md
@@ -1,0 +1,247 @@
+# Burger Tokenomics and Commands
+
+Current state as of 2026-05-18. This file describes the implementation that exists
+today, not an ideal future design.
+
+## Code Map
+
+Core tokenomics code:
+
+- Ledger table: [`treasury_trx`](../src/database.py)
+- Payout constants and transaction types: [`treasury/constants.py`](../src/tgbot/handlers/treasury/constants.py)
+- Balance, leaderboard, supply, transfer helpers: [`treasury/service.py`](../src/tgbot/handlers/treasury/service.py)
+- Idempotent mint/charge wrappers: [`treasury/payments.py`](../src/tgbot/handlers/treasury/payments.py)
+- User-facing burger commands: [`treasury/commands.py`](../src/tgbot/handlers/treasury/commands.py)
+- Command registry: [`tgbot/app.py`](../src/tgbot/app.py)
+
+Flows and handlers that create burger transactions:
+
+- Upload review payouts: [`upload/moderation.py`](../src/tgbot/handlers/upload/moderation.py)
+- Invite/share deep links: [`deep_link.py`](../src/tgbot/handlers/deep_link.py)
+- Channel publication payout: [`crossposting/meme.py`](../src/flows/crossposting/meme.py)
+- Weekly uploaded-meme rewards: [`rewards/uploaded_memes.py`](../src/flows/rewards/uploaded_memes.py)
+- Daily activity reward: [`rewards/daily.py`](../src/flows/rewards/daily.py)
+- Chat transfers and chat reward drops: [`chat/send_tokens.py`](../src/tgbot/handlers/chat/send_tokens.py)
+- Paid chat-agent replies: [`chat/chat.py`](../src/tgbot/handlers/chat/chat.py)
+- Channel boost reward: [`admin/boost.py`](../src/tgbot/handlers/admin/boost.py)
+- Giveaway claims: [`treasury/giveaway.py`](../src/tgbot/handlers/treasury/giveaway.py)
+- Weekly burger economy channel report: [`weekly_report.py`](../src/flows/crossposting/weekly_report.py)
+
+## Ledger Model
+
+All burger movement is stored as append-only rows in `treasury_trx`:
+
+| Column | Meaning |
+| --- | --- |
+| `user_id` | Owner of this ledger row. |
+| `type` | One of `TrxType` from `treasury/constants.py`. |
+| `amount` | Positive mints/receipts, negative charges/sends. |
+| `external_id` | Idempotency key for "pay once" operations. |
+| `created_at` | Used for weekly windows and reports. |
+
+The displayed balance is `SUM(treasury_trx.amount)` for the user. The denormalized
+`user.balance` field is only a cache updated after balance reads.
+
+Current supply is `SUM(treasury_trx.amount)` across all users. It is not capped.
+
+## Payout Table
+
+Current values from `PAYOUTS`:
+
+| Transaction type | Amount | Trigger | Idempotency |
+| --- | ---: | --- | --- |
+| `meme_uploader` | +5 | Uploaded meme approved in manual review. | `meme.id` |
+| `meme_upload_reviewer` | +1 | Moderator reviews an uploaded meme. | `meme.id` |
+| `meme_published` | +50 | Uploaded meme is posted to RU or EN public channel. | `meme.id` |
+| `meme_shared` | +10 | Existing user clicks a shared meme deep link from another user. | Current date |
+| `user_inviter` | +100 | New user joins from another user's meme deep link. | Invited user id |
+| `user_inviter_premium` | +200 | Same as above, but invited user has Telegram Premium. | Invited user id |
+| `uploader_top_weekly_1` | +500 | Weekly uploaded-meme top 1. | Current date |
+| `uploader_top_weekly_2` | +300 | Weekly uploaded-meme top 2. | Current date |
+| `uploader_top_weekly_3` | +200 | Weekly uploaded-meme top 3. | Current date |
+| `uploader_top_weekly_4` | +100 | Weekly uploaded-meme top 4. | Current date |
+| `uploader_top_weekly_5` | +50 | Weekly uploaded-meme top 5. | Current date |
+| `daily_reward` | +1 | User reaches exactly 10 memes watched today. | Current date |
+| `booster_channel` | +500 | User boosts RU or EN public channel. | Current date |
+| `giveaway` | +77 | User claims a giveaway deep link. | Giveaway deep link |
+| `purchase_token` | variable | Successful Telegram Stars purchase. | Telegram payment charge id |
+| `receive` | variable | User receives a manual group-chat transfer. | Sender user id |
+| `send` | negative variable | User sends burgers in group chat. | Recipient user id |
+| `bot_reply_payment` | -1 | Bot is mentioned/replied to in a group while chat agent is enabled. | Chat id + message id |
+
+Important current behavior: leaderboard and weekly economy "minted" totals count
+every positive row. This includes purchases, receives, giveaways, boost rewards,
+daily rewards, and inviter rewards, not only "earned by contribution" payouts.
+
+## User Commands
+
+### `/balance` and `/b`
+
+Private chat only. Shows the user's current ledger-summed balance and renders
+purchase buttons for 100, 1000, and 10000 burgers.
+
+Code:
+
+- Registered in [`tgbot/app.py`](../src/tgbot/app.py)
+- Rendered by [`handle_show_balance`](../src/tgbot/handlers/treasury/commands.py)
+- Purchase invoice flow in [`payments/purchase.py`](../src/tgbot/handlers/payments/purchase.py)
+
+### `/kitchen`
+
+Private chat only. Explains how to earn and spend burgers. It also sends the
+current explainer video when `KITCHEN_EXPLAINER_VIDEO_FILE_ID` is configured.
+
+Localization rule: if `user_language` contains `ru`, show Russian copy. Otherwise
+show English copy. Telegram app language is not used for this command.
+
+Code:
+
+- Registered in [`tgbot/app.py`](../src/tgbot/app.py)
+- Rendered by [`handle_show_kitchen`](../src/tgbot/handlers/treasury/commands.py)
+
+### `/leaderboard` and `/l`
+
+Private chat only. Shows top users by positive burger transactions in the last
+7 days, total supply, and the requesting user's own place when available.
+
+Localization rule: if `user_language` contains `ru`, show Russian copy. Otherwise
+show English copy.
+
+Current ranking rules:
+
+- Window: last 7 days, from `LEADERBOARD_WINDOW_DAYS`.
+- Included rows: `treasury_trx.amount > 0`.
+- Tie-breaker: smaller `user.id` first.
+- Nicknames come from `user.nickname`; missing nicknames get a random emoji fallback.
+- User-entered nicknames are HTML-escaped before display.
+
+Code:
+
+- Registered in [`tgbot/app.py`](../src/tgbot/app.py)
+- Rendered by [`handle_show_leaderbaord`](../src/tgbot/handlers/treasury/commands.py)
+- Data from [`get_leaderboard`](../src/tgbot/handlers/treasury/service.py) and
+  [`get_user_place_in_leaderboard`](../src/tgbot/handlers/treasury/service.py)
+
+### `/nickname <name>`
+
+Private chat only. Stores a public nickname in `user.nickname`. The nickname is
+shown in `/leaderboard`, weekly channel reports, and other public places.
+
+Current validation:
+
+- Required as first command argument.
+- Max length: 32 characters.
+- Disallowed characters: `<` and `>`.
+
+Code: [`handle_change_nickname`](../src/tgbot/handlers/treasury/commands.py).
+
+### `/uploads`
+
+Private chat only. Shows stats for the user's uploaded memes and recent upload
+media. It does not directly change burger balance, but it is part of the upload
+economy surface.
+
+Code:
+
+- Registered in [`tgbot/app.py`](../src/tgbot/app.py)
+- Rendered by [`upload/stats.py`](../src/tgbot/handlers/upload/stats.py)
+
+### `/refund`
+
+Private chat only, admin-only in the handler. Calls Telegram Stars refund by
+payment charge id. It currently does not reverse local `purchase_token` ledger
+rows.
+
+Code: [`refund_command`](../src/tgbot/handlers/payments/purchase.py).
+
+### Group chat `+<number>`
+
+Group chats only, reply-only. Transfers burgers from the sender to the author of
+the replied-to message.
+
+Rules:
+
+- Sender must have enough balance.
+- Recipient must be an existing non-blocked bot user.
+- Sending to self is ignored.
+- Creates one negative `send` row for the sender and one positive `receive` row
+  for the recipient.
+
+Code:
+
+- Registered in [`tgbot/app.py`](../src/tgbot/app.py)
+- Transfer logic in [`send_tokens_to_reply`](../src/tgbot/handlers/chat/send_tokens.py)
+- Ledger write in [`transfer_tokens`](../src/tgbot/handlers/treasury/service.py)
+
+### Group chat `+fire <n>`
+
+Group chats only. Rewards active chat users with `active_in_chat` burgers.
+
+Code:
+
+- Registered in [`tgbot/app.py`](../src/tgbot/app.py)
+- Logic in [`reward_active_chat_users`](../src/tgbot/handlers/chat/send_tokens.py)
+
+### Chat-agent replies in groups
+
+When the chat agent is enabled and the bot is mentioned/replied to, a successful
+agent request charges `bot_reply_payment` (`-1`) from the requester.
+
+Code: [`handle_agent_trigger`](../src/tgbot/handlers/chat/chat.py).
+
+## Non-Treasury Commands
+
+These are registered commands that are not themselves burger-economy commands:
+
+| Command | Scope | Notes |
+| --- | --- | --- |
+| `/start` | Private | Onboarding, deep links, giveaway links, shared meme links. |
+| `/lang` | Private | Bot meme-language settings in `user_language`. |
+| `/chat`, `/c`, `/с` | Private text prefix | Feedback/chat to admins. Implemented as a message regex, not `CommandHandler`. |
+| `/wrapped` | Private | Wrapped stats flow. |
+| `/wrapped_clear` | Private | Clears wrapped cache/state. |
+| `/stats` | Private | User stats. |
+| `/delete` | Private | User data deletion flow. |
+| `/promotemod` | Private | Admin/moderator operation. |
+| `/broadcastru`, `/broadcastru1` | Private | Admin broadcast operations. |
+| `/discoveredsources`, `/meme`, `/show` | Private | Moderator/source operations. |
+
+Users can also upload photo/video/animation media in private chat; this starts
+the upload moderation path that can later mint `meme_uploader` and
+`meme_published` burgers.
+
+## Weekly Channel Reports
+
+The weekly burger economy report posts to `@fastfoodmemes` via
+`TELEGRAM_CHANNEL_RU_CHAT_ID`.
+
+Current report metrics:
+
+- `minted`: sum of positive rows in the last 7 days.
+- `spent`: absolute sum of negative rows in the last 7 days.
+- `active_earners`: distinct users with positive rows in the last 7 days.
+- `total_supply`: all-time sum of all ledger rows.
+- `top_earners`: top 5 users by positive rows in the last 7 days.
+
+Top earners now include `user.nickname`; missing nicknames are rendered as
+`без /nickname`.
+
+Code: [`weekly_report.py`](../src/flows/crossposting/weekly_report.py).
+
+## Open Refactor Questions
+
+These are current design debts worth resolving before changing values:
+
+- Should purchases and user-to-user `receive` rows count in `/leaderboard`, or
+  should public leaderboards count only contribution rewards?
+- Should daily rewards and giveaways count in weekly top earners?
+- Should `user.balance` be removed or made strictly transactional? Today it is
+  a cache, while the ledger is source of truth.
+- Should `send` and `receive` become one atomic transaction with a shared
+  transfer id?
+- Should `/refund` reverse local burger ledger rows when Telegram Stars are
+  refunded?
+- Should all command copy move into YAML localization instead of being embedded
+  in handlers?
+- Should `meme_shared` be per-link, per-clicking-user, or remain one reward per
+  sharer per day?

--- a/src/flows/crossposting/weekly_report.py
+++ b/src/flows/crossposting/weekly_report.py
@@ -1,9 +1,11 @@
 """
-Weekly burger economy report for @ffmemes channel.
+Weekly burger economy report for @fastfoodmemes channel.
 
 Posts a Sunday 14:00 MSK summary of burger transactions to the channel.
 Scheduled via Prefect cron in serve_flows.py.
 """
+
+from html import escape
 
 from prefect import flow, get_run_logger
 from sqlalchemy import text
@@ -54,12 +56,17 @@ async def _get_weekly_burger_stats() -> dict:
     top_earners = await fetch_all(
         text(
             """
-            SELECT user_id, SUM(amount) as earned
-            FROM treasury_trx
-            WHERE amount > 0
-              AND created_at > now() - interval '7 days'
-            GROUP BY user_id
-            ORDER BY earned DESC
+            SELECT
+                trx.user_id,
+                u.nickname,
+                SUM(trx.amount) as earned
+            FROM treasury_trx trx
+            LEFT JOIN "user" u
+                ON u.id = trx.user_id
+            WHERE trx.amount > 0
+              AND trx.created_at > now() - interval '7 days'
+            GROUP BY trx.user_id, u.nickname
+            ORDER BY earned DESC, trx.user_id ASC
             LIMIT 5
         """
         )
@@ -100,7 +107,9 @@ def _format_report(stats: dict) -> str:
         medals = ["🥇", "🥈", "🥉", "4️⃣", "5️⃣"]
         for i, earner in enumerate(stats["top_earners"]):
             earned = int(earner["earned"])
-            lines.append(f"{medals[i]} +{earned:,} 🍔".replace(",", " "))
+            nickname = (earner.get("nickname") or "").strip()
+            public_name = escape(nickname) if nickname else "без /nickname"
+            lines.append(f"{medals[i]} {public_name}: +{earned:,} 🍔".replace(",", " "))
 
     lines.append("")
     lines.append(
@@ -117,7 +126,7 @@ def _format_report(stats: dict) -> str:
     on_failure=[notify_telegram_on_failure],
 )
 async def post_weekly_burger_report():
-    """Post weekly burger economy snapshot to @ffmemes channel."""
+    """Post weekly burger economy snapshot to @fastfoodmemes channel."""
     logger = get_run_logger()
 
     stats = await _get_weekly_burger_stats()

--- a/src/tgbot/handlers/treasury/commands.py
+++ b/src/tgbot/handlers/treasury/commands.py
@@ -1,3 +1,5 @@
+from html import escape
+
 from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
@@ -20,8 +22,22 @@ from src.tgbot.handlers.treasury.service import (
 from src.tgbot.senders.utils import get_random_emoji
 
 # get_user_place_in_leaderboard,
-from src.tgbot.service import update_user
+from src.tgbot.service import get_user_languages, update_user
 from src.tgbot.user_info import update_user_info_cache
+
+
+def _format_burgers(amount: int | None) -> str:
+    return f"{int(amount or 0):,}".replace(",", " ")
+
+
+def _public_name(nickname: str | None, fallback: str) -> str:
+    nickname = (nickname or "").strip()
+    return escape(nickname) if nickname else fallback
+
+
+async def _user_has_russian_enabled(user_id: int) -> bool:
+    languages = await get_user_languages(user_id)
+    return any(language and language.startswith("ru") for language in languages)
 
 
 # command: /b / /balance
@@ -75,30 +91,59 @@ KITCHEN_EXPLAINER_VIDEO_FILE_ID = (
 # command: /kitchen
 # shows all possible ways to earn / to mine 🍔
 async def handle_show_kitchen(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Sends you the meme by it's id"""
-    text = f"""
-<b>🍔 Kitchen</b>
+    """Show current burger earning and spending rules."""
+    is_ru = await _user_has_russian_enabled(update.effective_user.id)
+    if is_ru:
+        text = f"""
+<b>🍔 Кухня</b>
 
-How to get more 🍔.
+Как получить бургеры:
 
-Menu:
-▪ forward a funny meme to the bot & pass the modedation: {PAYOUTS[TrxType.MEME_UPLOADER]} 🍔
-▪ you share a meme from bot and your friend clicks a link under meme: {PAYOUTS[TrxType.USER_INVITER]} 🍔
-▪▪ an invited friend has Telegram premium: {PAYOUTS[TrxType.USER_INVITER_PREMIUM]} 🍔
-▪▪ only new ffmemes users counts
+▪ загрузить мем в бота и пройти модерацию: {PAYOUTS[TrxType.MEME_UPLOADER]} 🍔
+▪ если принятый мем попадет в наш канал: {PAYOUTS[TrxType.MEME_PUBLISHED]} 🍔
+▪ кто-то нажал ссылку под мемом, которым ты поделился: {PAYOUTS[TrxType.MEME_SHARED]} 🍔 раз в день
+▪ новый пользователь пришел по твоей ссылке под мемом: {PAYOUTS[TrxType.USER_INVITER]} 🍔
+▪ если у нового пользователя Telegram Premium: {PAYOUTS[TrxType.USER_INVITER_PREMIUM]} 🍔
 
-▪ top 5 uploaded memes in weekly leaderboard:
+▪ топ-5 загруженных мемов недели:
     🥇: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_1]} 🍔
     🥈: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_2]} 🍔
     🥉: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_3]} 🍔
     4: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_4]} 🍔
     5: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_5]} 🍔
 
-▪ be active in our chats ❤️
+▪ активность в чатах во время раздач: {PAYOUTS[TrxType.ACTIVE_IN_CHAT]} 🍔
 
-Soon:
-▪ follow our channels: ? 🍔
-▪ more ways to spend your 🍔🍔🍔
+Потратить:
+▪ ответ бота в чате: {PAYOUTS[TrxType.BOT_REPLY_PAYMENT] * -1} 🍔
+▪ перевести бургеры другому: ответь на его сообщение +число, например +10
+
+/leaderboard /balance /lang /chat /nickname
+        """
+    else:
+        text = f"""
+<b>🍔 Kitchen</b>
+
+How to get more burgers:
+
+▪ upload a meme to the bot and pass moderation: {PAYOUTS[TrxType.MEME_UPLOADER]} 🍔
+▪ if an approved meme reaches our channel: {PAYOUTS[TrxType.MEME_PUBLISHED]} 🍔
+▪ someone clicks the link under a meme you shared: {PAYOUTS[TrxType.MEME_SHARED]} 🍔 once per day
+▪ a new user joins through your meme link: {PAYOUTS[TrxType.USER_INVITER]} 🍔
+▪ if that new user has Telegram Premium: {PAYOUTS[TrxType.USER_INVITER_PREMIUM]} 🍔
+
+▪ top 5 uploaded memes of the week:
+    🥇: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_1]} 🍔
+    🥈: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_2]} 🍔
+    🥉: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_3]} 🍔
+    4: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_4]} 🍔
+    5: {PAYOUTS[TrxType.UPLOADER_TOP_WEEKLY_5]} 🍔
+
+▪ chat activity during reward drops: {PAYOUTS[TrxType.ACTIVE_IN_CHAT]} 🍔
+
+Spend:
+▪ bot reply in chat: {PAYOUTS[TrxType.BOT_REPLY_PAYMENT] * -1} 🍔
+▪ send burgers to someone: reply to their message with +number, for example +10
 
 /leaderboard /balance /lang /chat /nickname
         """  # noqa
@@ -116,17 +161,27 @@ Soon:
 # command: /leaderboard /l
 async def handle_show_leaderbaord(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     emoji = get_random_emoji()
+    is_ru = await _user_has_russian_enabled(update.effective_user.id)
     leaderboard = await get_leaderboard()
 
-    LEADERBOARD_TEXT = f"{emoji} Leaderboard (last {LEADERBOARD_WINDOW_DAYS} days) {emoji}\n\n"
+    if is_ru:
+        LEADERBOARD_TEXT = (
+            f"{emoji} Лидерборд за последние {LEADERBOARD_WINDOW_DAYS} дней {emoji}\n\n"
+        )
+    else:
+        LEADERBOARD_TEXT = f"{emoji} Leaderboard (last {LEADERBOARD_WINDOW_DAYS} days) {emoji}\n\n"
+
     for i, user in enumerate(leaderboard):
         icon = "🏆" if i == 0 else "🥈" if i == 1 else "🥉" if i == 2 else "🏅"
-        nick = user["nickname"] or get_random_emoji() * 3
+        nick = _public_name(user["nickname"], get_random_emoji() * 3)
         weekly_earned = user.get("weekly_earned", 0)
-        LEADERBOARD_TEXT += f"{icon} - {nick} - {weekly_earned} 🍔\n"
+        LEADERBOARD_TEXT += f"{icon} - {nick} - {_format_burgers(weekly_earned)} 🍔\n"
 
     tokens = await get_token_supply()
-    LEADERBOARD_TEXT += f"\nTotal supply: {tokens} 🍔"
+    if is_ru:
+        LEADERBOARD_TEXT += f"\nВсего в обороте: {_format_burgers(tokens)} 🍔"
+    else:
+        LEADERBOARD_TEXT += f"\nTotal supply: {_format_burgers(tokens)} 🍔"
 
     user_lb_data = await get_user_place_in_leaderboard(update.effective_user.id)
     if user_lb_data:
@@ -136,13 +191,24 @@ async def handle_show_leaderbaord(update: Update, context: ContextTypes.DEFAULT_
             user_lb_data.get("weekly_earned", 0),
         )
         if nickname:
-            LEADERBOARD_TEXT += f"""
+            if is_ru:
+                LEADERBOARD_TEXT += f"""
 
-You:
-#{place} - {nickname} - {weekly_earned} 🍔
+Ты:
+#{place} - {_public_name(nickname, "")} - {_format_burgers(weekly_earned)} 🍔
 
 /kitchen /uploads /chat
         """
+            else:
+                LEADERBOARD_TEXT += f"""
+
+You:
+#{place} - {_public_name(nickname, "")} - {_format_burgers(weekly_earned)} 🍔
+
+/kitchen /uploads /chat
+        """
+        elif is_ru:
+            LEADERBOARD_TEXT += "\nЧтобы увидеть свое место в лидерборде, задай /nickname ⬅️\n\n"
         else:
             LEADERBOARD_TEXT += "\nTo see your place in the leaderboard, set your /nickname ⬅️\n\n"  # noqa: E501
 

--- a/tests/flows/crossposting/test_weekly_report.py
+++ b/tests/flows/crossposting/test_weekly_report.py
@@ -1,0 +1,47 @@
+import pytest
+
+from src.flows.crossposting import weekly_report
+
+
+def test_format_report_includes_public_nicknames() -> None:
+    text = weekly_report._format_report(
+        {
+            "minted": 5978,
+            "spent": 23,
+            "active_earners": 457,
+            "total_supply": 533831,
+            "top_earners": [
+                {"nickname": "Alice & Bob", "earned": 1107},
+                {"nickname": None, "earned": 1000},
+            ],
+        }
+    )
+
+    assert "🥇 Alice &amp; Bob: +1 107 🍔" in text
+    assert "🥈 без /nickname: +1 000 🍔" in text
+
+
+@pytest.mark.asyncio
+async def test_weekly_burger_stats_queries_top_earner_nicknames(monkeypatch) -> None:
+    async def fake_fetch_one(statement):
+        sql = str(statement)
+        if "SUM(ABS(amount))" in sql:
+            return {"total": 23}
+        if "COUNT(DISTINCT user_id)" in sql:
+            return {"count": 457}
+        return {"total": 5978}
+
+    async def fake_fetch_all(statement):
+        sql = str(statement)
+        assert "u.nickname" in sql
+        assert 'LEFT JOIN "user" u' in sql
+        return [{"user_id": 10001, "nickname": "burger_ceo", "earned": 700}]
+
+    monkeypatch.setattr(weekly_report, "fetch_one", fake_fetch_one)
+    monkeypatch.setattr(weekly_report, "fetch_all", fake_fetch_all)
+
+    stats = await weekly_report._get_weekly_burger_stats()
+
+    assert stats["top_earners"][0]["user_id"] == 10001
+    assert stats["top_earners"][0]["nickname"] == "burger_ceo"
+    assert stats["top_earners"][0]["earned"] == 700

--- a/tests/tgbot/test_treasury_commands.py
+++ b/tests/tgbot/test_treasury_commands.py
@@ -28,14 +28,10 @@ async def test_kitchen_uses_russian_when_ru_enabled(monkeypatch) -> None:
     caption = update.message.reply_video.call_args.kwargs["caption"]
     assert "<b>🍔 Кухня</b>" in caption
     assert "Как получить бургеры" in caption
-    assert (
-        f"если принятый мем попадет в наш канал: {PAYOUTS[TrxType.MEME_PUBLISHED]} 🍔"
-        in caption
-    )
+    assert f"если принятый мем попадет в наш канал: {PAYOUTS[TrxType.MEME_PUBLISHED]} 🍔" in caption
     assert (
         "кто-то нажал ссылку под мемом, которым ты поделился: "
-        f"{PAYOUTS[TrxType.MEME_SHARED]} 🍔 раз в день"
-        in caption
+        f"{PAYOUTS[TrxType.MEME_SHARED]} 🍔 раз в день" in caption
     )
 
 
@@ -50,8 +46,7 @@ async def test_kitchen_uses_english_when_ru_not_enabled(monkeypatch) -> None:
     assert "<b>🍔 Kitchen</b>" in caption
     assert "How to get more burgers" in caption
     assert (
-        f"if an approved meme reaches our channel: {PAYOUTS[TrxType.MEME_PUBLISHED]} 🍔"
-        in caption
+        f"if an approved meme reaches our channel: {PAYOUTS[TrxType.MEME_PUBLISHED]} 🍔" in caption
     )
     assert "Как получить бургеры" not in caption
 

--- a/tests/tgbot/test_treasury_commands.py
+++ b/tests/tgbot/test_treasury_commands.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.tgbot.handlers.treasury import commands
+from src.tgbot.handlers.treasury.constants import PAYOUTS, TrxType
+
+
+def _make_update(user_id: int = 10001):
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=user_id),
+        message=SimpleNamespace(reply_text=AsyncMock(), reply_video=AsyncMock()),
+    )
+
+
+def _make_context():
+    return SimpleNamespace()
+
+
+@pytest.mark.asyncio
+async def test_kitchen_uses_russian_when_ru_enabled(monkeypatch) -> None:
+    update = _make_update()
+    monkeypatch.setattr(commands, "get_user_languages", AsyncMock(return_value={"ru", "en"}))
+
+    await commands.handle_show_kitchen(update, _make_context())
+
+    caption = update.message.reply_video.call_args.kwargs["caption"]
+    assert "<b>🍔 Кухня</b>" in caption
+    assert "Как получить бургеры" in caption
+    assert (
+        f"если принятый мем попадет в наш канал: {PAYOUTS[TrxType.MEME_PUBLISHED]} 🍔"
+        in caption
+    )
+    assert (
+        "кто-то нажал ссылку под мемом, которым ты поделился: "
+        f"{PAYOUTS[TrxType.MEME_SHARED]} 🍔 раз в день"
+        in caption
+    )
+
+
+@pytest.mark.asyncio
+async def test_kitchen_uses_english_when_ru_not_enabled(monkeypatch) -> None:
+    update = _make_update()
+    monkeypatch.setattr(commands, "get_user_languages", AsyncMock(return_value={"uk"}))
+
+    await commands.handle_show_kitchen(update, _make_context())
+
+    caption = update.message.reply_video.call_args.kwargs["caption"]
+    assert "<b>🍔 Kitchen</b>" in caption
+    assert "How to get more burgers" in caption
+    assert (
+        f"if an approved meme reaches our channel: {PAYOUTS[TrxType.MEME_PUBLISHED]} 🍔"
+        in caption
+    )
+    assert "Как получить бургеры" not in caption
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_uses_russian_when_ru_enabled(monkeypatch) -> None:
+    update = _make_update()
+    monkeypatch.setattr(commands, "get_user_languages", AsyncMock(return_value={"ru"}))
+    monkeypatch.setattr(commands, "get_random_emoji", lambda: "⭐")
+    monkeypatch.setattr(
+        commands,
+        "get_leaderboard",
+        AsyncMock(return_value=[{"nickname": "Alice & Bob", "weekly_earned": 1234}]),
+    )
+    monkeypatch.setattr(commands, "get_token_supply", AsyncMock(return_value=533831))
+    monkeypatch.setattr(
+        commands,
+        "get_user_place_in_leaderboard",
+        AsyncMock(return_value={"place": 2, "nickname": "Me", "weekly_earned": 50}),
+    )
+
+    await commands.handle_show_leaderbaord(update, _make_context())
+
+    text = update.message.reply_text.call_args.args[0]
+    assert "Лидерборд за последние" in text
+    assert "Alice &amp; Bob - 1 234 🍔" in text
+    assert "Всего в обороте: 533 831 🍔" in text
+    assert "Ты:" in text
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_uses_english_when_ru_not_enabled(monkeypatch) -> None:
+    update = _make_update()
+    monkeypatch.setattr(commands, "get_user_languages", AsyncMock(return_value={"uk"}))
+    monkeypatch.setattr(commands, "get_random_emoji", lambda: "⭐")
+    monkeypatch.setattr(
+        commands,
+        "get_leaderboard",
+        AsyncMock(return_value=[{"nickname": "Alice", "weekly_earned": 1234}]),
+    )
+    monkeypatch.setattr(commands, "get_token_supply", AsyncMock(return_value=533831))
+    monkeypatch.setattr(
+        commands,
+        "get_user_place_in_leaderboard",
+        AsyncMock(return_value={"place": 2, "nickname": "Me", "weekly_earned": 50}),
+    )
+
+    await commands.handle_show_leaderbaord(update, _make_context())
+
+    text = update.message.reply_text.call_args.args[0]
+    assert "Leaderboard (last" in text
+    assert "Total supply: 533 831 🍔" in text
+    assert "You:" in text
+    assert "Лидерборд" not in text


### PR DESCRIPTION
## Summary
- add specs/burger-tokenomics.md with the current burger ledger model, payout table, command surfaces, weekly reports, and refactor questions
- localize /kitchen and /leaderboard based on enabled bot languages: Russian only when user_language includes ru, English otherwise
- include nicknames in the weekly burger economy channel report and cover the behavior with tests

## Tests
- pytest tests/tgbot/test_treasury_commands.py tests/flows/crossposting/test_weekly_report.py
- ruff check src/tgbot/handlers/treasury/commands.py src/flows/crossposting/weekly_report.py tests/tgbot/test_treasury_commands.py tests/flows/crossposting/test_weekly_report.py