### PR TITLE
Localize source admin controls

### DIFF
--- a/src/tgbot/handlers/moderator/meme_source.py
+++ b/src/tgbot/handlers/moderator/meme_source.py
@@ -1,11 +1,14 @@
 import re
 from dataclasses import dataclass
+from html import escape as html_escape
+from typing import Any
 
 from telegram import Message, Update
 from telegram.ext import (
     ContextTypes,
 )
 
+from src import localizer
 from src.flows.parsers.tg import parse_telegram_source
 from src.flows.parsers.vk import parse_vk_source
 from src.storage.constants import MemeSourceStatus, MemeSourceType
@@ -31,6 +34,11 @@ MEME_SOURCE_LINK_REGEXP = (
 )
 
 _MEME_SOURCE_LINK_RE = re.compile(MEME_SOURCE_LINK_REGEXP)
+
+
+def _t(key: str, lang: str | None, **kwargs: object) -> str:
+    text = localizer.t(key, lang)
+    return text.format(**kwargs) if kwargs else text
 
 
 @dataclass(frozen=True)
@@ -78,13 +86,15 @@ def parse_meme_source_status_callback_data(data: str) -> tuple[int, str]:
 
 
 async def handle_meme_source_link(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if await get_moderator_user_info(update.effective_user.id) is None:
-        await update.message.reply_text("Only moderators can manage meme sources.")
+    moderator = await get_moderator_user_info(update.effective_user.id)
+    lang = _get_moderator_lang(update, moderator)
+    if moderator is None:
+        await update.message.reply_text(_t("moderator.meme_source.only_moderators_manage", lang))
         return
 
     link = parse_meme_source_link(update.message.text)
     if link is None:
-        await update.message.reply_text("Unsupported meme source")
+        await update.message.reply_text(_t("moderator.meme_source.unsupported_source", lang))
         return
 
     meme_source = await get_or_create_meme_source(
@@ -94,17 +104,19 @@ async def handle_meme_source_link(update: Update, context: ContextTypes.DEFAULT_
         added_by=update.effective_user.id,
     )
 
-    await meme_source_admin_pipeline(meme_source, update)
+    await meme_source_admin_pipeline(meme_source, update, lang)
 
 
 async def handle_meme_source_language_selection(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     user_id = update.effective_user.id
-    if await get_moderator_user_info(user_id) is None:
+    moderator = await get_moderator_user_info(user_id)
+    lang = _get_moderator_lang(update, moderator)
+    if moderator is None:
         await update.callback_query.answer(
-            "🤷‍♀️ Only moderators can change meme source language 🤷‍♂️"
-        )  # noqa: E501
+            _t("moderator.meme_source.only_moderators_language", lang)
+        )
         return
 
     args = update.callback_query.data.split(":")
@@ -118,7 +130,7 @@ async def handle_meme_source_language_selection(
             trigger_parse=False,
         )
     except MemeSourceNotFoundError:
-        await update.callback_query.answer("Meme source not found")
+        await update.callback_query.answer(_t("moderator.meme_source.not_found", lang))
         return
 
     await log(
@@ -126,22 +138,26 @@ async def handle_meme_source_language_selection(
         context.bot,
     )
 
-    await update.callback_query.answer(f"Meme source lang is {lang_code} now")
-    await meme_source_admin_pipeline(result["source"], update)
+    await update.callback_query.answer(
+        _t("moderator.meme_source.language_updated", lang, language=lang_code)
+    )
+    await meme_source_admin_pipeline(result["source"], update, lang)
 
 
 async def handle_meme_source_change_status(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     user_id = update.effective_user.id
-    if await get_moderator_user_info(user_id) is None:
-        await update.callback_query.answer("🤷‍♀️ Only moderators can change meme source status 🤷‍♂️")  # noqa: E501
+    moderator = await get_moderator_user_info(user_id)
+    lang = _get_moderator_lang(update, moderator)
+    if moderator is None:
+        await update.callback_query.answer(_t("moderator.meme_source.only_moderators_status", lang))
         return
 
     try:
         meme_source_id, status = parse_meme_source_status_callback_data(update.callback_query.data)
     except (IndexError, KeyError, ValueError):
-        await update.callback_query.answer("Invalid meme source status action")
+        await update.callback_query.answer(_t("moderator.meme_source.invalid_status_action", lang))
         return
 
     try:
@@ -154,7 +170,9 @@ async def handle_meme_source_change_status(
             trigger_parse=False,
         )
     except MemeSourceNotFoundError:
-        await update.callback_query.answer(f"Meme source {meme_source_id} not found")
+        await update.callback_query.answer(
+            _t("moderator.meme_source.not_found_by_id", lang, source_id=meme_source_id)
+        )
         return
     except ValueError as e:
         await update.callback_query.answer(str(e)[:180])
@@ -162,7 +180,12 @@ async def handle_meme_source_change_status(
 
     if result["unsnoozed_count"]:
         await update.effective_chat.send_message(
-            f"Unsnoozed {result['unsnoozed_count']} memes of {meme_source_id}"
+            _t(
+                "moderator.meme_source.unsnoozed_memes",
+                lang,
+                count=result["unsnoozed_count"],
+                source_id=meme_source_id,
+            )
         )
 
     await log(
@@ -170,8 +193,14 @@ async def handle_meme_source_change_status(
         context.bot,
     )
 
-    await update.callback_query.answer(f"Meme source status is {status} now")
-    await meme_source_admin_pipeline(result["source"], update)
+    await update.callback_query.answer(
+        _t(
+            "moderator.meme_source.status_updated",
+            lang,
+            status=_status_label(status, lang),
+        )
+    )
+    await meme_source_admin_pipeline(result["source"], update, lang)
 
     meme_source = result["source"]
     if status == MemeSourceStatus.PARSING_ENABLED:  # trigger parsing
@@ -183,57 +212,127 @@ async def handle_meme_source_change_status(
 
     if result["snoozed_count"]:
         await update.effective_chat.send_message(
-            f"Snoozed {result['snoozed_count']} memes of {meme_source_id}"
+            _t(
+                "moderator.meme_source.snoozed_memes",
+                lang,
+                count=result["snoozed_count"],
+                source_id=meme_source_id,
+            )
         )
 
 
-def _get_meme_source_info(meme_source: dict) -> str:
-    return f"""
-id: {meme_source["id"]}
-url: {meme_source["url"]}
-type: {meme_source["type"]}
-language: {meme_source["language_code"]}
-added by: {meme_source["added_by"]}
-<b>status</b>: {meme_source["status"]}
-    """
-
-    # Column("nlikes", Integer, nullable=False, server_default="0"),
-    # Column("ndislikes", Integer, nullable=False, server_default="0"),
-    # Column("nmemes_sent_events", Integer, nullable=False, server_default="0"),
-    # Column("nmemes_parsed", Integer, nullable=False, server_default="0"),
-    # Column("nmemes_sent", Integer, nullable=False, server_default="0"),
-    # Column("latest_meme_age", Integer, nullable=False, server_default="0"),
+def _get_moderator_lang(
+    update: Update,
+    moderator_info: dict[str, Any] | None = None,
+) -> str | None:
+    if moderator_info and moderator_info.get("interface_lang"):
+        return str(moderator_info["interface_lang"])
+    if update.effective_user and getattr(update.effective_user, "language_code", None):
+        return update.effective_user.language_code
+    return "ru"
 
 
-def _get_meme_source_stats_info(meme_source_stats: dict) -> str:
-    return f"""
-likes: {meme_source_stats["nlikes"]}
-dislikes: {meme_source_stats["ndislikes"]}
-memes sent events: {meme_source_stats["nmemes_sent_events"]}
-memes parsed: {meme_source_stats["nmemes_parsed"]}
-memes sent: {meme_source_stats["nmemes_sent"]}
-latest meme age: {meme_source_stats["latest_meme_age"]}
-    """
+def _html(value: object) -> str:
+    if value is None:
+        return "—"
+    return html_escape(str(value), quote=False)
+
+
+def _source_type_label(source_type: object) -> str:
+    value = getattr(source_type, "value", source_type)
+    if value == MemeSourceType.TELEGRAM.value:
+        return "Telegram"
+    if value == MemeSourceType.INSTAGRAM.value:
+        return "Instagram"
+    if value == MemeSourceType.VK.value:
+        return "VK"
+    return _html(value)
+
+
+def _status_label(status: object, lang: str | None) -> str:
+    value = getattr(status, "value", status)
+    try:
+        return localizer.t(f"moderator.meme_source.status.{value}", lang)
+    except KeyError:
+        return _html(value)
+
+
+def _format_int(value: object) -> str:
+    try:
+        return f"{int(value):,}".replace(",", " ")
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _format_latest_age(value: object, lang: str | None) -> str:
+    try:
+        days = int(value)
+    except (TypeError, ValueError):
+        return "—"
+
+    if days <= 0:
+        return localizer.t("moderator.meme_source.today", lang)
+
+    return _t("moderator.meme_source.days_short", lang, days=days)
+
+
+def _get_meme_source_info(meme_source: dict, lang: str | None) -> str:
+    source_type = _source_type_label(meme_source["type"])
+    language = _html(meme_source["language_code"])
+    added_by = _html(meme_source["added_by"])
+    status = _status_label(meme_source["status"], lang)
+
+    return _t(
+        "moderator.meme_source.card",
+        lang,
+        id=_html(meme_source["id"]),
+        type=source_type,
+        language=language,
+        url=_html(meme_source["url"]),
+        status=status,
+        added_by=added_by,
+    )
+
+
+def _get_meme_source_stats_info(meme_source_stats: dict, lang: str | None) -> str:
+    return _t(
+        "moderator.meme_source.stats",
+        lang,
+        likes=_format_int(meme_source_stats["nlikes"]),
+        dislikes=_format_int(meme_source_stats["ndislikes"]),
+        sent_events=_format_int(meme_source_stats["nmemes_sent_events"]),
+        parsed=_format_int(meme_source_stats["nmemes_parsed"]),
+        sent=_format_int(meme_source_stats["nmemes_sent"]),
+        latest_age=_format_latest_age(meme_source_stats["latest_meme_age"], lang),
+    )
 
 
 async def meme_source_admin_pipeline(
     meme_source: dict,
     update: Update,
+    lang: str | None = None,
 ) -> Message:
-    ms_info = _get_meme_source_info(meme_source)
+    if lang is None:
+        lang = _get_moderator_lang(update)
+
+    ms_info = _get_meme_source_info(meme_source, lang)
     ms_stats = await get_meme_source_stats_by_id(meme_source["id"])
     if ms_stats:
-        ms_info += _get_meme_source_stats_info(ms_stats)
+        ms_info += "\n\n" + _get_meme_source_stats_info(ms_stats, lang)
 
     if meme_source["language_code"] is None:
         return await send_or_edit(
             update,
-            text=f"""{ms_info}\nPlease select a language for {meme_source["url"]}""",
+            text=f"{ms_info}\n\n{localizer.t('moderator.meme_source.select_language', lang)}",
             reply_markup=meme_source_language_selection_keyboard(meme_source_id=meme_source["id"]),
         )
 
     return await send_or_edit(
         update,
         text=ms_info,
-        reply_markup=meme_source_change_status_keyboard(meme_source["id"], meme_source["status"]),
+        reply_markup=meme_source_change_status_keyboard(
+            meme_source["id"],
+            meme_source["status"],
+            lang,
+        ),
     )

--- a/src/tgbot/senders/keyboards.py
+++ b/src/tgbot/senders/keyboards.py
@@ -2,6 +2,7 @@ import random
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
+from src import localizer
 from src.storage.constants import (
     MemeSourceStatus,
 )
@@ -126,12 +127,13 @@ def meme_source_language_selection_keyboard(meme_source_id: int):
 def meme_source_change_status_keyboard(
     meme_source_id: int,
     current_status: MemeSourceStatus | str | None = None,
+    lang: str | None = "ru",
 ):
     return InlineKeyboardMarkup(
         [
             [
                 InlineKeyboardButton(
-                    f"➡️ {status.value}",
+                    localizer.t(f"moderator.meme_source.action.{status.value}", lang),
                     callback_data=MEME_SOURCE_SET_STATUS_PATTERN.format(
                         meme_source_id=meme_source_id,
                         status=status.value,

--- a/static/localization/moderator.yml
+++ b/static/localization/moderator.yml
@@ -1,0 +1,140 @@
+moderator.meme_source.only_moderators_manage:
+  en: Only moderators can manage meme sources.
+  ru: Только модераторы могут управлять источниками мемов.
+  uk: Тільки модератори можуть керувати джерелами мемів.
+
+moderator.meme_source.unsupported_source:
+  en: I do not recognize this meme source. Send a Telegram, VK, or Instagram link.
+  ru: Не узнаю этот источник. Пришли ссылку на Telegram, VK или Instagram.
+  uk: Не впізнаю це джерело. Надішли посилання на Telegram, VK або Instagram.
+
+moderator.meme_source.only_moderators_language:
+  en: Only moderators can change the source language.
+  ru: Только модераторы могут менять язык источника.
+  uk: Тільки модератори можуть змінювати мову джерела.
+
+moderator.meme_source.only_moderators_status:
+  en: Only moderators can change the source status.
+  ru: Только модераторы могут менять статус источника.
+  uk: Тільки модератори можуть змінювати статус джерела.
+
+moderator.meme_source.not_found:
+  en: Source not found.
+  ru: Источник не найден.
+  uk: Джерело не знайдено.
+
+moderator.meme_source.not_found_by_id:
+  en: Source #{source_id} not found.
+  ru: Источник #{source_id} не найден.
+  uk: Джерело #{source_id} не знайдено.
+
+moderator.meme_source.invalid_status_action:
+  en: This source action is no longer valid. Send the source link again.
+  ru: Эта кнопка уже неактуальна. Пришли ссылку на источник ещё раз.
+  uk: Ця кнопка вже неактуальна. Надішли посилання на джерело ще раз.
+
+moderator.meme_source.language_updated:
+  en: Language set to {language}.
+  ru: "Язык источника: {language}."
+  uk: "Мова джерела: {language}."
+
+moderator.meme_source.status_updated:
+  en: "Status changed: {status}."
+  ru: "Статус изменён: {status}."
+  uk: "Статус змінено: {status}."
+
+moderator.meme_source.unsnoozed_memes:
+  en: Returned {count} memes from source #{source_id}.
+  ru: Вернул {count} мемов из источника #{source_id}.
+  uk: Повернув {count} мемів із джерела #{source_id}.
+
+moderator.meme_source.snoozed_memes:
+  en: Hidden {count} memes from source #{source_id}.
+  ru: Спрятал {count} мемов из источника #{source_id}.
+  uk: Сховав {count} мемів із джерела #{source_id}.
+
+moderator.meme_source.select_language:
+  en: "Choose the source language:"
+  ru: "Выбери язык источника:"
+  uk: "Обери мову джерела:"
+
+moderator.meme_source.card:
+  en: |-
+    <b>Source #{id}</b> · {type} · {language}
+    {url}
+
+    <b>Status:</b> {status}
+    <b>Added by:</b> {added_by}
+  ru: |-
+    <b>Источник #{id}</b> · {type} · {language}
+    {url}
+
+    <b>Статус:</b> {status}
+    <b>Добавил:</b> {added_by}
+  uk: |-
+    <b>Джерело #{id}</b> · {type} · {language}
+    {url}
+
+    <b>Статус:</b> {status}
+    <b>Додав:</b> {added_by}
+
+moderator.meme_source.stats:
+  en: |-
+    👍 {likes} · 👎 {dislikes} · sends {sent_events}
+    Memes: {parsed} parsed · {sent} shown · latest {latest_age}
+  ru: |-
+    👍 {likes} · 👎 {dislikes} · отправок {sent_events}
+    Мемы: {parsed} собрано · {sent} показано · свежесть {latest_age}
+  uk: |-
+    👍 {likes} · 👎 {dislikes} · відправок {sent_events}
+    Меми: {parsed} зібрано · {sent} показано · свіжість {latest_age}
+
+moderator.meme_source.today:
+  en: today
+  ru: сегодня
+  uk: сьогодні
+
+moderator.meme_source.days_short:
+  en: "{days}d"
+  ru: "{days} дн."
+  uk: "{days} дн."
+
+moderator.meme_source.status.in_moderation:
+  en: in moderation
+  ru: на модерации
+  uk: на модерації
+
+moderator.meme_source.status.parsing_enabled:
+  en: parsing enabled, memes are shown
+  ru: парсинг включён, мемы показываются
+  uk: парсинг увімкнено, меми показуються
+
+moderator.meme_source.status.parsing_disabled:
+  en: parsing paused, old memes can still be shown
+  ru: парсинг на паузе, старые мемы ещё показываются
+  uk: парсинг на паузі, старі меми ще показуються
+
+moderator.meme_source.status.snoozed:
+  en: source disabled, its memes are hidden
+  ru: источник выключен, его мемы скрыты
+  uk: джерело вимкнено, його меми приховані
+
+moderator.meme_source.action.in_moderation:
+  en: 🕓 Send to moderation
+  ru: 🕓 На модерацию
+  uk: 🕓 На модерацію
+
+moderator.meme_source.action.parsing_enabled:
+  en: ✅ Enable parsing
+  ru: ✅ Включить парсинг
+  uk: ✅ Увімкнути парсинг
+
+moderator.meme_source.action.parsing_disabled:
+  en: ⏸ Stop parsing
+  ru: ⏸ Остановить парсинг
+  uk: ⏸ Зупинити парсинг
+
+moderator.meme_source.action.snoozed:
+  en: ⛔ Disable source
+  ru: ⛔ Выключить источник
+  uk: ⛔ Вимкнути джерело

--- a/tests/tgbot/test_meme_source_handler.py
+++ b/tests/tgbot/test_meme_source_handler.py
@@ -79,9 +79,9 @@ def test_meme_source_status_keyboard_uses_stable_callback_values() -> None:
     assert all(re.match(MEME_SOURCE_SET_STATUS_REGEXP, data) for data in callback_data)
     assert all("MemeSourceStatus." not in data for data in callback_data)
     assert {button.text for button in buttons} == {
-        "➡️ in_moderation",
-        "➡️ parsing_disabled",
-        "➡️ snoozed",
+        "🕓 На модерацию",
+        "⏸ Остановить парсинг",
+        "⛔ Выключить источник",
     }
 
 
@@ -100,10 +100,43 @@ def test_parse_meme_source_status_callback_data_accepts_current_and_legacy_butto
     assert meme_source.parse_meme_source_status_callback_data(callback_data) == expected
 
 
+def test_meme_source_admin_card_is_compact_and_localized_ru() -> None:
+    source = {
+        "id": 203,
+        "url": "https://t.me/cozy_abomination",
+        "type": MemeSourceType.TELEGRAM.value,
+        "language_code": "uk",
+        "added_by": None,
+        "status": MemeSourceStatus.PARSING_ENABLED.value,
+    }
+    stats = {
+        "nlikes": 14257,
+        "ndislikes": 24803,
+        "nmemes_sent_events": 40255,
+        "nmemes_parsed": 3335,
+        "nmemes_sent": 2947,
+        "latest_meme_age": 1,
+    }
+
+    text = (
+        meme_source._get_meme_source_info(source, "ru")
+        + "\n\n"
+        + meme_source._get_meme_source_stats_info(stats, "ru")
+    )
+
+    assert "<b>Источник #203</b> · Telegram · uk" in text
+    assert "<b>Статус:</b> парсинг включён, мемы показываются" in text
+    assert "<b>Добавил:</b> —" in text
+    assert "👍 14 257 · 👎 24 803 · отправок 40 255" in text
+    assert "Мемы: 3 335 собрано · 2 947 показано · свежесть 1 дн." in text
+    assert "memes parsed" not in text
+    assert len([line for line in text.splitlines() if line.strip()]) == 6
+
+
 @pytest.mark.asyncio
 async def test_handle_meme_source_link_refreshes_to_moderator_and_opens_admin_card() -> None:
     update = SimpleNamespace(
-        effective_user=SimpleNamespace(id=1007266539),
+        effective_user=SimpleNamespace(id=1007266539, language_code="ru"),
         message=SimpleNamespace(
             text="please add t.me/Cozy_Abomination/42?single",
             reply_text=AsyncMock(),
@@ -115,7 +148,7 @@ async def test_handle_meme_source_link_refreshes_to_moderator_and_opens_admin_ca
     with (
         patch(
             "src.tgbot.handlers.moderator.meme_source.get_moderator_user_info",
-            new=AsyncMock(return_value={"type": "moderator"}),
+            new=AsyncMock(return_value={"type": "moderator", "interface_lang": "ru"}),
         ),
         patch(
             "src.tgbot.handlers.moderator.meme_source.get_or_create_meme_source",
@@ -131,7 +164,7 @@ async def test_handle_meme_source_link_refreshes_to_moderator_and_opens_admin_ca
     get_or_create.assert_awaited_once()
     assert get_or_create.await_args.kwargs["url"] == "https://t.me/cozy_abomination"
     assert get_or_create.await_args.kwargs["type"] == MemeSourceType.TELEGRAM
-    admin_pipeline.assert_awaited_once_with(source_row, update)
+    admin_pipeline.assert_awaited_once_with(source_row, update, "ru")
     update.message.reply_text.assert_not_awaited()
 
 
@@ -149,4 +182,6 @@ async def test_handle_meme_source_link_tells_non_moderator_why_nothing_happens()
     ):
         await meme_source.handle_meme_source_link(update, context)
 
-    update.message.reply_text.assert_awaited_once_with("Only moderators can manage meme sources.")
+    update.message.reply_text.assert_awaited_once_with(
+        "Только модераторы могут управлять источниками мемов."
+    )


### PR DESCRIPTION
## Summary
- Localize meme source admin cards, status buttons, and callback answers for moderator source management
- Replace the verbose technical source dump with a compact stats card
- Cover the Russian compact card and localized status buttons with tests

## Tests
- DATABASE_URL=postgresql+asyncpg://app:app@localhost:65432/app REDIS_URL=redis://:myStrongPassword@localhost:36379 CORS_ORIGINS='[]' CORS_HEADERS='[]' TELEGRAM_BOT_TOKEN=test TELEGRAM_ADMIN_BOT_TOKEN=test OPENROUTER_API_KEY=test python -m pytest tests/ -x -q
- python -m ruff check src tests
- python -m ruff format --check src tests