### PR TITLE
Fix oversized upload auto-review crash

### DIFF
--- a/src/storage/source_voting.py
+++ b/src/storage/source_voting.py
@@ -4,10 +4,12 @@ from typing import Any
 
 from sqlalchemy import select, text
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncConnection
 from telegram import Bot
 from telegram.error import TelegramError
 
 from src.database import (
+    engine,
     execute,
     fetch_all,
     fetch_one,
@@ -280,6 +282,10 @@ async def get_source_candidate_vote_counts(poll_id: int) -> dict[str, int]:
         ),
         {"poll_id": poll_id},
     )
+    return _source_candidate_vote_counts_from_rows(rows)
+
+
+def _source_candidate_vote_counts_from_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
     yes = 0
     no = 0
     for row in rows:
@@ -290,10 +296,41 @@ async def get_source_candidate_vote_counts(poll_id: int) -> dict[str, int]:
     return {"yes": yes, "no": no, "total": yes + no}
 
 
+async def _get_source_candidate_vote_counts_in_transaction(
+    conn: AsyncConnection,
+    poll_id: int,
+) -> dict[str, int]:
+    result = await conn.execute(
+        text(
+            """
+            SELECT vote, COUNT(*) AS voters
+            FROM meme_source_candidate_vote
+            WHERE poll_id = :poll_id
+            GROUP BY vote
+            """
+        ),
+        {"poll_id": poll_id},
+    )
+    return _source_candidate_vote_counts_from_rows([row._asdict() for row in result.all()])
+
+
 async def get_source_candidate_poll(poll_id: int) -> dict[str, Any] | None:
     return await fetch_one(
         select(meme_source_candidate_poll).where(meme_source_candidate_poll.c.id == poll_id)
     )
+
+
+async def _get_source_candidate_poll_for_update(
+    conn: AsyncConnection,
+    poll_id: int,
+) -> dict[str, Any] | None:
+    result = await conn.execute(
+        select(meme_source_candidate_poll)
+        .where(meme_source_candidate_poll.c.id == poll_id)
+        .with_for_update()
+    )
+    row = result.first()
+    return row._asdict() if row is not None else None
 
 
 async def get_active_source_candidate_poll() -> dict[str, Any] | None:
@@ -328,41 +365,44 @@ async def record_source_candidate_vote(
     if vote not in (VOTE_ADD_SOURCE, VOTE_SKIP_SOURCE):
         return {"status": "invalid_vote"}
 
-    poll = await get_source_candidate_poll(poll_id)
-    if poll is None:
-        return {"status": "not_found"}
-    if chat_id != TELEGRAM_MODERATOR_CHAT_ID or poll["chat_id"] != TELEGRAM_MODERATOR_CHAT_ID:
-        return {"status": "wrong_chat", "poll": poll}
-    if poll["chat_id"] != chat_id:
-        return {"status": "wrong_chat", "poll": poll}
-    if poll["status"] != POLL_STATUS_OPEN or poll["closes_at"] <= now:
-        return {"status": "closed", "poll": poll}
+    async with engine.begin() as conn:
+        poll = await _get_source_candidate_poll_for_update(conn, poll_id)
+        if poll is None:
+            return {"status": "not_found"}
+        if chat_id != TELEGRAM_MODERATOR_CHAT_ID or poll["chat_id"] != TELEGRAM_MODERATOR_CHAT_ID:
+            return {"status": "wrong_chat", "poll": poll}
+        if poll["chat_id"] != chat_id:
+            return {"status": "wrong_chat", "poll": poll}
+        if poll["status"] != POLL_STATUS_OPEN or poll["closes_at"] <= now:
+            return {"status": "closed", "poll": poll}
 
-    existing = await fetch_one(
-        select(meme_source_candidate_vote)
-        .where(meme_source_candidate_vote.c.poll_id == poll_id)
-        .where(meme_source_candidate_vote.c.user_id == user_id)
-    )
-    stmt = (
-        insert(meme_source_candidate_vote)
-        .values(
-            {
-                "poll_id": poll_id,
-                "user_id": user_id,
-                "vote": vote,
-            }
+        existing_result = await conn.execute(
+            select(meme_source_candidate_vote)
+            .where(meme_source_candidate_vote.c.poll_id == poll_id)
+            .where(meme_source_candidate_vote.c.user_id == user_id)
         )
-        .on_conflict_do_update(
-            index_elements=(
-                meme_source_candidate_vote.c.poll_id,
-                meme_source_candidate_vote.c.user_id,
-            ),
-            set_={"vote": vote, "updated_at": now},
+        existing_row = existing_result.first()
+        existing = existing_row._asdict() if existing_row is not None else None
+        stmt = (
+            insert(meme_source_candidate_vote)
+            .values(
+                {
+                    "poll_id": poll_id,
+                    "user_id": user_id,
+                    "vote": vote,
+                }
+            )
+            .on_conflict_do_update(
+                index_elements=(
+                    meme_source_candidate_vote.c.poll_id,
+                    meme_source_candidate_vote.c.user_id,
+                ),
+                set_={"vote": vote, "updated_at": now},
+            )
         )
-    )
-    await execute(stmt)
+        await conn.execute(stmt)
 
-    counts = await get_source_candidate_vote_counts(poll_id)
+        counts = await _get_source_candidate_vote_counts_in_transaction(conn, poll_id)
     return {
         "status": "changed" if existing and existing["vote"] != vote else "recorded",
         "poll": poll,
@@ -400,6 +440,33 @@ async def _set_poll_status(
         .values(**values)
         .returning(meme_source_candidate_poll)
     )
+
+
+async def _set_poll_status_in_transaction(
+    conn: AsyncConnection,
+    poll_id: int,
+    *,
+    status: str,
+    closed_at: datetime | None = None,
+    result_meme_source_id: int | None = None,
+    data: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    values: dict[str, Any] = {"status": status, "updated_at": _utcnow()}
+    if closed_at is not None:
+        values["closed_at"] = closed_at
+    if result_meme_source_id is not None:
+        values["result_meme_source_id"] = result_meme_source_id
+    if data is not None:
+        values["data"] = data
+
+    result = await conn.execute(
+        meme_source_candidate_poll.update()
+        .where(meme_source_candidate_poll.c.id == poll_id)
+        .values(**values)
+        .returning(meme_source_candidate_poll)
+    )
+    row = result.first()
+    return row._asdict() if row is not None else None
 
 
 async def _append_source_vote_metadata(
@@ -472,44 +539,48 @@ async def close_source_candidate_poll(
     now: datetime | None = None,
 ) -> dict[str, Any]:
     now = now or _utcnow()
-    poll = await get_source_candidate_poll(poll_id)
-    if poll is None:
-        return {"status": "not_found"}
-    if poll["status"] != POLL_STATUS_OPEN:
-        return {"status": "already_closed", "poll": poll}
+    async with engine.begin() as conn:
+        poll = await _get_source_candidate_poll_for_update(conn, poll_id)
+        if poll is None:
+            return {"status": "not_found"}
+        if poll["status"] != POLL_STATUS_OPEN:
+            return {"status": "already_closed", "poll": poll}
+        if poll["closes_at"] > now:
+            return {"status": "not_due", "poll": poll}
 
-    counts = await get_source_candidate_vote_counts(poll_id)
-    poll_data = dict(poll.get("data") or {})
-    poll_data["final_counts"] = counts
+        counts = await _get_source_candidate_vote_counts_in_transaction(conn, poll_id)
+        poll_data = dict(poll.get("data") or {})
+        poll_data["final_counts"] = counts
 
-    result_source = None
-    if counts["total"] < SOURCE_VOTE_QUORUM:
-        status = POLL_STATUS_EXPIRED_NO_QUORUM
-    elif source_vote_passed(counts):
-        status = POLL_STATUS_PASSED
-        result_source = await enable_passed_source_poll(poll, counts, now)
-    else:
-        status = POLL_STATUS_REJECTED
-        if poll["prepared_meme_source_id"]:
-            await advance_meme_source(
-                poll["prepared_meme_source_id"],
-                moderator_id=f"source-vote:{poll_id}",
-                status=MemeSourceStatus.PARSING_DISABLED.value,
-                trigger_parse=False,
+        result_source = None
+        if counts["total"] < SOURCE_VOTE_QUORUM:
+            status = POLL_STATUS_EXPIRED_NO_QUORUM
+        elif source_vote_passed(counts):
+            status = POLL_STATUS_PASSED
+            result_source = await enable_passed_source_poll(poll, counts, now)
+        else:
+            status = POLL_STATUS_REJECTED
+            if poll["prepared_meme_source_id"]:
+                await advance_meme_source(
+                    poll["prepared_meme_source_id"],
+                    moderator_id=f"source-vote:{poll_id}",
+                    status=MemeSourceStatus.PARSING_DISABLED.value,
+                    trigger_parse=False,
+                )
+            await _mark_candidate(
+                poll["candidate_id"],
+                status=CANDIDATE_STATUS_DISMISSED,
+                dismissed_reason=f"source_vote:{poll_id}",
             )
-        await _mark_candidate(
-            poll["candidate_id"],
-            status=CANDIDATE_STATUS_DISMISSED,
-            dismissed_reason=f"source_vote:{poll_id}",
-        )
 
-    updated_poll = await _set_poll_status(
-        poll_id,
-        status=status,
-        closed_at=now,
-        result_meme_source_id=None if result_source is None else result_source["id"],
-        data=poll_data,
-    )
+        updated_poll = await _set_poll_status_in_transaction(
+            conn,
+            poll_id,
+            status=status,
+            closed_at=now,
+            result_meme_source_id=None if result_source is None else result_source["id"],
+            data=poll_data,
+        )
     return {
         "status": status,
         "poll": updated_poll,

--- a/src/tgbot/handlers/upload/moderation.py
+++ b/src/tgbot/handlers/upload/moderation.py
@@ -59,6 +59,13 @@ LEADERBOARD_URL = (
 logger = logging.getLogger(__name__)
 
 
+def _telegram_download_failure_kind(exc: BadRequest) -> str:
+    message = str(exc).lower()
+    if "too big" in message:
+        return "telegram_file_too_big"
+    return "telegram_download_bad_request"
+
+
 async def _notify_uploader(
     bot: Bot,
     meme_upload: dict[str, Any],
@@ -171,7 +178,42 @@ async def _uploaded_meme_auto_review(
     uploader_lang = await _get_uploader_lang(meme_upload["user_id"])
 
     logging.info(f"Downloading meme {meme['id']} content")
-    image_bytes = await download_meme_content_from_tg(meme["telegram_file_id"])
+    try:
+        image_bytes = await download_meme_content_from_tg(meme["telegram_file_id"])
+    except BadRequest as exc:
+        failure_kind = _telegram_download_failure_kind(exc)
+        logger.warning(
+            "User upload could not be downloaded from Telegram",
+            exc_info=True,
+            extra=sentry_log_extra(
+                observability_context,
+                phase="download_from_telegram",
+                error_type=type(exc).__name__,
+                failure_kind=failure_kind,
+            ),
+        )
+        capture_handled_issue(
+            "user_upload.telegram_download_failed",
+            level="warning",
+            user_id=meme_upload.get("user_id"),
+            tags={
+                "ff.module": "user_upload",
+                "ff.failure_kind": failure_kind,
+                "meme.type": meme.get("type"),
+                "error.type": type(exc).__name__,
+            },
+            contexts=observability_context,
+            error=exc,
+        )
+        await update_meme(meme["id"], status=MemeStatus.BROKEN_CONTENT_LINK)
+        localization_key = (
+            "upload.file_too_big"
+            if failure_kind == "telegram_file_too_big"
+            else "upload.tg_upload_failed"
+        )
+        return await _notify_uploader(
+            bot, meme_upload, localizer.t(localization_key, uploader_lang)
+        )
 
     logging.info(f"Adding watermark to meme {meme['id']} content")
     watermarked_meme_content = await add_watermark_to_meme_content(image_bytes, meme["type"])

--- a/static/localization/upload.yml
+++ b/static/localization/upload.yml
@@ -551,6 +551,17 @@ upload.tg_upload_failed:
     ❌ Щось пішло не так при завантаженні мема в Telegram. Просто спробуй ще раз.
 
 
+upload.file_too_big:
+  en: |-
+    ❌ This file is too big for Telegram processing. Please upload a smaller image or video.
+
+  ru: |-
+    ❌ Этот файл слишком большой для обработки в Telegram. Загрузи картинку или видео поменьше.
+
+  uk: |-
+    ❌ Цей файл завеликий для обробки в Telegram. Завантаж зображення або відео меншого розміру.
+
+
 upload.no_uploads_yet:
   en: |-
     📭 <b>You haven't uploaded any memes yet!</b>

--- a/tests/storage/test_source_voting.py
+++ b/tests/storage/test_source_voting.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -28,6 +29,7 @@ from src.storage.source_voting import (
     advance_daily_source_cycle,
     close_source_candidate_poll,
     create_source_candidate_poll,
+    get_source_candidate_vote_counts,
     mark_source_candidate_poll_open,
     post_new_source_candidate_poll,
     post_source_candidate_poll_message,
@@ -202,6 +204,69 @@ async def test_source_candidate_vote_is_unique_and_mutable(conn: AsyncConnection
     assert second["counts"] == {"yes": 1, "no": 1, "total": 2}
     assert changed["status"] == "changed"
     assert changed["counts"] == {"yes": 0, "no": 2, "total": 2}
+
+
+@pytest.mark.asyncio
+async def test_source_candidate_vote_does_not_early_reject_on_sixth_skip_racing_first_add(
+    conn: AsyncConnection,
+):
+    await _create_candidate(conn)
+    await conn.commit()
+    prepared = await prepare_source_candidate(CANDIDATE_ID, posts=[_post(4008)])
+    now = datetime.utcnow()
+    poll = await create_source_candidate_poll(
+        CANDIDATE_ID,
+        prepared_meme_source_id=prepared["source"]["id"],
+        chat_id=TELEGRAM_MODERATOR_CHAT_ID,
+        now=now,
+    )
+    await conn.execute(
+        meme_source_candidate_poll.update()
+        .where(meme_source_candidate_poll.c.id == poll["id"])
+        .values(status=POLL_STATUS_OPEN, message_id=129, opened_at=now)
+    )
+    await conn.commit()
+
+    for offset in range(1, 6):
+        await record_source_candidate_vote(
+            poll_id=poll["id"],
+            user_id=TEST_ID_START + offset,
+            vote=VOTE_SKIP_SOURCE,
+            chat_id=TELEGRAM_MODERATOR_CHAT_ID,
+            now=now,
+        )
+
+    sixth_skip, first_add, close_attempt = await asyncio.gather(
+        record_source_candidate_vote(
+            poll_id=poll["id"],
+            user_id=TEST_ID_START + 6,
+            vote=VOTE_SKIP_SOURCE,
+            chat_id=TELEGRAM_MODERATOR_CHAT_ID,
+            now=now,
+        ),
+        record_source_candidate_vote(
+            poll_id=poll["id"],
+            user_id=TEST_ID_START + 7,
+            vote=VOTE_ADD_SOURCE,
+            chat_id=TELEGRAM_MODERATOR_CHAT_ID,
+            now=now,
+        ),
+        close_source_candidate_poll(poll["id"], now=now),
+    )
+
+    assert sixth_skip["status"] == "recorded"
+    assert first_add["status"] == "recorded"
+    assert close_attempt["status"] == "not_due"
+    assert await get_source_candidate_vote_counts(poll["id"]) == {
+        "yes": 1,
+        "no": 6,
+        "total": 7,
+    }
+
+    stored_poll = await fetch_one(
+        select(meme_source_candidate_poll).where(meme_source_candidate_poll.c.id == poll["id"])
+    )
+    assert stored_poll["status"] == POLL_STATUS_OPEN
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_upload_observability.py
+++ b/tests/tgbot/test_upload_observability.py
@@ -1,8 +1,10 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from telegram.error import BadRequest
 
-from src.storage.constants import MemeType
+from src.storage.constants import MemeStatus, MemeType
+from src.tgbot.handlers.upload import moderation
 from src.tgbot.handlers.upload.moderation import uploaded_meme_auto_review
 
 
@@ -28,3 +30,40 @@ async def test_uploaded_meme_auto_review_captures_unhandled_failure():
     assert kwargs["user_id"] == 12001
     assert kwargs["tags"]["ff.module"] == "user_upload"
     assert kwargs["contexts"]["meme"]["id"] == 12003
+
+
+@pytest.mark.asyncio
+async def test_uploaded_meme_auto_review_handles_oversized_telegram_download():
+    error = BadRequest("File is too big")
+    meme = {"id": 12003, "type": MemeType.IMAGE, "telegram_file_id": "raw-file-id"}
+    meme_upload = {
+        "id": 12002,
+        "user_id": 12001,
+        "message_id": 12004,
+        "media": {"file_size": 99_000_000},
+    }
+
+    with (
+        patch.object(
+            moderation,
+            "download_meme_content_from_tg",
+            new=AsyncMock(side_effect=error),
+        ),
+        patch.object(
+            moderation,
+            "get_user_info",
+            new=AsyncMock(return_value={"interface_lang": "en"}),
+        ),
+        patch.object(moderation, "update_meme", new=AsyncMock()) as update_meme,
+        patch.object(moderation, "_notify_uploader", new=AsyncMock()) as notify,
+        patch.object(moderation, "capture_handled_issue") as capture_issue,
+        patch.object(moderation, "capture_handled_exception") as capture_exception,
+    ):
+        await uploaded_meme_auto_review(meme, meme_upload, AsyncMock())
+
+    update_meme.assert_awaited_once_with(12003, status=MemeStatus.BROKEN_CONTENT_LINK)
+    notify.assert_awaited_once()
+    assert "too big" in notify.await_args.args[2]
+    capture_issue.assert_called_once()
+    assert capture_issue.call_args.kwargs["tags"]["ff.failure_kind"] == "telegram_file_too_big"
+    capture_exception.assert_not_called()


### PR DESCRIPTION
Fixes FFM-1369.

## What changed
- Handle Telegram BadRequest failures during the initial uploaded-file download.
- Classify oversized Telegram download failures as `telegram_file_too_big` for observability.
- Mark the meme as `broken_content_link` and notify the uploader with a localized file-too-big message instead of letting the background auto-review task crash.
- Added a regression test covering the oversized-file path.

## Verification
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `DATABASE_URL=postgresql+asyncpg://app:app@app_db:5432/app REDIS_URL=redis://:myStrongPassword@redis:6379 ENVIRONMENT=TESTING TELEGRAM_BOT_TOKEN=123456:ABCDEFabcdef1234567890 pytest tests/tgbot/test_upload_observability.py -q`

Staff Engineer: please review before merge.