### PR TITLE
Fix meme source admin link handling

### DIFF
--- a/alembic/versions/2026-05-25_grant_mearsm_source_moderation.py
+++ b/alembic/versions/2026-05-25_grant_mearsm_source_moderation.py
@@ -1,0 +1,53 @@
+"""grant mearsm source moderation
+
+Revision ID: 8c2f4a6d9e10
+Revises: 7b2c9f1e4a6d
+Create Date: 2026-05-25 11:10:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8c2f4a6d9e10"
+down_revision = "7b2c9f1e4a6d"
+branch_labels = None
+depends_on = None
+
+MEARSM_USER_ID = 1007266539
+TELEGRAM_MODERATOR_CHAT_ID = -1001305866294
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO "user" (id, type, created_at, last_active_at, blocked_bot_at)
+            VALUES (:user_id, 'moderator', now(), now(), NULL)
+            ON CONFLICT (id)
+            DO UPDATE SET
+                type = 'moderator',
+                blocked_bot_at = NULL
+            """
+        ),
+        {"user_id": MEARSM_USER_ID},
+    )
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO user_tg_chat_membership (user_tg_id, chat_id, last_seen_at)
+            SELECT id, :chat_id, now()
+            FROM user_tg
+            WHERE id = :user_id
+            ON CONFLICT (user_tg_id, chat_id)
+            DO UPDATE SET last_seen_at = now()
+            """
+        ),
+        {"user_id": MEARSM_USER_ID, "chat_id": TELEGRAM_MODERATOR_CHAT_ID},
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/src/storage/etl.py
+++ b/src/storage/etl.py
@@ -19,7 +19,10 @@ from src.storage.parsers.schemas import (
     VkGroupPostParsingResult,
 )
 
-_TG_FORWARD_URL_PATTERN = re.compile(r"^https?://t\.me/(?:s/)?([a-zA-Z0-9_]+)(?:/\d+)?/?$")
+_TG_FORWARD_URL_PATTERN = re.compile(
+    r"^(?:https?://)?(?:t\.me|telegram\.me)/(?:s/)?([a-zA-Z0-9_]+)(?:/\d+)?/?$",
+    re.IGNORECASE,
+)
 TG_RECENT_POSTS_WINDOW = 10
 TG_TOP_VIEWED_POSTS_LIMIT = 5
 

--- a/src/tgbot/handlers/moderator/meme_source.py
+++ b/src/tgbot/handlers/moderator/meme_source.py
@@ -1,3 +1,6 @@
+import re
+from dataclasses import dataclass
+
 from telegram import Message, Update
 from telegram.ext import (
     ContextTypes,
@@ -11,7 +14,7 @@ from src.storage.moderation import (
     MemeSourceNotFoundError,
     advance_meme_source,
 )
-from src.tgbot.constants import UserType
+from src.tgbot.handlers.moderator.permissions import get_moderator_user_info
 from src.tgbot.logs import log
 from src.tgbot.senders.keyboards import (
     meme_source_change_status_keyboard,
@@ -22,41 +25,62 @@ from src.tgbot.service import (
     get_meme_source_stats_by_id,
     get_or_create_meme_source,
 )
-from src.tgbot.user_info import get_user_info
+
+MEME_SOURCE_LINK_REGEXP = (
+    r"(?i)(?:https?://)?(?:t\.me|telegram\.me|vk\.com|(?:www\.)?instagram\.com)/[^\s<>()]+"
+)
+
+_MEME_SOURCE_LINK_RE = re.compile(MEME_SOURCE_LINK_REGEXP)
+
+
+@dataclass(frozen=True)
+class MemeSourceLink:
+    url: str
+    type: MemeSourceType
+
+
+def parse_meme_source_link(text: str | None) -> MemeSourceLink | None:
+    if not text:
+        return None
+
+    match = _MEME_SOURCE_LINK_RE.search(text.strip())
+    if match is None:
+        return None
+
+    url = match.group(0).rstrip(".,)")
+    url_lower = url.lower()
+    if url_lower.startswith(("t.me/", "telegram.me/", "vk.com/", "instagram.com/")):
+        url = f"https://{url}"
+
+    normalized_lower = url.lower()
+    if "t.me/" in normalized_lower or "telegram.me/" in normalized_lower:
+        canonical = normalize_telegram_channel_url(url)
+        if canonical is None:
+            return None
+        return MemeSourceLink(url=canonical, type=MemeSourceType.TELEGRAM)
+
+    if "vk.com/" in normalized_lower:
+        return MemeSourceLink(url=url.split("?", 1)[0], type=MemeSourceType.VK)
+
+    if "instagram.com/" in normalized_lower:
+        return MemeSourceLink(url=url.split("?", 1)[0], type=MemeSourceType.INSTAGRAM)
+
+    return None
 
 
 async def handle_meme_source_link(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    user_info = await get_user_info(update.effective_user.id)
-    if not UserType(user_info["type"]).is_moderator:
+    if await get_moderator_user_info(update.effective_user.id) is None:
+        await update.message.reply_text("Only moderators can manage meme sources.")
         return
 
-    url = update.message.text.strip().lower()
-    if "https://t.me/" in url:
-        # Route through the same canonicalizer as the discovery pipeline
-        # so trailing slashes, post ids, and `?utm=...` suffixes collapse onto
-        # the canonical https://t.me/<channel> form. Without this, manual
-        # entries can leave duplicate `discovered` rows in the moderator queue
-        # because list_pending_source_candidates anti-joins on exact url match.
-        canonical = normalize_telegram_channel_url(url)
-        if canonical is None:
-            await update.message.reply_text(
-                "Unsupported telegram URL (private/invite link or unrecognized format)"
-            )
-            return
-        url = canonical
-        meme_source_type = MemeSourceType.TELEGRAM
-    elif "https://vk.com/" in url:
-        meme_source_type = MemeSourceType.VK
-    elif "https://www.instagram.com/" in url:
-        meme_source_type = MemeSourceType.INSTAGRAM
-        url = url.split("?")[0]  # remove query params
-    else:
+    link = parse_meme_source_link(update.message.text)
+    if link is None:
         await update.message.reply_text("Unsupported meme source")
         return
 
     meme_source = await get_or_create_meme_source(
-        url=url,
-        type=meme_source_type,
+        url=link.url,
+        type=link.type,
         status=MemeSourceStatus.IN_MODERATION,
         added_by=update.effective_user.id,
     )
@@ -68,8 +92,10 @@ async def handle_meme_source_language_selection(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     user_id = update.effective_user.id
-    user_info = await get_user_info(user_id)
-    if not UserType(user_info["type"]).is_moderator:
+    if await get_moderator_user_info(user_id) is None:
+        await update.callback_query.answer(
+            "🤷‍♀️ Only moderators can change meme source language 🤷‍♂️"
+        )  # noqa: E501
         return
 
     args = update.callback_query.data.split(":")
@@ -99,8 +125,7 @@ async def handle_meme_source_change_status(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     user_id = update.effective_user.id
-    user_info = await get_user_info(user_id)
-    if not UserType(user_info["type"]).is_moderator:
+    if await get_moderator_user_info(user_id) is None:
         await update.callback_query.answer("🤷‍♀️ Only moderators can change meme source status 🤷‍♂️")  # noqa: E501
         return
 

--- a/src/tgbot/handlers/moderator/permissions.py
+++ b/src/tgbot/handlers/moderator/permissions.py
@@ -1,0 +1,40 @@
+import logging
+from collections.abc import Mapping
+
+from src.tgbot.constants import UserType
+from src.tgbot.exceptions import UserNotFound
+from src.tgbot.user_info import get_user_info, update_user_info_cache
+
+
+def _is_moderator_type(raw_type: object) -> bool:
+    try:
+        return UserType(str(raw_type)).is_moderator
+    except ValueError:
+        logging.warning("Unknown user type '%s' encountered during moderator check", raw_type)
+        return False
+
+
+async def get_moderator_user_info(user_id: int) -> Mapping[str, object] | None:
+    """Return user info only when the user currently has moderator privileges.
+
+    Moderator gates are sensitive to role changes. `get_user_info` is cached for
+    an hour, so if the cache says "not a moderator" we refresh once from DB
+    before denying access.
+    """
+    try:
+        user_info = await get_user_info(user_id)
+    except UserNotFound:
+        return None
+
+    if _is_moderator_type(user_info["type"]):
+        return user_info
+
+    try:
+        fresh_user_info = await update_user_info_cache(user_id)
+    except UserNotFound:
+        return None
+
+    if _is_moderator_type(fresh_user_info["type"]):
+        return fresh_user_info
+
+    return None

--- a/src/tgbot/handlers/moderator/registry.py
+++ b/src/tgbot/handlers/moderator/registry.py
@@ -33,7 +33,7 @@ def add_moderator_handlers(application: Application) -> None:
             ),
             MessageHandler(
                 filters=filters.ChatType.PRIVATE
-                & filters.Regex("^(https://t.me|https://vk.com|https://www.instagram.com)"),
+                & filters.Regex(meme_source.MEME_SOURCE_LINK_REGEXP),
                 callback=meme_source.handle_meme_source_link,
             ),
             CallbackQueryHandler(

--- a/src/tgbot/handlers/moderator/source_candidates.py
+++ b/src/tgbot/handlers/moderator/source_candidates.py
@@ -3,8 +3,8 @@ from telegram.error import BadRequest
 from telegram.ext import ContextTypes
 
 from src.storage.source_voting import record_source_candidate_vote
-from src.tgbot.constants import UserType
 from src.tgbot.handlers.moderator.meme_source import meme_source_admin_pipeline
+from src.tgbot.handlers.moderator.permissions import get_moderator_user_info
 from src.tgbot.logs import log
 from src.tgbot.senders.keyboards import (
     source_candidate_actions_keyboard,
@@ -16,7 +16,6 @@ from src.tgbot.service import (
     list_pending_source_candidates,
     promote_source_candidate,
 )
-from src.tgbot.user_info import get_user_info
 
 _LIST_LIMIT = 20
 
@@ -29,8 +28,8 @@ async def handle_discovered_sources_command(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
 ) -> None:
-    user_info = await get_user_info(update.effective_user.id)
-    if not UserType(user_info["type"]).is_moderator:
+    if await get_moderator_user_info(update.effective_user.id) is None:
+        await update.message.reply_text("Only moderators can list source candidates.")
         return
 
     candidates = await list_pending_source_candidates(limit=_LIST_LIMIT)
@@ -55,8 +54,7 @@ async def handle_source_candidate_action(
     context: ContextTypes.DEFAULT_TYPE,
 ) -> None:
     user_id = update.effective_user.id
-    user_info = await get_user_info(user_id)
-    if not UserType(user_info["type"]).is_moderator:
+    if await get_moderator_user_info(user_id) is None:
         await update.callback_query.answer("🤷‍♀️ Only moderators can act on source candidates 🤷‍♂️")
         return
 

--- a/tests/storage/test_etl_candidates.py
+++ b/tests/storage/test_etl_candidates.py
@@ -12,6 +12,9 @@ from src.storage.etl import normalize_telegram_channel_url
         ("https://t.me/somechannel/12345", "https://t.me/somechannel"),
         ("https://t.me/s/somechannel/12345", "https://t.me/somechannel"),
         ("http://t.me/somechannel/12345", "https://t.me/somechannel"),
+        ("t.me/somechannel/12345", "https://t.me/somechannel"),
+        ("telegram.me/somechannel/12345", "https://t.me/somechannel"),
+        ("https://telegram.me/somechannel/12345", "https://t.me/somechannel"),
         # Query strings and fragments must collapse onto the canonical form so
         # manual moderator entries dedupe against discovery-pipeline candidates.
         ("https://t.me/somechannel?utm_source=share", "https://t.me/somechannel"),

--- a/tests/tgbot/test_meme_source_handler.py
+++ b/tests/tgbot/test_meme_source_handler.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.storage.constants import MemeSourceType
+from src.tgbot.handlers.moderator import meme_source
+
+
+@pytest.mark.parametrize(
+    "text,expected_url,expected_type",
+    [
+        (
+            "https://t.me/cozy_abomination",
+            "https://t.me/cozy_abomination",
+            MemeSourceType.TELEGRAM,
+        ),
+        (
+            "t.me/Cozy_Abomination/42?single",
+            "https://t.me/cozy_abomination",
+            MemeSourceType.TELEGRAM,
+        ),
+        (
+            "source: http://telegram.me/Cozy_Abomination/42",
+            "https://t.me/cozy_abomination",
+            MemeSourceType.TELEGRAM,
+        ),
+        (
+            "https://vk.com/example_group?from=share",
+            "https://vk.com/example_group",
+            MemeSourceType.VK,
+        ),
+        (
+            "https://www.instagram.com/example.page/?utm_source=ig_web_copy_link",
+            "https://www.instagram.com/example.page/",
+            MemeSourceType.INSTAGRAM,
+        ),
+    ],
+)
+def test_parse_meme_source_link_accepts_common_source_formats(
+    text: str,
+    expected_url: str,
+    expected_type: MemeSourceType,
+) -> None:
+    parsed = meme_source.parse_meme_source_link(text)
+
+    assert parsed is not None
+    assert parsed.url == expected_url
+    assert parsed.type == expected_type
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://t.me/+private_invite",
+        "https://t.me/joinchat/abcdef",
+        "just a message",
+        "",
+    ],
+)
+def test_parse_meme_source_link_rejects_unsupported_sources(text: str) -> None:
+    assert meme_source.parse_meme_source_link(text) is None
+
+
+@pytest.mark.asyncio
+async def test_handle_meme_source_link_refreshes_to_moderator_and_opens_admin_card() -> None:
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1007266539),
+        message=SimpleNamespace(
+            text="please add t.me/Cozy_Abomination/42?single",
+            reply_text=AsyncMock(),
+        ),
+    )
+    context = SimpleNamespace()
+    source_row = {"id": 123, "url": "https://t.me/cozy_abomination"}
+
+    with (
+        patch(
+            "src.tgbot.handlers.moderator.meme_source.get_moderator_user_info",
+            new=AsyncMock(return_value={"type": "moderator"}),
+        ),
+        patch(
+            "src.tgbot.handlers.moderator.meme_source.get_or_create_meme_source",
+            new=AsyncMock(return_value=source_row),
+        ) as get_or_create,
+        patch(
+            "src.tgbot.handlers.moderator.meme_source.meme_source_admin_pipeline",
+            new=AsyncMock(),
+        ) as admin_pipeline,
+    ):
+        await meme_source.handle_meme_source_link(update, context)
+
+    get_or_create.assert_awaited_once()
+    assert get_or_create.await_args.kwargs["url"] == "https://t.me/cozy_abomination"
+    assert get_or_create.await_args.kwargs["type"] == MemeSourceType.TELEGRAM
+    admin_pipeline.assert_awaited_once_with(source_row, update)
+    update.message.reply_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_meme_source_link_tells_non_moderator_why_nothing_happens() -> None:
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=42),
+        message=SimpleNamespace(text="https://t.me/cozy_abomination", reply_text=AsyncMock()),
+    )
+    context = SimpleNamespace()
+
+    with patch(
+        "src.tgbot.handlers.moderator.meme_source.get_moderator_user_info",
+        new=AsyncMock(return_value=None),
+    ):
+        await meme_source.handle_meme_source_link(update, context)
+
+    update.message.reply_text.assert_awaited_once_with("Only moderators can manage meme sources.")

--- a/tests/tgbot/test_moderator_permissions.py
+++ b/tests/tgbot/test_moderator_permissions.py
@@ -1,0 +1,34 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.tgbot.exceptions import UserNotFound
+from src.tgbot.handlers.moderator.permissions import get_moderator_user_info
+
+
+@pytest.mark.asyncio
+async def test_get_moderator_user_info_refreshes_stale_non_moderator_cache() -> None:
+    with (
+        patch(
+            "src.tgbot.handlers.moderator.permissions.get_user_info",
+            new=AsyncMock(return_value={"type": "user"}),
+        ),
+        patch(
+            "src.tgbot.handlers.moderator.permissions.update_user_info_cache",
+            new=AsyncMock(return_value={"type": "moderator"}),
+        ) as refresh,
+    ):
+        user_info = await get_moderator_user_info(1007266539)
+
+    refresh.assert_awaited_once_with(1007266539)
+    assert user_info is not None
+    assert user_info["type"] == "moderator"
+
+
+@pytest.mark.asyncio
+async def test_get_moderator_user_info_denies_missing_user() -> None:
+    with patch(
+        "src.tgbot.handlers.moderator.permissions.get_user_info",
+        new=AsyncMock(side_effect=UserNotFound(42)),
+    ):
+        assert await get_moderator_user_info(42) is None


### PR DESCRIPTION
## Summary
- refresh moderator permissions from DB before denying source-admin actions so role grants are not blocked by stale Redis cache
- accept common source link formats such as t.me/..., telegram.me/..., http://t.me/... and links embedded in text
- grant @mearsm (1007266539) moderator/source-management access via migration

## Tests
- python -m pytest tests/tgbot/test_meme_source_handler.py tests/tgbot/test_moderator_permissions.py tests/storage/test_etl_candidates.py -q
- python -m ruff check src/tgbot/handlers/moderator src/storage/etl.py tests/tgbot/test_meme_source_handler.py tests/tgbot/test_moderator_permissions.py tests/storage/test_etl_candidates.py alembic/versions/2026-05-25_grant_mearsm_source_moderation.py
- DATABASE_URL=postgresql+asyncpg://app:app@localhost:65432/app REDIS_URL=redis://:myStrongPassword@localhost:36379 ... alembic upgrade head