### PR TITLE
Fix: exclude blocked users from ghost monitor

### DIFF
--- a/src/flows/monitors/ghost_users.py
+++ b/src/flows/monitors/ghost_users.py
@@ -6,7 +6,8 @@ this monitor existed we only learned about ghosts when a friend of
 @ohld complained.
 
 Definition: a ghost is a `user` row created N seconds ago with no
-`user_meme_reaction` row. Two severities, both filtered by
+`user_meme_reaction` row, excluding users who have blocked the bot.
+Two severities, both filtered by
 `user_tg.deep_link` to exclude blocked acquisition channels (where
 silent drop is by design):
 
@@ -71,6 +72,7 @@ def _ghost_count_sql() -> str:
             WHERE u.created_at BETWEEN NOW() - INTERVAL '25 minutes'
                                   AND NOW() - INTERVAL '60 seconds'
               AND u.type NOT IN ('blocked_bot', 'banned', 'waitlist')
+              AND u.blocked_bot_at IS NULL
               AND NOT EXISTS (
                   SELECT 1 FROM user_meme_reaction r WHERE r.user_id = u.id
               )


### PR DESCRIPTION
Fixes FFM-1409.

## What
- Adds `u.blocked_bot_at IS NULL` to the ghost-user monitor candidate filter.
- Updates the monitor definition comment so current bot blockers are explicitly excluded.

## Why
PR #297 preserved normal user roles when users block the bot, moving current block state to `blocked_bot_at`. The ghost monitor still only excluded legacy `type = blocked_bot`, so new users who blocked the bot before receiving a meme could produce false WARN/ERROR alerts.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/db REDIS_URL=redis://localhost:6379/0 CORS_ORIGINS=["*"] CORS_HEADERS=["*"] TELEGRAM_BOT_TOKEN=123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh python3 -c "from src.flows.monitors.ghost_users import _ghost_count_sql; sql = _ghost_count_sql(); assert 'u.blocked_bot_at IS NULL' in sql; assert \"u.type NOT IN ('blocked_bot', 'banned', 'waitlist')\" in sql; print('ghost SQL excludes blocked_bot_at users')"`