### PR TITLE
Fix meme source status callbacks

### DIFF
--- a/src/tgbot/constants.py
+++ b/src/tgbot/constants.py
@@ -40,7 +40,7 @@ MEME_SOURCE_SET_LANG_PATTERN = "ms:{meme_source_id}:set_lang:{lang_code}"
 MEME_SOURCE_SET_LANG_REGEXP = r"^ms:\d+:set_lang:\w{2}$"
 
 MEME_SOURCE_SET_STATUS_PATTERN = "ms:{meme_source_id}:set_status:{status}"
-MEME_SOURCE_SET_STATUS_REGEXP = r"^ms:\d+:set_status:\w+$"
+MEME_SOURCE_SET_STATUS_REGEXP = r"^ms:\d+:set_status:(?:\w+|MemeSourceStatus\.\w+)$"
 
 # Source-candidate (discovered from forwarded TG posts) approval buttons.
 SOURCE_CANDIDATE_ACTION_PATTERN = "msc:{candidate_id}:{action}"

--- a/src/tgbot/handlers/broken.py
+++ b/src/tgbot/handlers/broken.py
@@ -7,6 +7,22 @@ from telegram.ext import (
     ContextTypes,
 )
 
+from src import localizer
+from src.tgbot.exceptions import UserNotFound
+from src.tgbot.user_info import get_user_info
+
+
+async def _get_interface_lang(update: Update) -> str | None:
+    if update.effective_user is None:
+        return None
+
+    try:
+        user_info = await get_user_info(update.effective_user.id)
+    except UserNotFound:
+        return update.effective_user.language_code
+
+    return user_info["interface_lang"] or update.effective_user.language_code
+
 
 async def handle_broken_callback_query(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     import sys
@@ -14,4 +30,5 @@ async def handle_broken_callback_query(update: Update, context: ContextTypes.DEF
     cb = update.callback_query.data if update.callback_query else "none"
     sys.stderr.write(f"[broken] catch-all fired: cb={cb}\n")
     sys.stderr.flush()
-    await update.effective_user.send_message("🔄 The bot was updated. Press /start to continue.")
+    lang = await _get_interface_lang(update)
+    await update.effective_user.send_message(localizer.t("service.bot_updated", lang))

--- a/src/tgbot/handlers/moderator/meme_source.py
+++ b/src/tgbot/handlers/moderator/meme_source.py
@@ -68,6 +68,15 @@ def parse_meme_source_link(text: str | None) -> MemeSourceLink | None:
     return None
 
 
+def parse_meme_source_status_callback_data(data: str) -> tuple[int, str]:
+    _, meme_source_id, _, raw_status = data.split(":", maxsplit=3)
+    if raw_status.startswith("MemeSourceStatus."):
+        status_name = raw_status.split(".", maxsplit=1)[1]
+        return int(meme_source_id), MemeSourceStatus[status_name].value
+
+    return int(meme_source_id), raw_status
+
+
 async def handle_meme_source_link(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if await get_moderator_user_info(update.effective_user.id) is None:
         await update.message.reply_text("Only moderators can manage meme sources.")
@@ -129,8 +138,11 @@ async def handle_meme_source_change_status(
         await update.callback_query.answer("🤷‍♀️ Only moderators can change meme source status 🤷‍♂️")  # noqa: E501
         return
 
-    args = update.callback_query.data.split(":")
-    meme_source_id, status = int(args[1]), args[3]
+    try:
+        meme_source_id, status = parse_meme_source_status_callback_data(update.callback_query.data)
+    except (IndexError, KeyError, ValueError):
+        await update.callback_query.answer("Invalid meme source status action")
+        return
 
     try:
         # `trigger_parse=False` keeps parse-after-UI ordering: we want the

--- a/src/tgbot/senders/keyboards.py
+++ b/src/tgbot/senders/keyboards.py
@@ -9,6 +9,7 @@ from src.tgbot.constants import (
     MEME_BUTTON_CALLBACK_DATA_PATTERN,
     MEME_QUEUE_IS_EMPTY_ALERT_CALLBACK_DATA,
     MEME_SOURCE_SET_LANG_PATTERN,
+    MEME_SOURCE_SET_STATUS_PATTERN,
     SOURCE_CANDIDATE_ACTION_PATTERN,
     SOURCE_CANDIDATE_VOTE_PATTERN,
     Reaction,
@@ -124,14 +125,17 @@ def meme_source_language_selection_keyboard(meme_source_id: int):
 
 def meme_source_change_status_keyboard(
     meme_source_id: int,
-    current_status: MemeSourceStatus | None = None,
+    current_status: MemeSourceStatus | str | None = None,
 ):
     return InlineKeyboardMarkup(
         [
             [
                 InlineKeyboardButton(
-                    f"➡️ {status}",
-                    callback_data=f"ms:{meme_source_id}:set_status:{status}",
+                    f"➡️ {status.value}",
+                    callback_data=MEME_SOURCE_SET_STATUS_PATTERN.format(
+                        meme_source_id=meme_source_id,
+                        status=status.value,
+                    ),
                 )
             ]
             for status in MemeSourceStatus

--- a/static/localization/service.yml
+++ b/static/localization/service.yml
@@ -51,4 +51,11 @@ service.out_of_memes:
     🚀 आपने जोक्स देख लिए हैं जो हमने आपके लिए तैयार किए हैं! 
     
     कल वापस आइए और अधिक देखें या अधिक भाषाएँ जोड़ें: /lang. 🍔
-  
+
+service.bot_updated:
+  en: |-
+    🔄 The bot was updated. Press /start to continue.
+  ru: |-
+    🔄 Бот обновился. Нажми /start, чтобы продолжить.
+  uk: |-
+    🔄 Бот оновився. Натисни /start, щоб продовжити.

--- a/tests/tgbot/test_broken_handler.py
+++ b/tests/tgbot/test_broken_handler.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.tgbot.handlers import broken
+
+
+@pytest.mark.asyncio
+async def test_broken_callback_query_uses_user_interface_language() -> None:
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=49820636, language_code="en", send_message=AsyncMock()),
+        callback_query=SimpleNamespace(data="ms:203:set_status:old-value"),
+    )
+    context = SimpleNamespace()
+
+    with patch(
+        "src.tgbot.handlers.broken.get_user_info",
+        new=AsyncMock(return_value={"interface_lang": "ru"}),
+    ):
+        await broken.handle_broken_callback_query(update, context)
+
+    update.effective_user.send_message.assert_awaited_once_with(
+        "🔄 Бот обновился. Нажми /start, чтобы продолжить."
+    )

--- a/tests/tgbot/test_meme_source_handler.py
+++ b/tests/tgbot/test_meme_source_handler.py
@@ -1,10 +1,13 @@
+import re
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from src.storage.constants import MemeSourceType
+from src.storage.constants import MemeSourceStatus, MemeSourceType
+from src.tgbot.constants import MEME_SOURCE_SET_STATUS_REGEXP
 from src.tgbot.handlers.moderator import meme_source
+from src.tgbot.senders.keyboards import meme_source_change_status_keyboard
 
 
 @pytest.mark.parametrize(
@@ -60,6 +63,41 @@ def test_parse_meme_source_link_accepts_common_source_formats(
 )
 def test_parse_meme_source_link_rejects_unsupported_sources(text: str) -> None:
     assert meme_source.parse_meme_source_link(text) is None
+
+
+def test_meme_source_status_keyboard_uses_stable_callback_values() -> None:
+    keyboard = meme_source_change_status_keyboard(
+        meme_source_id=203,
+        current_status=MemeSourceStatus.PARSING_ENABLED.value,
+    )
+
+    buttons = [row[0] for row in keyboard.inline_keyboard]
+    callback_data = [button.callback_data for button in buttons]
+
+    assert "ms:203:set_status:snoozed" in callback_data
+    assert "ms:203:set_status:parsing_enabled" not in callback_data
+    assert all(re.match(MEME_SOURCE_SET_STATUS_REGEXP, data) for data in callback_data)
+    assert all("MemeSourceStatus." not in data for data in callback_data)
+    assert {button.text for button in buttons} == {
+        "➡️ in_moderation",
+        "➡️ parsing_disabled",
+        "➡️ snoozed",
+    }
+
+
+@pytest.mark.parametrize(
+    "callback_data,expected",
+    [
+        ("ms:203:set_status:snoozed", (203, "snoozed")),
+        ("ms:203:set_status:MemeSourceStatus.SNOOZED", (203, "snoozed")),
+    ],
+)
+def test_parse_meme_source_status_callback_data_accepts_current_and_legacy_buttons(
+    callback_data: str,
+    expected: tuple[int, str],
+) -> None:
+    assert re.match(MEME_SOURCE_SET_STATUS_REGEXP, callback_data)
+    assert meme_source.parse_meme_source_status_callback_data(callback_data) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- generate meme source status callback_data from enum values instead of enum reprs
- accept legacy MemeSourceStatus.* callback payloads from already-sent admin cards
- localize the generic stale callback fallback message

## Tests
- DATABASE_URL=postgresql+asyncpg://app:app@localhost:65432/app REDIS_URL=redis://:myStrongPassword@localhost:36379 CORS_ORIGINS='[]' CORS_HEADERS='[]' TELEGRAM_BOT_TOKEN=test TELEGRAM_ADMIN_BOT_TOKEN=test OPENROUTER_API_KEY=test python -m pytest tests/ -x -q
- python -m ruff check src tests
- python -m ruff format --check src tests