### PR TITLE
Implement tagged channel audience giveaway

### DIFF
--- a/src/tgbot/handlers/treasury/constants.py
+++ b/src/tgbot/handlers/treasury/constants.py
@@ -30,6 +30,7 @@ class TrxType(str, Enum):
     BOT_REPLY_PAYMENT = "bot_reply_payment"
 
     GIVEAWAY = "giveaway"
+    CHANNEL_AUDIENCE_GIVEAWAY = "channel_audience_giveaway"
 
 
 TREASURY_USER_ID = 1123681771
@@ -52,6 +53,7 @@ PAYOUTS = {
     TrxType.ACTIVE_IN_CHAT: 5,
     TrxType.BOT_REPLY_PAYMENT: -1,
     TrxType.GIVEAWAY: 77,
+    TrxType.CHANNEL_AUDIENCE_GIVEAWAY: 10,
 }
 
 # TODO: localize
@@ -73,4 +75,5 @@ TRX_TYPE_DESCRIPTIONS = {
     TrxType.ACTIVE_IN_CHAT: "being active in chat",
     TrxType.BOT_REPLY_PAYMENT: "chatting_with_bot",
     TrxType.GIVEAWAY: "channel giveaway",
+    TrxType.CHANNEL_AUDIENCE_GIVEAWAY: "channel audience giveaway",
 }

--- a/src/tgbot/handlers/treasury/giveaway.py
+++ b/src/tgbot/handlers/treasury/giveaway.py
@@ -7,7 +7,7 @@ Example: https://t.me/ffmemesbot?start=giveaway_77
 Only whitelisted campaign IDs are accepted. Users craft arbitrary
 giveaway_* links otherwise and mint unlimited burgers.
 
-Each giveaway campaign is identified by its deep link string.
+Each giveaway campaign is identified by its deep link string and transaction type.
 A user can only claim each giveaway once (enforced by pay_if_not_paid).
 """
 
@@ -19,10 +19,11 @@ from src.tgbot.handlers.treasury.constants import PAYOUTS, TrxType
 from src.tgbot.handlers.treasury.payments import pay_if_not_paid
 from src.tgbot.senders.next_message import next_message
 
-# Whitelist of active giveaway campaign IDs.
+# Whitelist of active giveaway campaign IDs mapped to their readout transaction type.
 # Add new campaigns here before posting the deep link to the channel.
-ACTIVE_GIVEAWAY_CAMPAIGNS = {
-    "giveaway_77",  # launch giveaway: 77 burgers to first clickers
+ACTIVE_GIVEAWAY_CAMPAIGNS: dict[str, TrxType] = {
+    "giveaway_77": TrxType.GIVEAWAY,  # launch giveaway: 77 burgers to first clickers
+    "giveaway_channel_audience_2026_05_25": TrxType.CHANNEL_AUDIENCE_GIVEAWAY,
 }
 
 
@@ -33,7 +34,8 @@ async def handle_giveaway(
 ) -> None:
     user_id = update.effective_user.id
 
-    if deep_link not in ACTIVE_GIVEAWAY_CAMPAIGNS:
+    trx_type = ACTIVE_GIVEAWAY_CAMPAIGNS.get(deep_link)
+    if trx_type is None:
         # Unknown campaign — silently continue to meme feed
         await next_message(
             context.bot,
@@ -43,10 +45,10 @@ async def handle_giveaway(
         )
         return
 
-    amount = PAYOUTS[TrxType.GIVEAWAY]
+    amount = PAYOUTS[trx_type]
 
     # deep_link is the external_id — ensures one claim per campaign per user
-    balance = await pay_if_not_paid(user_id, TrxType.GIVEAWAY, deep_link)
+    balance = await pay_if_not_paid(user_id, trx_type, deep_link)
 
     if balance is not None:
         await context.bot.send_message(

--- a/tests/tgbot/test_giveaway.py
+++ b/tests/tgbot/test_giveaway.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.tgbot.handlers.treasury.constants import TrxType
+from src.tgbot.handlers.treasury.giveaway import handle_giveaway
+
+
+def _make_update(user_id: int = 90203):
+    return SimpleNamespace(effective_user=SimpleNamespace(id=user_id))
+
+
+def _make_context():
+    return SimpleNamespace(bot=AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_channel_audience_giveaway_uses_tagged_ten_burger_reward():
+    update = _make_update()
+    context = _make_context()
+    deep_link = "giveaway_channel_audience_2026_05_25"
+
+    with (
+        patch(
+            "src.tgbot.handlers.treasury.giveaway.pay_if_not_paid",
+            new_callable=AsyncMock,
+            return_value=10,
+        ) as pay,
+        patch(
+            "src.tgbot.handlers.treasury.giveaway.next_message",
+            new_callable=AsyncMock,
+        ) as next_message,
+    ):
+        await handle_giveaway(update, context, deep_link)
+
+    pay.assert_awaited_once_with(
+        update.effective_user.id,
+        TrxType.CHANNEL_AUDIENCE_GIVEAWAY,
+        deep_link,
+    )
+    context.bot.send_message.assert_awaited_once()
+    assert "+<b>10</b>" in context.bot.send_message.await_args.kwargs["text"]
+    next_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_legacy_giveaway_keeps_legacy_payout_type():
+    update = _make_update()
+    context = _make_context()
+
+    with (
+        patch(
+            "src.tgbot.handlers.treasury.giveaway.pay_if_not_paid",
+            new_callable=AsyncMock,
+            return_value=77,
+        ) as pay,
+        patch("src.tgbot.handlers.treasury.giveaway.next_message", new_callable=AsyncMock),
+    ):
+        await handle_giveaway(update, context, "giveaway_77")
+
+    pay.assert_awaited_once_with(
+        update.effective_user.id,
+        TrxType.GIVEAWAY,
+        "giveaway_77",
+    )
+    assert "+<b>77</b>" in context.bot.send_message.await_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_giveaway_does_not_pay():
+    update = _make_update()
+    context = _make_context()
+
+    with (
+        patch(
+            "src.tgbot.handlers.treasury.giveaway.pay_if_not_paid",
+            new_callable=AsyncMock,
+        ) as pay,
+        patch(
+            "src.tgbot.handlers.treasury.giveaway.next_message",
+            new_callable=AsyncMock,
+        ) as next_message,
+    ):
+        await handle_giveaway(update, context, "giveaway_fake")
+
+    pay.assert_not_awaited()
+    context.bot.send_message.assert_not_awaited()
+    next_message.assert_awaited_once()


### PR DESCRIPTION
Fixes FFM-1403.

## What changed
- Adds the tagged channel CTA deep link: `giveaway_channel_audience_2026_05_25`.
- Preserves the legacy `giveaway_77` payout/type.
- Adds a separate treasury transaction type, `channel_audience_giveaway`, with a 10-burger payout.
- Keeps reward issuance idempotent through `pay_if_not_paid(user_id, trx_type, external_id=deep_link)`.

## Analyst readout fields
- Tagged clicks: `user_deep_link_log.deep_link = 'giveaway_channel_audience_2026_05_25'`.
- Reward claims: `treasury_trx.type = 'channel_audience_giveaway'` and `treasury_trx.external_id = 'giveaway_channel_audience_2026_05_25'`.
- Existing/new/reactivated user classification can join those rows to `user` / `user_tg` by `user_id` and creation/activity timestamps.

## Verification
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/postgres TELEGRAM_BOT_TOKEN=123456:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA python3 -m pytest tests/tgbot/test_giveaway.py -q`

Note: host pytest needs a SQLAlchemy 2-compatible `DATABASE_URL`; the default runtime env exposed `postgres://...`, which fails during import before tests run.