### PR TITLE
Add upload review rejection reasons

### DIFF
--- a/src/tgbot/handlers/upload/moderation.py
+++ b/src/tgbot/handlers/upload/moderation.py
@@ -39,7 +39,18 @@ from src.tgbot.service import get_tg_user_by_id
 from src.tgbot.user_info import get_user_info
 
 UPLOADED_MEME_REIVIEW_CALLBACK_DATA_PATTERN = "upload:{upload_id}:review:{action}"
-UPLOADED_MEME_REVIEW_CALLBACK_DATA_REGEXP = r"upload:(\d+):review:(\w+)"
+UPLOADED_MEME_REVIEW_CALLBACK_DATA_REGEXP = r"upload:(\d+):review:([a-z_]+)"
+UPLOADED_MEME_REVIEW_APPROVE_ACTION = "approve"
+UPLOADED_MEME_REVIEW_REJECT_NOT_FUNNY_ACTION = "reject_not_funny"
+UPLOADED_MEME_REVIEW_REJECT_WRONG_LANGUAGE_ACTION = "reject_wrong_language"
+UPLOADED_MEME_REVIEW_REJECTION_LOCALIZATION_KEYS = {
+    UPLOADED_MEME_REVIEW_REJECT_NOT_FUNNY_ACTION: "upload.rejected_not_funny",
+    UPLOADED_MEME_REVIEW_REJECT_WRONG_LANGUAGE_ACTION: "upload.rejected_wrong_language",
+}
+UPLOADED_MEME_REVIEW_REJECTION_CAPTION_REASONS = {
+    UPLOADED_MEME_REVIEW_REJECT_NOT_FUNNY_ACTION: "Не смешно",
+    UPLOADED_MEME_REVIEW_REJECT_WRONG_LANGUAGE_ACTION: "Не тот язык",
+}
 
 LEADERBOARD_URL = (
     "https://metabase.okhlopkov.com/public/question/663c4def-4b42-4303-aa3b-73ab5bfa677a"
@@ -233,15 +244,25 @@ def review_keyboard(upload_id: int) -> InlineKeyboardMarkup:
         inline_keyboard=[
             [
                 InlineKeyboardButton(
-                    text="✅ Approve",
+                    text="✅ Всё ок",
                     callback_data=UPLOADED_MEME_REIVIEW_CALLBACK_DATA_PATTERN.format(
-                        upload_id=upload_id, action="approve"
+                        upload_id=upload_id, action=UPLOADED_MEME_REVIEW_APPROVE_ACTION
+                    ),
+                ),
+            ],
+            [
+                InlineKeyboardButton(
+                    text="❌ Не смешно",
+                    callback_data=UPLOADED_MEME_REIVIEW_CALLBACK_DATA_PATTERN.format(
+                        upload_id=upload_id,
+                        action=UPLOADED_MEME_REVIEW_REJECT_NOT_FUNNY_ACTION,
                     ),
                 ),
                 InlineKeyboardButton(
-                    text="❌ Reject",
+                    text="🌐 Не тот язык",
                     callback_data=UPLOADED_MEME_REIVIEW_CALLBACK_DATA_PATTERN.format(
-                        upload_id=upload_id, action="reject"
+                        upload_id=upload_id,
+                        action=UPLOADED_MEME_REVIEW_REJECT_WRONG_LANGUAGE_ACTION,
                     ),
                 ),
             ],
@@ -261,6 +282,14 @@ def _is_upload_review_chat(message: Any) -> bool:
     if message is None or settings.UPLOADED_MEMES_REVIEW_CHAT_ID is None:
         return False
     return str(message.chat_id) == str(settings.UPLOADED_MEMES_REVIEW_CHAT_ID)
+
+
+def _is_uploaded_meme_approve_action(action: str) -> bool:
+    return action == UPLOADED_MEME_REVIEW_APPROVE_ACTION
+
+
+def _is_uploaded_meme_rejection_action(action: str) -> bool:
+    return action in UPLOADED_MEME_REVIEW_REJECTION_LOCALIZATION_KEYS
 
 
 def _tg_user_info_to_name(tg_user_info: dict):
@@ -328,6 +357,14 @@ async def handle_uploaded_meme_review_button(
 
     reg = re.match(UPLOADED_MEME_REVIEW_CALLBACK_DATA_REGEXP, update.callback_query.data)
     upload_id, action = int(reg.group(1)), reg.group(2)
+
+    if not _is_uploaded_meme_approve_action(action) and not _is_uploaded_meme_rejection_action(
+        action
+    ):
+        await update.callback_query.answer("Unknown upload review action")
+        await restore_review_keyboard(update.callback_query.message, upload_id)
+        return
+
     meme_upload = await get_meme_raw_upload_by_id(upload_id)
     prev_caption = update.callback_query.message.caption
 
@@ -340,7 +377,7 @@ async def handle_uploaded_meme_review_button(
 
     meme = await update_meme_by_upload_id(
         upload_id,
-        status=MemeStatus.OK if action == "approve" else MemeStatus.REJECTED,
+        status=(MemeStatus.OK if _is_uploaded_meme_approve_action(action) else MemeStatus.REJECTED),
     )
 
     await pay_if_not_paid_with_alert(
@@ -350,7 +387,7 @@ async def handle_uploaded_meme_review_button(
         external_id=str(meme["id"]),
     )
 
-    if action == "approve":
+    if _is_uploaded_meme_approve_action(action):
         new_caption = prev_caption + "\n✅ Approved by {}".format(update.effective_user.name)
         if (
             update.callback_query.message.caption != new_caption
@@ -397,8 +434,10 @@ async def handle_uploaded_meme_review_button(
         )
 
     else:
-        await update_meme_by_upload_id(upload_id, status=MemeStatus.REJECTED)
-        new_caption = prev_caption + "\n❌ Rejected by {}".format(update.effective_user.name)
+        rejection_reason = UPLOADED_MEME_REVIEW_REJECTION_CAPTION_REASONS[action]
+        new_caption = prev_caption + "\n❌ Rejected by {}: {}".format(
+            update.effective_user.name, rejection_reason
+        )
         if (
             update.callback_query.message.caption != new_caption
             or update.callback_query.message.reply_markup is not None
@@ -413,6 +452,7 @@ async def handle_uploaded_meme_review_button(
                     raise
 
         uploader_lang = await _get_uploader_lang(meme_upload["user_id"])
+        localization_key = UPLOADED_MEME_REVIEW_REJECTION_LOCALIZATION_KEYS[action]
         await _notify_uploader(
-            context.bot, meme_upload, localizer.t("upload.rejected", uploader_lang)
+            context.bot, meme_upload, localizer.t(localization_key, uploader_lang)
         )

--- a/static/localization/upload.yml
+++ b/static/localization/upload.yml
@@ -494,6 +494,30 @@ upload.rejected:
     Модератори відхилили твій мем. Надішли щось інше!
 
 
+upload.rejected_not_funny:
+  en: |-
+    😢😢😢
+
+    Your meme was rejected by our moderators: it wasn't funny enough. Send us something else!
+
+  ru: |-
+    😢😢😢
+
+    Модераторы отклонили твой мем: не смешно. Присылай что-нибудь другое!
+
+
+upload.rejected_wrong_language:
+  en: |-
+    😢😢😢
+
+    Your meme was rejected because the selected meme language doesn't match the meme. Upload it again with the correct language.
+
+  ru: |-
+    😢😢😢
+
+    Модераторы отклонили твой мем: выбран не тот язык. Загрузи его ещё раз и выбери правильный язык.
+
+
 upload.rejected_duplicate:
   en: |-
     😬 This meme is already in our collection, so we can't accept it again. Send us something else!

--- a/tests/tgbot/test_upload_moderation.py
+++ b/tests/tgbot/test_upload_moderation.py
@@ -10,11 +10,12 @@ def _update(
     *,
     user_id: int = 1,
     chat_id: int = -100,
-    data: str = "upload:42:review:reject",
+    data: str = "upload:42:review:reject_not_funny",
 ):
     message = SimpleNamespace(
         chat_id=chat_id,
         caption="review caption",
+        reply_markup=object(),
         edit_caption=AsyncMock(),
         edit_reply_markup=AsyncMock(),
     )
@@ -49,6 +50,28 @@ async def test_self_review_restores_review_buttons(monkeypatch):
     update_meme.assert_not_awaited()
 
 
+def test_review_keyboard_separates_approve_and_rejection_reasons():
+    keyboard = moderation.review_keyboard(42).inline_keyboard
+
+    assert len(keyboard) == 2
+    assert [button.text for button in keyboard[0]] == ["✅ Всё ок"]
+    assert [button.callback_data for button in keyboard[0]] == ["upload:42:review:approve"]
+    assert [button.text for button in keyboard[1]] == ["❌ Не смешно", "🌐 Не тот язык"]
+    assert [button.callback_data for button in keyboard[1]] == [
+        "upload:42:review:reject_not_funny",
+        "upload:42:review:reject_wrong_language",
+    ]
+
+
+def test_rejection_reason_messages_are_localized_in_english_and_russian():
+    assert "wasn't funny enough" in moderation.localizer.t("upload.rejected_not_funny", "en")
+    assert "не смешно" in moderation.localizer.t("upload.rejected_not_funny", "ru")
+    assert "selected meme language doesn't match" in moderation.localizer.t(
+        "upload.rejected_wrong_language", "en"
+    )
+    assert "выбран не тот язык" in moderation.localizer.t("upload.rejected_wrong_language", "ru")
+
+
 @pytest.mark.asyncio
 async def test_review_callback_outside_upload_review_chat_is_ignored(monkeypatch):
     monkeypatch.setattr(moderation.settings, "UPLOADED_MEMES_REVIEW_CHAT_ID", "-100")
@@ -68,7 +91,10 @@ async def test_review_callback_outside_upload_review_chat_is_ignored(monkeypatch
 @pytest.mark.asyncio
 async def test_upload_review_chat_member_can_reject_without_moderator_user_type(monkeypatch):
     monkeypatch.setattr(moderation.settings, "UPLOADED_MEMES_REVIEW_CHAT_ID", "-100")
-    update, message, query = _update(user_id=8)
+    update, message, query = _update(
+        user_id=8,
+        data="upload:42:review:reject_wrong_language",
+    )
     context = SimpleNamespace(bot=AsyncMock())
 
     with (
@@ -87,14 +113,16 @@ async def test_upload_review_chat_member_can_reject_without_moderator_user_type(
         patch.object(
             moderation,
             "get_user_info",
-            new=AsyncMock(return_value={"interface_lang": "en"}),
+            new=AsyncMock(return_value={"interface_lang": "ru"}),
         ) as get_user_info,
     ):
         await moderation.handle_uploaded_meme_review_button(update, context)
 
     query.answer.assert_awaited_once_with()
-    assert update_meme.await_count == 2
+    update_meme.assert_awaited_once_with(42, status=moderation.MemeStatus.REJECTED)
     pay.assert_awaited_once()
     message.edit_caption.assert_awaited_once()
+    assert "Не тот язык" in message.edit_caption.await_args.kwargs["caption"]
     notify.assert_awaited_once()
+    assert "выбран не тот язык" in notify.await_args.args[2]
     get_user_info.assert_awaited_once_with(7)


### PR DESCRIPTION
## Summary
- split upload review keyboard into one approve button and two direct rejection-reason buttons
- notify uploaders with localized EN/RU rejection messages for not funny and wrong language
- keep rejection handling as a single click: each reason button immediately rejects the upload

## Tests
- python -m ruff check src/tgbot/handlers/upload/moderation.py tests/tgbot/test_upload_moderation.py
- python -m pytest tests/tgbot/test_upload_moderation.py