### PR TITLE
Fix: disable unregistered text-light blender exposure

### DIFF
--- a/specs/recommendations.md
+++ b/specs/recommendations.md
@@ -38,11 +38,11 @@ Removed engines: `fast_dopamine`, `classic`, `multiply_all_scores`, `selected_so
 | Stage | Trigger | Engines | Source |
 |-------|---------|---------|--------|
 | Cold start | nmemes_sent < 30 | 3-phase adaptive with text-light guards: explore/adapt/fallback avoid OCR text above 30 words | [`pipeline.py`](../src/recommendations/pipeline.py) |
-| Growing | 30-100 | A/B: control uses `lr_smoothed`; treatment swaps that slot to `text_light_lr_smoothed` | [`pipeline.py`](../src/recommendations/pipeline.py) |
-| Mature | 100+ | Recently-liked blender v2, then A/B text-light overlay can swap `lr_smoothed` to `text_light_lr_smoothed` | [`pipeline.py`](../src/recommendations/pipeline.py) |
+| Growing | 30-100 | Control uses `lr_smoothed`; the text-light overlay is disabled unless explicitly enabled by a registered experiment | [`pipeline.py`](../src/recommendations/pipeline.py) |
+| Mature | 100+ | Recently-liked blender v2; the text-light overlay is disabled unless explicitly enabled by a registered experiment | [`pipeline.py`](../src/recommendations/pipeline.py) |
 | Moderator/Admin | user_type check | 75% low_sent_pool + 25% regular (by maturity) | [`pipeline.py`](../src/recommendations/pipeline.py) |
 
-`fixed_pos={0: "lr_smoothed"}` forces first position to `lr_smoothed` in blended mode. In the `text_light_blender_v1` treatment, that fixed slot becomes `text_light_lr_smoothed`.
+`fixed_pos={0: "lr_smoothed"}` forces first position to `lr_smoothed` in blended mode. If the `text_light_blender_v1` overlay is explicitly enabled, its treatment slot becomes `text_light_lr_smoothed`.
 
 ## Diagnostics Refactor
 

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -139,7 +139,9 @@ async def generate_recommendations(
             meme_ids_in_queue=meme_ids_in_queue,
             random_seed=random_seed,
             cold_start_nsessions_gate_enabled=settings.COLD_START_NSESSIONS_GATE_ENABLED,
-            text_light_blender_v1_enabled=True,
+            # FFM-1357: stop new exposure until this overlay has a CEO-owned
+            # active experiment record. Existing assignment rows remain readable.
+            text_light_blender_v1_enabled=False,
             source_diversity_enabled=settings.RECOMMENDATION_SOURCE_DIVERSITY_ENABLED,
             shadow_scoring_enabled=settings.RECOMMENDATION_SHADOW_SCORING_ENABLED,
             diagnostics_sample_rate=settings.RECOMMENDATION_DIAGNOSTICS_SAMPLE_RATE,

--- a/src/recommendations/pipeline.py
+++ b/src/recommendations/pipeline.py
@@ -70,7 +70,7 @@ class RecommendationBatchRequest:
     meme_ids_in_queue: Sequence[int] = field(default_factory=tuple)
     random_seed: int | None = None
     cold_start_nsessions_gate_enabled: bool = False
-    text_light_blender_v1_enabled: bool = True
+    text_light_blender_v1_enabled: bool = False
     source_diversity_enabled: bool = False
     shadow_scoring_enabled: bool = True
     diagnostics_sample_rate: float = 0.01

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -376,21 +376,18 @@ async def test_generate_above_100_treatment_uses_recently_liked_weights():
 
 
 @pytest.mark.asyncio
-async def test_text_light_blender_v1_treatment_pins_text_light_engine():
+async def test_text_light_blender_v1_is_disabled_in_queue_generation():
     captured_weights = None
     captured_fixed_pos = None
 
     async def one_candidate(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return [{"id": 4, "recommended_by": "generic"}]
 
-    async def text_light_candidate(self, user_id, limit=10, exclude_meme_ids=[], **kw):
-        return [{"id": 7, "recommended_by": "text_light_lr_smoothed"}]
-
     class TestRetriever(CandidatesRetriever):
         engine_map = {
             "best_uploaded_memes": one_candidate,
             "like_spread_and_recent_memes": one_candidate,
-            "text_light_lr_smoothed": text_light_candidate,
+            "lr_smoothed": one_candidate,
             "recently_liked": one_candidate,
             "goat": one_candidate,
             "es_ranked": one_candidate,
@@ -404,7 +401,7 @@ async def test_text_light_blender_v1_treatment_pins_text_light_engine():
         nonlocal captured_weights, captured_fixed_pos
         captured_weights = weights_dict
         captured_fixed_pos = fixed_pos
-        return [{"id": 7, "recommended_by": "text_light_lr_smoothed"}]
+        return [{"id": 4, "recommended_by": "lr_smoothed"}]
 
     with (
         patch(
@@ -416,16 +413,17 @@ async def test_text_light_blender_v1_treatment_pins_text_light_engine():
             "src.recommendations.meme_queue.get_text_light_blender_v1_weights",
             new_callable=AsyncMock,
             return_value=treatment_weights,
-        ),
+        ) as get_text_light_weights,
         patch("src.recommendations.meme_queue.blend", side_effect=capture_blend),
     ):
         candidates = await generate_recommendations(
             TEST_USER_ID, 10, 200, TestRetriever(), random_seed=102
         )
 
-    assert candidates == [{"id": 7, "recommended_by": "text_light_lr_smoothed"}]
-    assert "lr_smoothed" not in captured_weights
-    assert captured_fixed_pos == {0: "text_light_lr_smoothed"}
+    assert candidates == [{"id": 4, "recommended_by": "lr_smoothed"}]
+    assert captured_weights == MATURE_BLENDER_CONTROL_WEIGHTS
+    assert captured_fixed_pos == {0: "lr_smoothed"}
+    get_text_light_weights.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes FFM-1357.

## What changed
- Disables the `text_light_blender_v1` overlay in the production queue generation path.
- Flips the `RecommendationBatchRequest` default to disabled so callers must opt in explicitly.
- Updates the queue regression test to assert the text-light assignment helper is not called by default.
- Updates the recommendation spec to reflect that text-light overlay requires a registered experiment before exposure.

## Root cause
The `generate_recommendations()` hot path hard-coded `text_light_blender_v1_enabled=True`, so queue refills could create and honor `text_light_blender_v1` assignments even though no CEO-owned active experiment record existed.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `python3 -m pytest tests/recommendations/test_meme_queue.py tests/recommendations/test_pipeline.py -q`