### PR TITLE
Fix repeated comms topic families

### DIFF
--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -65,9 +65,10 @@ UTC by the `Write Channel Stats Report` Prefect deployment). It contains:
 - Category frequency + last-7 category/entity combos (rotation hint)
 
 Use this as a taste signal: formats/topics that landed above the median →
-do more of that. Weak ones → avoid the same framing. Entity combos from
-the last 7 posts are enforced by code as a hard rotation check (see
-"Posting" below), but you should also aim for variety beyond that.
+do more of that. Weak ones → avoid the same framing. Entity combos and
+canonical topic families from the last 14 posts are enforced by code as a hard
+rotation check (see "Posting" below), but you should also aim for variety
+beyond that.
 
 If the file is missing (first run, or cron failed), proceed without it —
 the rotation check still runs against the database.
@@ -89,19 +90,28 @@ Pick ONE from:
 **Never fall back to topics from the HARD BAN list below.**
 
 ### Step 2 — Rotation check (enforce variety)
-Read the last 7 posts from the channel:
+Read the last 14 posts from the channel:
 ```python
 from src.comms.channel_history import get_last_n_posts
-recent = await get_last_n_posts(n=7)
+recent = await get_last_n_posts(n=14)
 ```
-Extract the topic/entity of each. Your next post MUST differ from the last 7 on
-BOTH `category` (A-F) AND `entity_id` (the specific source, metric, or feature
-the post is about). Reject a topic if any recent post covered the same
-category+entity. Pick the next strongest anomaly instead.
+Extract the topic/entity of each. Your next post MUST differ from recent posts
+on the actual topic family, not just on a new slug. For example,
+`session_record_20`, `session_length_median`, and `north_star_daily` are the
+same public topic: session length. Reject the topic and pick the next strongest
+anomaly if the reader would experience it as "another post about the same
+metric/source/feature".
 
 If `get_last_n_posts` returns `[]` (Telethon misconfigured / session expired),
 log a warning to `$ADMIN_LOGS_CHAT_ID` and proceed without rotation — failing
 closed would block the channel.
+
+### Step 2b — Draft backlog check
+Before creating a new `[post:...]` issue, search Paperclip for open or blocked
+`[post:...]` issues and read `docs/comms/published/`. Treat approved-but-not-
+published and blocked drafts as already used topics for rotation. Do not write
+another session-length/North-Star post while a session-length draft is waiting
+for CEO approval, write access, or publication.
 
 ### Step 3 — HARD BAN self-check (before drafting)
 Your topic must NOT be any of:
@@ -390,7 +400,7 @@ try:
         text=final_post_text,           # HTML-formatted, see "Post Formatting"
         channel="ffmemes",               # "ffmemes" build-in-public, "ru" @fastfoodmemes, "en" @fast_food_memes
         category="C",                    # A/B/C/D/E/F — see "Content Categories"
-        entity_id="dau_delta_2026_04_24",# stable slug for the specific anomaly/topic
+        entity_id="dau_delta",           # stable topic family, not a date-specific slug
         photo_bytes=png,                 # OR photo_file_id / photo_url — always include a visual
         topic_slug="dau-delta-anomaly",
         button_text=None, button_url=None,  # optional inline button
@@ -415,8 +425,9 @@ don't try):
 - **Expandable-by-default blockquotes.** Every `<blockquote>` is rewritten
   to `<blockquote expandable>`.
 - **Substring/pattern ban.** The HARD BAN list from Step 3 is enforced here.
-- **Rotation check.** `(category, entity_id)` is compared against the last
-  14 editorial posts in the database. Duplicate key → rejected.
+- **Rotation check.** `(category, entity_id)` and canonical topic family are
+  compared against the last 14 editorial posts in the database. Duplicate
+  family, even with a new slug, is rejected.
 - **Idempotency.** Same `(channel, text, photo, category, entity_id)` →
   same `draft_hash` → no double-post. Safe to retry.
 - **Stats registration.** Inserts into `editorial_posts` so the stats
@@ -554,8 +565,9 @@ curl -s -X POST "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/
   progress, or any infra firefighting — the HARD BAN is enforced by code
 - Do NOT write iteration updates like "день 11/14" for an experiment — post
   the conclusive learning when it's done, not the progress bar
-- Do NOT skip the rotation check — posts must differ from the last 14 on
-  category AND entity_id (enforced)
+- Do NOT skip the rotation check — posts must differ from the last 14 by
+  actual topic family. Do not hide repetition by changing the `entity_id`
+  suffix or date
 - Do NOT nest `<blockquote>` inside another `<blockquote>` — Telegram doesn't
   render it and the validator rejects it
 - Do NOT write "нажми чтобы развернуть" / "тапни чтобы развернуть" —

--- a/agents/comms-manager/routines/daily-channel-post.description.md
+++ b/agents/comms-manager/routines/daily-channel-post.description.md
@@ -10,6 +10,10 @@ Things that trip people up:
 - For generated/local visuals, pass `photo_bytes=png` directly. Do not post the image to the moderator chat for staging or `file_id` extraction.
 - Step 0 — read `experiments/reports/channel-stats-YYYY-MM-DD.md` for yesterday's performance.
 - Step 1 — pick the strongest `Chart-worthy: yes` finding from `experiments/reports/anomalies-YYYY-MM-DD.md`.
+- Step 2 — avoid the last 14 topic families, not just exact slugs. A new
+  session-length/North-Star slug is still a repeated session-length post.
+- Step 2b — search open/blocked `[post:...]` issues before drafting; blocked or
+  approved-unpublished drafts count as already used topics.
 - Step 7 — archive to `docs/comms/published/YYYY-MM-DD-slug.md` and close this issue with a one-liner pointing at the archive.
 - Outcome comments must include the actual public channel and Telegram URL.
   `telegram_message_id` alone is ambiguous because @ffmemes and @fastfoodmemes

--- a/docs/comms/comms-writer-role-setup.sql
+++ b/docs/comms/comms-writer-role-setup.sql
@@ -5,11 +5,11 @@
 -- + telegram_message_id backfill). Granting it the full app DATABASE_URL is
 -- overkill; this role is the least-privilege handle the Comms env should use.
 --
--- Optional future upgrade. Current Paperclip config maps the Comms agent's
--- DATABASE_URL env var to the existing ANALYST_DATABASE_URL read-only secret
--- by CEO decision. If Comms needs to persist editorial_posts directly from
--- the agent runtime, run this once on prod against the ff database as a
--- superuser. After this, create/update the Comms Paperclip secret binding:
+-- The Comms agent receives ANALYST_DATABASE_URL for read-only analysis and
+-- DATABASE_URL for the narrow publishing write path. DATABASE_URL must NOT be
+-- mapped to ANALYST_DATABASE_URL or to the full app FFMEMES_DATABASE_URL.
+-- Run this once on prod against the ff database as a superuser. After this,
+-- create/update the Comms Paperclip secret binding:
 --   DATABASE_URL=postgresql+asyncpg://comms_writer:<password>@<host>:<port>/ff
 -- (use the asyncpg driver — src/database.py builds an async engine).
 --

--- a/src/comms/publishing.py
+++ b/src/comms/publishing.py
@@ -275,7 +275,7 @@ def canonical_entity_family(entity_id: str | None) -> str:
     if not entity_id:
         return ""
 
-    normalized = entity_id.strip().lower().replace("-", "_")
+    normalized = entity_id.strip().lower().replace("-", "_").replace(":", "_")
     normalized = _DATE_TOKEN_RE.sub("_", normalized)
     normalized = _TRAILING_NUMBER_RE.sub("", normalized)
     normalized = re.sub(r"_+", "_", normalized).strip("_")
@@ -296,11 +296,11 @@ def canonical_entity_family(entity_id: str | None) -> str:
         ("wau", ("wau", "weekly_active")),
         ("dau", ("dau", "daily_active")),
         ("like_rate", ("lr", "like_rate")),
+        ("moderator_sources", ("moderator_source", "source_vote", "source_voting")),
         ("source_quality", ("source", "source_quality", "source_climber")),
         ("inline_search", ("inline_search", "inline")),
         ("meme_like_count", ("meme_like_count", "visible_like_count", "like_count")),
         ("video_vs_images", ("video_vs_images", "video_images", "media_type")),
-        ("moderator_sources", ("moderator_source", "source_vote", "source_voting")),
     )
     for family, needles in aliases:
         if any(needle in normalized for needle in needles):

--- a/src/comms/publishing.py
+++ b/src/comms/publishing.py
@@ -13,7 +13,8 @@ Invariants enforced here (not in prompt):
 - HTML tag whitelist (b, strong, i, em, code, a, blockquote).
 - `<blockquote>` is always rewritten to `<blockquote expandable>`.
 - Substring/pattern ban (describe_memes, circuit breakers, A/B iteration updates).
-- Category+entity rotation check against the last 14 editorial posts.
+- Category+entity plus canonical topic-family rotation check against the last
+  14 editorial posts.
 - Idempotency via SHA256 `draft_hash`. The hash row is INSERTED before the
   Telegram send (telegram_message_id NULL), then UPDATED with the real id
   after send returns. A retry that races with a previous in-flight call
@@ -52,6 +53,8 @@ _BLOCKQUOTE_OPEN_RE = re.compile(r"<blockquote(\s[^>]*)?>", re.IGNORECASE)
 # non-letter (or start-of-attrs) before `href` so `xhref=` is rejected.
 _HREF_ATTR_RE = re.compile(r"(?:^|[^a-z])href\s*=", re.IGNORECASE)
 _HREF_VALUE_RE = re.compile(r"href\s*=\s*['\"]([^'\"]*)['\"]", re.IGNORECASE)
+_DATE_TOKEN_RE = re.compile(r"(?:^|[_-])20\d{2}[_-]\d{2}[_-]\d{2}(?:$|[_-])")
+_TRAILING_NUMBER_RE = re.compile(r"[_-]\d+$")
 
 BANNED_SUBSTRINGS: tuple[str, ...] = (
     "describe_memes",
@@ -244,13 +247,65 @@ def _check_rotation(
     entity_id: str,
     recent: Iterable[tuple[str | None, str | None]],
 ) -> list[str]:
+    current_family = canonical_entity_family(entity_id)
     for rc, re_ in recent:
         if rc == category and re_ == entity_id:
             return [
                 f"Rotation violation: category={category!r} entity={entity_id!r} "
                 "was published in the last 14 editorial posts. Pick a different anomaly."
             ]
+        recent_family = canonical_entity_family(re_)
+        if current_family and current_family == recent_family:
+            return [
+                f"Rotation violation: entity family={current_family!r} "
+                "was published in the last 14 editorial posts. Pick a genuinely new topic, "
+                "not a new slug for the same metric."
+            ]
     return []
+
+
+def canonical_entity_family(entity_id: str | None) -> str:
+    """Collapse date-specific editorial entity ids into durable topic families.
+
+    Comms often sees daily anomalies where the metric is the same but the date
+    or wording changes. Rotation should block `session_record_20` right after
+    `session_length_median`, because readers experience both as "another
+    session-length post".
+    """
+    if not entity_id:
+        return ""
+
+    normalized = entity_id.strip().lower().replace("-", "_")
+    normalized = _DATE_TOKEN_RE.sub("_", normalized)
+    normalized = _TRAILING_NUMBER_RE.sub("", normalized)
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+
+    aliases: tuple[tuple[str, tuple[str, ...]], ...] = (
+        (
+            "session_length",
+            (
+                "north_star",
+                "session",
+                "session_length",
+                "session_median",
+                "session_record",
+                "median_memes_sent",
+                "memes_per_session",
+            ),
+        ),
+        ("wau", ("wau", "weekly_active")),
+        ("dau", ("dau", "daily_active")),
+        ("like_rate", ("lr", "like_rate")),
+        ("source_quality", ("source", "source_quality", "source_climber")),
+        ("inline_search", ("inline_search", "inline")),
+        ("meme_like_count", ("meme_like_count", "visible_like_count", "like_count")),
+        ("video_vs_images", ("video_vs_images", "video_images", "media_type")),
+        ("moderator_sources", ("moderator_source", "source_vote", "source_voting")),
+    )
+    for family, needles in aliases:
+        if any(needle in normalized for needle in needles):
+            return family
+    return normalized
 
 
 def validate_post_draft(

--- a/tests/comms/test_publishing.py
+++ b/tests/comms/test_publishing.py
@@ -257,6 +257,30 @@ def test_canonical_entity_family_strips_dates_and_aliases_session_terms():
     assert canonical_entity_family("north_star_daily") == "session_length"
 
 
+def test_canonical_entity_family_strips_colon_prefixed_iso_dates():
+    assert canonical_entity_family("cohort_week:2026-04-27") == "cohort_week"
+    assert canonical_entity_family("cohort_week:2026-05-04") == "cohort_week"
+
+
+def test_validate_rejects_rotation_same_colon_date_family():
+    result = validate_post_draft(
+        text="<b>hi</b>",
+        has_media=True,
+        category="C",
+        entity_id="cohort_week:2026-05-04",
+        recent=[("C", "cohort_week:2026-04-27")],
+    )
+    assert not result.ok
+    assert any("entity family='cohort_week'" in e for e in result.errors)
+
+
+def test_canonical_entity_family_keeps_moderator_sources_distinct():
+    assert canonical_entity_family("moderator_source") == "moderator_sources"
+    assert canonical_entity_family("source_vote") == "moderator_sources"
+    assert canonical_entity_family("source_voting") == "moderator_sources"
+    assert canonical_entity_family("source_climber") == "source_quality"
+
+
 # ── Metadata ──────────────────────────────────────────────────────────────
 
 

--- a/tests/comms/test_publishing.py
+++ b/tests/comms/test_publishing.py
@@ -11,6 +11,7 @@ from src.comms.publishing import (
     ALLOWED_HTML_TAGS,
     TELEGRAM_CAPTION_MAX,
     EditorialValidationError,
+    canonical_entity_family,
     compute_draft_hash,
     media_key,
     normalize_blockquote,
@@ -236,6 +237,24 @@ def test_validate_passes_rotation_with_distinct_entity():
         recent=[("C", "dau_delta_2026_04_24")],
     )
     assert result.ok
+
+
+def test_validate_rejects_rotation_same_metric_family():
+    result = validate_post_draft(
+        text="<b>hi</b>",
+        has_media=True,
+        category="C",
+        entity_id="session_record_20",
+        recent=[("C", "session_length_median")],
+    )
+    assert not result.ok
+    assert any("entity family='session_length'" in e for e in result.errors)
+
+
+def test_canonical_entity_family_strips_dates_and_aliases_session_terms():
+    assert canonical_entity_family("dau_delta_2026_04_24") == "dau"
+    assert canonical_entity_family("session-record-20") == "session_length"
+    assert canonical_entity_family("north_star_daily") == "session_length"
 
 
 # ── Metadata ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- collapse date-specific comms entity ids into canonical topic families before rotation checks
- update Comms agent instructions to avoid repeated topic families and blocked draft duplicates
- align comms_writer setup docs with the current narrow DATABASE_URL publishing path

## Tests
- docker compose exec app pytest tests/comms/test_publishing.py
- docker compose exec app ruff check src/comms/publishing.py tests/comms/test_publishing.py
- docker compose exec app ruff format --check src/comms/publishing.py tests/comms/test_publishing.py