### PR TITLE
Add share-max crossposting canary

### DIFF
--- a/experiments/active/2026-05-19-crossposting-forward-intent-ranker.md
+++ b/experiments/active/2026-05-19-crossposting-forward-intent-ranker.md
@@ -1,0 +1,152 @@
+# Experiment: Crossposting Forward-Intent Ranker
+Created: 2026-05-19
+Status: proposed - offline evaluator, then RU-only canary
+Owner: analyst + engineer
+Deployed: pending
+Measure after: pending
+
+## Hypothesis
+
+Source-level share history is useful, but not enough to select the actual meme
+that will be forwarded. Telegram channel forwards should be predicted by a
+content-level "forward intent" score observed before channel posting:
+
+1. Timestamp-safe in-bot share clicks for the exact meme.
+2. Users whose historical share clicks, not likes, preceded channel-forward
+   wins.
+3. Source-level channel-forward prior as a fallback, not the dominant term.
+
+Primary target: `forwards_per_1k_views` at 24h after channel posting.
+Secondary target: absolute `forwards_24h`.
+
+## Current Evidence
+
+On 2026-05-19 we manually posted two `score_version=3` share-max candidates that
+were chosen mostly from source-level channel-forward history:
+
+| Channel | Meme | Age at check | Views | Forwards | Fwd/1k | Read |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| RU | 4643497 | 3.2h | 218 | 6 | 27.5 | good, not exceptional |
+| EN | 994936 | 3.2h | 37 | 0 | 0.0 | failed |
+
+RU was around the 74th percentile against mature 30-day `score_version=2`
+posts by fwd/1k, but only around the 44th percentile against early 1-8h
+snapshots. EN was below the median on both forwards and fwd/1k.
+
+Interpretation: source prior alone can find acceptable RU memes, but it did not
+produce a breakout and should not be promoted to the scheduled ranker. EN should
+remain separate; current EN share signals are not positive.
+
+## Next Plan
+
+### Phase A: Offline Evaluator
+
+Build a read-only evaluator that reconstructs candidate signals as of each
+historical channel decision:
+
+1. Label outcomes from the nearest 3h, 6h, and 24h channel snapshots.
+2. Use only `user_deep_link_log` share clicks created before the channel
+   decision.
+3. Exclude self-clicks encoded as `s_{sharer_user_id}_{meme_id}`.
+4. Train share-user weights from historical share-click lift, not from likes.
+5. Split per channel by time: train, validation, test.
+6. Compare four variants:
+   - current `score_version=2`;
+   - source-prior-only share-max;
+   - exact-meme prior-share-only;
+   - hybrid forward-intent score.
+
+Offline success gate:
+
+- RU test coverage >= 10% of candidate posts with an exact-meme prior-share
+  signal, or the feature is too sparse for hot ranking.
+- Hybrid Spearman correlation beats current v2 and source-prior-only by >= 0.05.
+- Top-20% hybrid-ranked posts beat v2 top-20% by >= 20% on `forwards_24h`.
+- Absolute `forwards_24h` does not drop when fwd/1k improves.
+- EN must pass the same gate independently before any EN online posting.
+
+### Phase B: RU-Only Canary
+
+If Phase A passes for RU, post 5 RU canary slots over 24-48 hours using the
+hybrid score. Keep these as manual or one-shot `score_version=3` posts; do not
+replace the scheduled ranker yet.
+
+Canary pass criteria:
+
+- Mean early fwd/1k is above the RU v2 early p75 baseline observed on
+  2026-05-19: about 39 forwards per 1k views.
+- Mean early absolute forwards is above the RU v2 early p75 baseline: about
+  9 forwards.
+- Views are not more than 20% below the comparable early v2 median.
+- No source supplies more than 2 of the 5 canary posts.
+
+Stop the canary early if two consecutive posts land below the early v2 median
+on both absolute forwards and fwd/1k.
+
+### Phase C: Online A/B
+
+Only after the RU canary passes:
+
+- Add a small scheduled RU exploration bucket: 10-20% of channel slots.
+- Keep v2 as control.
+- Keep one source per 24h diversity cap.
+- Keep image-only policy.
+- Keep EN disabled until it has its own positive offline result.
+
+Candidate score:
+
+```text
+forward_intent_score =
+  source_forward_prior
+  * (1 + capped_exact_meme_prior_share_users)
+  * (1 + capped_weighted_share_user_lift)
+  * quality_guardrails
+```
+
+Initial caps should be conservative:
+
+- exact-meme prior-share users: max +50%;
+- weighted share-user lift: max +30%;
+- source prior: keep as a rank floor, not an unlimited multiplier.
+
+## Metrics
+
+Primary:
+
+- `forwards_per_1k_views_24h`
+- `forwards_24h`
+
+Early read:
+
+- `forwards_per_1k_views_3h`
+- `forwards_3h`
+- views at 3h to catch reach loss
+
+Guardrails:
+
+- No skipped posting slots due to empty pool.
+- No post-after-post leakage in offline evaluation.
+- EN and RU model weights are trained and evaluated independently.
+- Human review link is available for one-shot candidates before posting.
+
+## Implementation Notes
+
+- Reuse the existing `score_version=3` decision-log fields:
+  `share_source_base`, `share_user_boost`, `share_invited_boost`,
+  `share_max_base_score`, and `share_max_score`.
+- Add a candidate preview/report step before manual posting so the selected
+  source URL can be reviewed.
+- Do not compute predictor-user weights inline in the hot crossposting SQL.
+  Materialize or cache them if the offline evaluator passes.
+- Keep the current scheduled crossposting ranker at `score_version=2` until the
+  RU canary passes.
+
+## Metrics After
+
+Pending.
+
+## Conclusion
+
+Pending. Current read: the next useful bet is not "more source prior"; it is a
+timestamp-safe forward-intent feature based on exact-meme share behavior and
+historically good share users, tested RU-first.

--- a/scripts/serve_flows.py
+++ b/scripts/serve_flows.py
@@ -28,6 +28,8 @@ from src.flows.crossposting.editorial import post_editorial_to_channel
 from src.flows.crossposting.meme import (
     post_meme_to_tgchannelen,
     post_meme_to_tgchannelru,
+    post_share_max_meme_to_tgchannelen,
+    post_share_max_meme_to_tgchannelru,
 )
 from src.flows.crossposting.stats_collector import collect_channel_stats
 from src.flows.crossposting.weekly_report import post_weekly_burger_report
@@ -156,6 +158,13 @@ if __name__ == "__main__":
         post_meme_to_tgchannelen.to_deployment(
             name="Post to TG Channel EN",
             schedules=[CronSchedule(cron="40 8,10,14,18,20 * * *", timezone=MSK)],
+        ),
+        # One-shot crossposting canary flows. Operators trigger these manually.
+        post_share_max_meme_to_tgchannelru.to_deployment(
+            name="Post Share Max Meme to TG Channel RU",
+        ),
+        post_share_max_meme_to_tgchannelen.to_deployment(
+            name="Post Share Max Meme to TG Channel EN",
         ),
         # ── Channel Stats (every 6h) ──
         collect_channel_stats.to_deployment(

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -520,6 +520,27 @@ _SHARE_MAX_QUERY = """
         ) ranked_base
         WHERE base_rank <= :prelimit
     ),
+    share_clicks AS MATERIALIZED (
+        SELECT
+            share_match.parts[2]::bigint AS meme_id,
+            COUNT(*) AS pre_inbot_share_clicks,
+            COUNT(DISTINCT udll.user_id) AS pre_inbot_share_click_users
+        FROM user_deep_link_log udll
+        CROSS JOIN selected_at
+        CROSS JOIN LATERAL regexp_matches(
+            udll.deep_link,
+            '^s_([1-9][0-9]{0,18})_([1-9][0-9]{0,18})$'
+        ) AS share_match(parts)
+        WHERE udll.created_at < selected_at.decided_at
+          AND CASE
+              WHEN length(share_match.parts[1]) = 19
+                AND share_match.parts[1] > '9223372036854775807' THEN false
+              WHEN length(share_match.parts[2]) = 19
+                AND share_match.parts[2] > '9223372036854775807' THEN false
+              ELSE udll.user_id <> share_match.parts[1]::bigint
+          END
+        GROUP BY share_match.parts[2]::bigint
+    ),
     scored AS MATERIALIZED (
         SELECT
             with_shares.*,
@@ -566,25 +587,7 @@ _SHARE_MAX_QUERY = """
               END
         ) AS share_max_score
             FROM prelimited
-            CROSS JOIN selected_at
-            LEFT JOIN LATERAL (
-                SELECT
-                    COUNT(*) AS pre_inbot_share_clicks,
-                    COUNT(DISTINCT user_id) AS pre_inbot_share_click_users
-                FROM user_deep_link_log udll
-                CROSS JOIN LATERAL (
-                    SELECT substring(
-                        udll.deep_link FROM ('^s_([1-9][0-9]{0,18})_' || prelimited.id || '$')
-                    ) AS sharer_id
-                ) share_link
-                WHERE udll.created_at < selected_at.decided_at
-                  AND CASE
-                      WHEN share_link.sharer_id IS NULL THEN false
-                      WHEN length(share_link.sharer_id) = 19
-                        AND share_link.sharer_id > '9223372036854775807' THEN false
-                      ELSE udll.user_id <> share_link.sharer_id::bigint
-                  END
-            ) share_clicks ON true
+            LEFT JOIN share_clicks ON share_clicks.meme_id = prelimited.id
         ) with_shares
     )
     SELECT *

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -573,11 +573,13 @@ _SHARE_MAX_QUERY = """
                     COUNT(DISTINCT user_id) AS pre_inbot_share_click_users
                 FROM user_deep_link_log udll
                 CROSS JOIN LATERAL (
-                    SELECT split_part(udll.deep_link, '_', 2) AS sharer_id
+                    SELECT substring(
+                        udll.deep_link FROM ('^s_([1-9][0-9]{0,18})_' || prelimited.id || '$')
+                    ) AS sharer_id
                 ) share_link
                 WHERE udll.created_at < selected_at.decided_at
-                  AND udll.deep_link ~ ('^s_[1-9][0-9]{0,18}_' || prelimited.id || '$')
                   AND CASE
+                      WHEN share_link.sharer_id IS NULL THEN false
                       WHEN length(share_link.sharer_id) = 19
                         AND share_link.sharer_id > '9223372036854775807' THEN false
                       ELSE udll.user_id <> share_link.sharer_id::bigint

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -112,28 +112,34 @@ def _build_decision_log(
     log_candidates = []
     for i, row in enumerate(candidates):
         breakdown = _compute_score_breakdown(row, channel)
-        log_candidates.append(
-            {
-                "rank": i + 1,
-                "meme_id": row["id"],
-                "source_id": row.get("meme_source_id"),
-                "nlikes": row.get("nlikes"),
-                "ndislikes": row.get("ndislikes"),
-                "raw_impr_rank": row.get("raw_impr_rank"),
-                "age_days": row.get("age_days"),
-                "nmemes_sent": row.get("nmemes_sent"),
-                "invited_count": row.get("invited_count"),
-                "pre_inbot_share_clicks": row.get("pre_inbot_share_clicks") or 0,
-                "pre_inbot_share_click_users": row.get("pre_inbot_share_click_users") or 0,
-                "caption_present": row.get("caption") is not None,
-                "src_signal": (
-                    round(float(row["src_signal"]), 4)
-                    if row.get("src_signal") is not None
-                    else None
-                ),
-                **breakdown,
-            }
-        )
+        log_candidate = {
+            "rank": i + 1,
+            "meme_id": row["id"],
+            "source_id": row.get("meme_source_id"),
+            "nlikes": row.get("nlikes"),
+            "ndislikes": row.get("ndislikes"),
+            "raw_impr_rank": row.get("raw_impr_rank"),
+            "age_days": row.get("age_days"),
+            "nmemes_sent": row.get("nmemes_sent"),
+            "invited_count": row.get("invited_count"),
+            "pre_inbot_share_clicks": row.get("pre_inbot_share_clicks") or 0,
+            "pre_inbot_share_click_users": row.get("pre_inbot_share_click_users") or 0,
+            "caption_present": row.get("caption") is not None,
+            "src_signal": (
+                round(float(row["src_signal"]), 4) if row.get("src_signal") is not None else None
+            ),
+            **breakdown,
+        }
+        for key in (
+            "share_max_base_score",
+            "share_max_score",
+            "share_source_base",
+            "share_user_boost",
+            "share_invited_boost",
+        ):
+            if row.get(key) is not None:
+                log_candidate[key] = round(float(row[key]), 6)
+        log_candidates.append(log_candidate)
     return {
         "channel": channel,
         "picked_meme_id": picked["id"],
@@ -414,6 +420,200 @@ _EN_QUERY = """
 """
 
 
+_SHARE_MAX_QUERY = """
+    WITH selected_at AS (
+        SELECT NOW() AS decided_at
+    ),
+    src_quality AS (
+        SELECT
+            m.meme_source_id,
+            AVG(cp.forwards * SQRT(GREATEST(cp.views, 1) / 100.0)) AS signal,
+            COUNT(*) AS n_posts
+        FROM crossposting cp
+        JOIN meme m ON m.id = cp.meme_id
+        WHERE cp.channel = :channel
+          AND cp.created_at > NOW() - INTERVAL '30 days'
+          AND cp.created_at < NOW() - INTERVAL '48 hours'
+          AND cp.views IS NOT NULL
+          AND cp.views > 0
+          AND cp.forwards IS NOT NULL
+          AND m.type = 'image'
+        GROUP BY m.meme_source_id
+        HAVING COUNT(*) >= 5
+    ),
+    src_median AS (
+        SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY signal) AS m_signal
+        FROM src_quality
+    ),
+    recent_src AS (
+        SELECT DISTINCT m2.meme_source_id
+        FROM crossposting cp2
+        JOIN meme m2 ON m2.id = cp2.meme_id
+        WHERE cp2.channel = :channel
+          AND cp2.created_at > NOW() - INTERVAL '24 hours'
+          AND cp2.telegram_message_id IS NOT NULL
+    ),
+    base AS MATERIALIZED (
+        SELECT
+            M.id, M.type, M.telegram_file_id, M.caption,
+            M.meme_source_id,
+            MS.nlikes, MS.ndislikes, MS.raw_impr_rank,
+            MS.age_days, MS.nmemes_sent, MS.invited_count,
+            SQ.signal AS src_signal,
+            (SELECT m_signal FROM src_median) AS median_signal,
+            COALESCE(SQ.signal, 0.5 * (SELECT m_signal FROM src_median), 1.0)
+                AS share_source_base,
+            COUNT(*) OVER () AS candidate_pool_size,
+            ROW_NUMBER() OVER (
+                PARTITION BY M.meme_source_id
+                ORDER BY
+                    COALESCE(SQ.signal, 0.5 * (SELECT m_signal FROM src_median), 1.0)
+                    * (1.0 + LEAST(COALESCE(MS.invited_count, 0), 10) * :invited_weight)
+                    * CASE WHEN M.caption IS NULL THEN 1.0 ELSE 0.75 END
+                    * CASE
+                        WHEN MS.nmemes_sent <= 1 THEN 1.0
+                        ELSE LEAST(1.25, GREATEST(
+                            0.75,
+                            (MS.nlikes + MS.ndislikes) * 1.0 / MS.nmemes_sent
+                        ))
+                      END DESC,
+                    M.id
+            ) AS base_source_rank
+        FROM meme M
+        INNER JOIN meme_stats MS ON MS.meme_id = M.id
+        LEFT JOIN crossposting CP ON CP.meme_id = M.id AND CP.channel = :channel
+        LEFT JOIN src_quality SQ ON SQ.meme_source_id = M.meme_source_id
+        WHERE 1=1
+          AND CP.meme_id IS NULL
+          AND M.status = 'ok'
+          AND M.language_code = :language_code
+          AND M.type = 'image'
+          AND M.telegram_file_id IS NOT NULL
+          AND MS.nlikes >= 5
+          AND SQ.signal IS NOT NULL
+          AND (
+              :respect_recent_source_cap = false
+              OR M.meme_source_id NOT IN (SELECT meme_source_id FROM recent_src)
+          )
+    ),
+    prelimited AS MATERIALIZED (
+        SELECT *
+        FROM (
+            SELECT
+                base.*,
+                ROW_NUMBER() OVER (
+                    ORDER BY
+                        share_source_base
+                        * (1.0 + LEAST(COALESCE(invited_count, 0), 10) * :invited_weight)
+                        * CASE WHEN caption IS NULL THEN 1.0 ELSE 0.75 END
+                        * CASE
+                            WHEN nmemes_sent <= 1 THEN 1.0
+                            ELSE LEAST(1.25, GREATEST(
+                                0.75,
+                                (nlikes + ndislikes) * 1.0 / nmemes_sent
+                            ))
+                          END DESC,
+                        id
+                ) AS base_rank
+            FROM base
+            WHERE base_source_rank <= :per_source_limit
+        ) ranked_base
+        WHERE base_rank <= :prelimit
+    ),
+    scored AS MATERIALIZED (
+        SELECT
+            with_shares.*,
+            ROW_NUMBER() OVER (
+                PARTITION BY meme_source_id
+                ORDER BY share_max_score DESC, id
+            ) AS source_rank
+        FROM (
+            SELECT
+        prelimited.*,
+        COALESCE(share_clicks.pre_inbot_share_clicks, 0) AS pre_inbot_share_clicks,
+        COALESCE(share_clicks.pre_inbot_share_click_users, 0)
+            AS pre_inbot_share_click_users,
+        (1.0 + LEAST(COALESCE(share_clicks.pre_inbot_share_click_users, 0), 5)
+            * :share_user_weight) AS share_user_boost,
+        (1.0 + LEAST(COALESCE(prelimited.invited_count, 0), 10) * :invited_weight)
+            AS share_invited_boost,
+        (
+            prelimited.share_source_base
+            * (1.0 + LEAST(COALESCE(prelimited.invited_count, 0), 10) * :invited_weight)
+            * CASE WHEN prelimited.caption IS NULL THEN 1.0 ELSE 0.75 END
+            * CASE
+                WHEN prelimited.nmemes_sent <= 1 THEN 1.0
+                ELSE LEAST(1.25, GREATEST(
+                    0.75,
+                    (prelimited.nlikes + prelimited.ndislikes) * 1.0
+                    / prelimited.nmemes_sent
+                ))
+              END
+        ) AS share_max_base_score,
+        (
+            prelimited.share_source_base
+            * (1.0 + LEAST(COALESCE(share_clicks.pre_inbot_share_click_users, 0), 5)
+                * :share_user_weight)
+            * (1.0 + LEAST(COALESCE(prelimited.invited_count, 0), 10) * :invited_weight)
+            * CASE WHEN prelimited.caption IS NULL THEN 1.0 ELSE 0.75 END
+            * CASE
+                WHEN prelimited.nmemes_sent <= 1 THEN 1.0
+                ELSE LEAST(1.25, GREATEST(
+                    0.75,
+                    (prelimited.nlikes + prelimited.ndislikes) * 1.0
+                    / prelimited.nmemes_sent
+                ))
+              END
+        ) AS share_max_score
+            FROM prelimited
+            CROSS JOIN selected_at
+            LEFT JOIN LATERAL (
+                SELECT
+                    COUNT(*) AS pre_inbot_share_clicks,
+                    COUNT(DISTINCT user_id) AS pre_inbot_share_click_users
+                FROM user_deep_link_log udll
+                CROSS JOIN LATERAL (
+                    SELECT substring(
+                        udll.deep_link
+                        FROM ('^s_([1-9][0-9]{0,18})_' || prelimited.id || '$')
+                    ) AS sharer_id
+                ) share_link
+                WHERE udll.created_at < selected_at.decided_at
+                  AND CASE
+                      WHEN share_link.sharer_id IS NULL THEN false
+                      WHEN length(share_link.sharer_id) = 19
+                        AND share_link.sharer_id > '9223372036854775807' THEN false
+                      ELSE udll.user_id <> share_link.sharer_id::bigint
+                  END
+            ) share_clicks ON true
+        ) with_shares
+    )
+    SELECT *
+    FROM scored
+    WHERE source_rank = 1
+    ORDER BY share_max_score DESC, id
+    LIMIT :limit
+"""
+
+
+_SHARE_MAX_PARAMS: dict[str, dict[str, Any]] = {
+    "tgchannelru": {
+        "channel": "tgchannelru",
+        "language_code": "ru",
+        "share_user_weight": 0.5,
+        "invited_weight": 0.05,
+    },
+    # The May 18 readout showed prior in-bot shares were not predictive for EN,
+    # so EN share-max is intentionally source-quality-first.
+    "tgchannelen": {
+        "channel": "tgchannelen",
+        "language_code": "en",
+        "share_user_weight": 0.0,
+        "invited_weight": 0.03,
+    },
+}
+
+
 async def get_next_meme_for_tgchannelru(
     log_top_n: int = 5,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
@@ -441,6 +641,56 @@ async def get_next_meme_for_tgchannelen(
     if not rows:
         return None, None
     return _picked_meme_dict(rows[0]), _build_decision_log("tgchannelen", 2, rows)
+
+
+async def get_next_share_max_meme_for_tgchannelru(
+    log_top_n: int = 5,
+    prelimit: int = 80,
+    per_source_limit: int = 5,
+    respect_recent_source_cap: bool = True,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """One-shot experimental picker for RU channel slots optimized for forwards.
+
+    This is intentionally not wired into the scheduled deployment. It is for a
+    small score_version=3 exploration where source-level channel-forward history
+    dominates the score and timestamp-safe prior in-bot shares are a RU-only
+    boost.
+    """
+    params = {
+        **_SHARE_MAX_PARAMS["tgchannelru"],
+        "limit": log_top_n,
+        "prelimit": prelimit,
+        "per_source_limit": per_source_limit,
+        "respect_recent_source_cap": respect_recent_source_cap,
+    }
+    rows = await fetch_all(text(_SHARE_MAX_QUERY), params)
+    if not rows:
+        return None, None
+    return _picked_meme_dict(rows[0]), _build_decision_log("tgchannelru", 3, rows)
+
+
+async def get_next_share_max_meme_for_tgchannelen(
+    log_top_n: int = 5,
+    prelimit: int = 80,
+    per_source_limit: int = 5,
+    respect_recent_source_cap: bool = True,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """One-shot experimental picker for EN channel slots optimized for forwards.
+
+    EN keeps prior-share influence at zero because the offline readout showed a
+    negative EN prior-share lift. This picker still logs share fields for review.
+    """
+    params = {
+        **_SHARE_MAX_PARAMS["tgchannelen"],
+        "limit": log_top_n,
+        "prelimit": prelimit,
+        "per_source_limit": per_source_limit,
+        "respect_recent_source_cap": respect_recent_source_cap,
+    }
+    rows = await fetch_all(text(_SHARE_MAX_QUERY), params)
+    if not rows:
+        return None, None
+    return _picked_meme_dict(rows[0]), _build_decision_log("tgchannelen", 3, rows)
 
 
 async def get_next_meme_for_vkgroupru():

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -573,14 +573,11 @@ _SHARE_MAX_QUERY = """
                     COUNT(DISTINCT user_id) AS pre_inbot_share_click_users
                 FROM user_deep_link_log udll
                 CROSS JOIN LATERAL (
-                    SELECT substring(
-                        udll.deep_link
-                        FROM ('^s_([1-9][0-9]{0,18})_' || prelimited.id || '$')
-                    ) AS sharer_id
+                    SELECT split_part(udll.deep_link, '_', 2) AS sharer_id
                 ) share_link
                 WHERE udll.created_at < selected_at.decided_at
+                  AND udll.deep_link ~ ('^s_[1-9][0-9]{0,18}_' || prelimited.id || '$')
                   AND CASE
-                      WHEN share_link.sharer_id IS NULL THEN false
                       WHEN length(share_link.sharer_id) = 19
                         AND share_link.sharer_id > '9223372036854775807' THEN false
                       ELSE udll.user_id <> share_link.sharer_id::bigint

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -555,7 +555,7 @@ _SHARE_MAX_QUERY = """
         COALESCE(share_clicks.pre_inbot_share_click_users, 0)
             AS pre_inbot_share_click_users,
         (1.0 + LEAST(COALESCE(share_clicks.pre_inbot_share_click_users, 0), 5)
-            * :share_user_weight) AS share_user_boost,
+            * CAST(:share_user_weight AS DOUBLE PRECISION)) AS share_user_boost,
         (1.0 + LEAST(COALESCE(prelimited.invited_count, 0), 10) * :invited_weight)
             AS share_invited_boost,
         (
@@ -574,7 +574,7 @@ _SHARE_MAX_QUERY = """
         (
             prelimited.share_source_base
             * (1.0 + LEAST(COALESCE(share_clicks.pre_inbot_share_click_users, 0), 5)
-                * :share_user_weight)
+                * CAST(:share_user_weight AS DOUBLE PRECISION))
             * (1.0 + LEAST(COALESCE(prelimited.invited_count, 0), 10) * :invited_weight)
             * CASE WHEN prelimited.caption IS NULL THEN 1.0 ELSE 0.75 END
             * CASE

--- a/src/flows/crossposting/meme.py
+++ b/src/flows/crossposting/meme.py
@@ -9,6 +9,8 @@ from src.crossposting.constants import Channel
 from src.crossposting.service import (
     get_next_meme_for_tgchannelen,
     get_next_meme_for_tgchannelru,
+    get_next_share_max_meme_for_tgchannelen,
+    get_next_share_max_meme_for_tgchannelru,
     log_meme_sent,
     log_ranker_decision,
 )
@@ -293,6 +295,121 @@ async def post_meme_to_tgchannelru():
             logger.info(f"VK posted meme {next_meme.id} as post_id={vk_result.get('post_id')}")
         except Exception as e:
             logger.error(f"VK crosspost failed for meme {next_meme.id}: {e}")
+
+    uploader_user_id = await get_meme_uploader_user_id(next_meme.id)
+    if uploader_user_id:
+        balance = await pay_if_not_paid(uploader_user_id, TrxType.MEME_PUBLISHED, str(next_meme.id))
+        if balance:
+            link = TELEGRAM_CHANNEL_RU_LINK + "/" + str(msg.message_id)
+            await bot.send_message(
+                uploader_user_id,
+                f"""
+/b: +<b>{PAYOUTS[TrxType.MEME_PUBLISHED]}</b> 🍔 за то, что мы <a href="{link}">запостили твой мем к себе в канал</a>.
+                """,  # noqa
+                parse_mode=ParseMode.HTML,
+                disable_web_page_preview=True,
+            )
+
+
+@flow(
+    name="Post Share Max Meme to TG Channel EN",
+    retries=0,
+    timeout_seconds=300,
+    on_failure=[notify_telegram_on_failure],
+)
+async def post_share_max_meme_to_tgchannelen():
+    """One-shot experimental post using score_version=3 share-max ranking."""
+    logger = get_run_logger()
+
+    meme_data, decision = await get_next_share_max_meme_for_tgchannelen(
+        respect_recent_source_cap=False
+    )
+    if meme_data is None:
+        logger.warning("No qualifying share-max meme for TG Channel EN, skipping slot")
+        return
+    next_meme = MemeData(**meme_data)
+    logger.info(f"Next share-max meme for TG Channel EN: {next_meme.id}")
+
+    if decision:
+        try:
+            await log_ranker_decision(**decision)
+        except Exception as e:
+            logger.error(f"log_ranker_decision failed for share-max {next_meme.id}: {e}")
+
+    caption_text = _get_en_caption_for_crossposting_meme(next_meme, Channel.TG_CHANNEL_EN)
+    next_meme.caption = caption_text
+    msg = await send_new_message_with_meme(
+        bot, TELEGRAM_CHANNEL_EN_CHAT_ID, next_meme, reply_markup=None
+    )
+
+    await log_meme_sent(
+        next_meme.id,
+        Channel.TG_CHANNEL_EN,
+        telegram_message_id=msg.message_id,
+        caption_text=caption_text,
+        score_version=3,
+    )
+    await update_meme(next_meme.id, status=MemeStatus.PUBLISHED)
+
+    uploader_user_id = await get_meme_uploader_user_id(next_meme.id)
+    if uploader_user_id:
+        balance = await pay_if_not_paid(uploader_user_id, TrxType.MEME_PUBLISHED, str(next_meme.id))
+        if balance:
+            link = TELEGRAM_CHANNEL_EN_LINK + "/" + str(msg.message_id)
+            await bot.send_message(
+                uploader_user_id,
+                f"""
+/b: +<b>{PAYOUTS[TrxType.MEME_PUBLISHED]}</b> 🍔 because we <a href="{link}">posted your meme in our channel</a>.
+                """,  # noqa
+                parse_mode=ParseMode.HTML,
+                disable_web_page_preview=True,
+            )
+
+
+@flow(
+    name="Post Share Max Meme to TG Channel RU",
+    retries=0,
+    timeout_seconds=300,
+    on_failure=[notify_telegram_on_failure],
+)
+async def post_share_max_meme_to_tgchannelru():
+    """One-shot experimental post using score_version=3 share-max ranking.
+
+    Unlike the scheduled RU flow, this does not crosspost to VK; the experiment
+    isolates Telegram channel forwards.
+    """
+    logger = get_run_logger()
+
+    meme_data, decision = await get_next_share_max_meme_for_tgchannelru(
+        respect_recent_source_cap=False
+    )
+    if meme_data is None:
+        logger.warning("No qualifying share-max meme for TG Channel RU, skipping slot")
+        return
+    next_meme = MemeData(**meme_data)
+    logger.info(f"Next share-max meme for TG Channel RU: {next_meme.id}")
+
+    if decision:
+        try:
+            await log_ranker_decision(**decision)
+        except Exception as e:
+            logger.error(f"log_ranker_decision failed for share-max {next_meme.id}: {e}")
+
+    caption_text = _get_ru_caption_for_crossposting_meme(next_meme, Channel.TG_CHANNEL_RU)
+    next_meme.caption = caption_text
+
+    msg = await send_new_message_with_meme(
+        bot, TELEGRAM_CHANNEL_RU_CHAT_ID, next_meme, reply_markup=None
+    )
+
+    await log_meme_sent(
+        next_meme.id,
+        Channel.TG_CHANNEL_RU,
+        telegram_message_id=msg.message_id,
+        caption_text=caption_text,
+        score_version=3,
+    )
+    await update_meme(next_meme.id, status=MemeStatus.PUBLISHED)
 
     uploader_user_id = await get_meme_uploader_user_id(next_meme.id)
     if uploader_user_id:

--- a/src/flows/crossposting/meme.py
+++ b/src/flows/crossposting/meme.py
@@ -380,9 +380,7 @@ async def post_share_max_meme_to_tgchannelru():
     """
     logger = get_run_logger()
 
-    meme_data, decision = await get_next_share_max_meme_for_tgchannelru(
-        respect_recent_source_cap=False
-    )
+    meme_data, decision = await get_next_share_max_meme_for_tgchannelru()
     if meme_data is None:
         logger.warning("No qualifying share-max meme for TG Channel RU, skipping slot")
         return

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -8,6 +8,8 @@ from sqlalchemy.dialects.postgresql import insert
 from src.crossposting.service import (
     get_next_meme_for_tgchannelen,
     get_next_meme_for_tgchannelru,
+    get_next_share_max_meme_for_tgchannelen,
+    get_next_share_max_meme_for_tgchannelru,
     log_ranker_decision,
 )
 from src.database import crossposting, crossposting_decision_log, engine, user_deep_link_log
@@ -363,6 +365,136 @@ async def test_en_ranker_decision_log_has_shadow_share_fields(clean_xpost):
     only_candidate = decision["candidates"][0]
     assert only_candidate["pre_inbot_share_clicks"] == 0
     assert only_candidate["pre_inbot_share_click_users"] == 0
+
+
+@pytest.mark.asyncio
+async def test_ru_share_max_picker_boosts_prior_inbot_shares(clean_xpost):
+    async with engine.connect() as conn:
+        await create_meme_source(conn, id=10370, language_code="ru")
+        await create_meme_source(conn, id=10380, language_code="ru")
+        await create_meme(
+            conn, id=10371, meme_source_id=10370, language_code="ru", type="image", status="ok"
+        )
+        await create_meme(
+            conn, id=10381, meme_source_id=10380, language_code="ru", type="image", status="ok"
+        )
+        await create_meme_stats(conn, meme_id=10371, nlikes=10, ndislikes=2)
+        await create_meme_stats(conn, meme_id=10381, nlikes=10, ndislikes=2)
+        for i in range(5):
+            left_id = 10372 + i
+            right_id = 10382 + i
+            await create_meme(
+                conn,
+                id=left_id,
+                meme_source_id=10370,
+                language_code="ru",
+                type="image",
+                status="ok",
+            )
+            await create_meme_stats(conn, meme_id=left_id, nlikes=5, ndislikes=0)
+            await _insert_crossposting(
+                conn, "tgchannelru", left_id, hours_ago=24 * 5, views=100, forwards=5
+            )
+            await create_meme(
+                conn,
+                id=right_id,
+                meme_source_id=10380,
+                language_code="ru",
+                type="image",
+                status="ok",
+            )
+            await create_meme_stats(conn, meme_id=right_id, nlikes=5, ndislikes=0)
+            await _insert_crossposting(
+                conn, "tgchannelru", right_id, hours_ago=24 * 5, views=100, forwards=5
+            )
+        for user_id in (10071, 10072):
+            await create_user(conn, id=user_id)
+        await conn.execute(
+            insert(user_deep_link_log),
+            [
+                {
+                    "user_id": 10072,
+                    "deep_link": "s_10071_10381",
+                    "created_at": datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1),
+                },
+            ],
+        )
+        await conn.commit()
+
+    picked, decision = await get_next_share_max_meme_for_tgchannelru()
+    assert picked is not None
+    assert picked["id"] == 10381
+    assert decision is not None
+    assert decision["score_version"] == 3
+    top_candidate = decision["candidates"][0]
+    assert top_candidate["pre_inbot_share_click_users"] == 1
+    assert top_candidate["share_user_boost"] == 1.5
+    assert top_candidate["share_max_score"] > top_candidate["share_max_base_score"]
+
+
+@pytest.mark.asyncio
+async def test_en_share_max_picker_logs_but_does_not_boost_prior_shares(clean_xpost):
+    async with engine.connect() as conn:
+        await create_meme_source(conn, id=10390, language_code="en")
+        await create_meme_source(conn, id=10410, language_code="en")
+        await create_meme(
+            conn, id=10391, meme_source_id=10390, language_code="en", type="image", status="ok"
+        )
+        await create_meme(
+            conn, id=10411, meme_source_id=10410, language_code="en", type="image", status="ok"
+        )
+        await create_meme_stats(conn, meme_id=10391, nlikes=10, ndislikes=2)
+        await create_meme_stats(conn, meme_id=10411, nlikes=10, ndislikes=2)
+        for i in range(5):
+            left_id = 10392 + i
+            right_id = 10412 + i
+            await create_meme(
+                conn,
+                id=left_id,
+                meme_source_id=10390,
+                language_code="en",
+                type="image",
+                status="ok",
+            )
+            await create_meme_stats(conn, meme_id=left_id, nlikes=5, ndislikes=0)
+            await _insert_crossposting(
+                conn, "tgchannelen", left_id, hours_ago=24 * 5, views=100, forwards=5
+            )
+            await create_meme(
+                conn,
+                id=right_id,
+                meme_source_id=10410,
+                language_code="en",
+                type="image",
+                status="ok",
+            )
+            await create_meme_stats(conn, meme_id=right_id, nlikes=5, ndislikes=0)
+            await _insert_crossposting(
+                conn, "tgchannelen", right_id, hours_ago=24 * 5, views=100, forwards=5
+            )
+        for user_id in (10091, 10092):
+            await create_user(conn, id=user_id)
+        await conn.execute(
+            insert(user_deep_link_log),
+            [
+                {
+                    "user_id": 10092,
+                    "deep_link": "s_10091_10411",
+                    "created_at": datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1),
+                },
+            ],
+        )
+        await conn.commit()
+
+    picked, decision = await get_next_share_max_meme_for_tgchannelen()
+    assert picked is not None
+    assert picked["id"] == 10391
+    assert decision is not None
+    assert decision["score_version"] == 3
+    shared_candidate = next(c for c in decision["candidates"] if c["meme_id"] == 10411)
+    assert shared_candidate["pre_inbot_share_click_users"] == 1
+    assert shared_candidate["share_user_boost"] == 1.0
+    assert shared_candidate["share_max_score"] == shared_candidate["share_max_base_score"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -423,8 +423,18 @@ async def test_ru_share_max_picker_boosts_prior_inbot_shares(clean_xpost):
 
     picked, decision = await get_next_share_max_meme_for_tgchannelru()
     assert picked is not None
-    assert picked["id"] == 10381, decision
     assert decision is not None
+    debug_candidates = [
+        (
+            c["meme_id"],
+            c["pre_inbot_share_click_users"],
+            c["share_user_boost"],
+            c["share_max_base_score"],
+            c["share_max_score"],
+        )
+        for c in decision["candidates"]
+    ]
+    assert picked["id"] == 10381, debug_candidates
     assert decision["score_version"] == 3
     top_candidate = decision["candidates"][0]
     assert top_candidate["pre_inbot_share_click_users"] == 1

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -423,7 +423,7 @@ async def test_ru_share_max_picker_boosts_prior_inbot_shares(clean_xpost):
 
     picked, decision = await get_next_share_max_meme_for_tgchannelru()
     assert picked is not None
-    assert picked["id"] == 10381
+    assert picked["id"] == 10381, decision
     assert decision is not None
     assert decision["score_version"] == 3
     top_candidate = decision["candidates"][0]


### PR DESCRIPTION
## Summary
- add one-shot `score_version=3` share-max pickers for RU/EN Telegram channel experiments
- add Prefect flows that publish share-max candidates without wiring them into the scheduled ranker
- extend decision logs with share-max score breakdown fields
- document the next forward-intent hypothesis after the May 19 canary readout

## Context
The May 19 manual canary showed source-prior share-max is not enough by itself: RU was okay but not exceptional, EN failed. The next plan is RU-first: offline evaluator for timestamp-safe exact-meme share clicks and historically good share users, then a 5-post RU canary only if the offline gate passes.

## Verification
- `python -m py_compile src/crossposting/service.py src/flows/crossposting/meme.py tests/test_crossposting_meme.py`
- `./scripts/format`
- `git diff --check`

`pytest tests/test_crossposting_meme.py -q` is blocked locally by the test database hostname: 9 tests pass, 10 DB-backed tests error while resolving `app_db:5432`.
