### PR TITLE
Add meme share button variants

### DIFF
--- a/src/storage/schemas.py
+++ b/src/storage/schemas.py
@@ -11,6 +11,7 @@ class MemeData(CustomModel):
     type: MemeType
     telegram_file_id: str
     caption: str | None
+    language_code: str | None = None
     recommended_by: str | None = None
     nlikes: int = 0
 

--- a/src/tgbot/handlers/deep_link.py
+++ b/src/tgbot/handlers/deep_link.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 
 from telegram import Bot
@@ -13,8 +12,9 @@ from src.tgbot.service import (
     get_user_by_id,
     update_user,
 )
+from src.tgbot.sharing import parse_meme_share_deep_link
 
-LINK_UNDER_MEME_PATTERN = r"s_\d+_\d+"
+LINK_UNDER_MEME_PATTERN = r"^s_\d+_\d+$"
 
 
 async def handle_invited_user(
@@ -23,11 +23,11 @@ async def handle_invited_user(
     invited_user_name: str,
     deep_link: str | None,
 ):
-    if not deep_link or not re.match(LINK_UNDER_MEME_PATTERN, deep_link):
+    share_link = parse_meme_share_deep_link(deep_link)
+    if share_link is None:
         return
 
-    _, user_id, _ = deep_link.split("_")
-    invitor_user_id = int(user_id)
+    invitor_user_id = share_link.sharer_user_id
 
     # get invitor user
     invitor_user = await get_user_by_id(invitor_user_id)
@@ -81,11 +81,11 @@ async def handle_shared_meme_reward(
     clicked_user_id: int,
     deep_link: str | None,
 ):
-    if not deep_link or not re.match(LINK_UNDER_MEME_PATTERN, deep_link):
+    share_link = parse_meme_share_deep_link(deep_link)
+    if share_link is None:
         return
 
-    _, user_id, _ = deep_link.split("_")
-    invitor_user_id = int(user_id)
+    invitor_user_id = share_link.sharer_user_id
 
     if clicked_user_id == invitor_user_id:
         return  # don't reward clicking on your links

--- a/src/tgbot/handlers/inline.py
+++ b/src/tgbot/handlers/inline.py
@@ -1,13 +1,15 @@
 from telegram import (
+    InlineQueryResultCachedGif,
     InlineQueryResultCachedPhoto,
+    InlineQueryResultCachedVideo,
     InlineQueryResultsButton,
     Update,
 )
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 
-from src.config import settings
 from src.localizer import t
+from src.storage.constants import MemeType
 from src.tgbot.constants import (
     INLINE_SEARCH_REQUEST_DEEPLINK,
 )
@@ -16,8 +18,10 @@ from src.tgbot.senders.utils import get_random_emoji
 from src.tgbot.service import (
     create_inline_chosen_result_log,
     create_inline_search_log,
+    get_shareable_meme_by_id,
     search_memes_for_inline_query,
 )
+from src.tgbot.sharing import get_meme_share_link
 from src.tgbot.user_info import get_user_info
 
 MIN_SEARCH_QUERY_LENGTH = 3
@@ -27,8 +31,7 @@ INLINE_SEARCH_RESULT_CACHE_SECONDS = 60 * 60 * 12  # 12 hours
 
 
 def get_inline_result_ref_link(user_id: int, meme_id: int):
-    deep_link = f"ir_{user_id}_{meme_id}"  # inline result
-    return f"https://t.me/{settings.TELEGRAM_BOT_USERNAME}?start={deep_link}"
+    return get_meme_share_link(user_id, meme_id)
 
 
 def get_inline_result_caption(meme, user_info):
@@ -40,6 +43,62 @@ def get_inline_result_caption(meme, user_info):
     caption += f"""{emoji} <a href="{ref_link}">Fast Food Memes</a>"""
 
     return caption
+
+
+def parse_exact_meme_inline_query(query: str) -> int | None:
+    if not query.startswith("#"):
+        return None
+
+    meme_id = query[1:]
+    if not meme_id.isdigit():
+        return None
+
+    return int(meme_id)
+
+
+def build_inline_meme_result(meme: dict, user_info: dict):
+    caption = get_inline_result_caption(meme, user_info)
+    meme_type = MemeType(meme["type"])
+    if meme_type == MemeType.IMAGE:
+        return InlineQueryResultCachedPhoto(
+            id=str(meme["id"]),
+            photo_file_id=meme["telegram_file_id"],
+            caption=caption,
+            parse_mode=ParseMode.HTML,
+        )
+    if meme_type == MemeType.VIDEO:
+        return InlineQueryResultCachedVideo(
+            id=str(meme["id"]),
+            video_file_id=meme["telegram_file_id"],
+            title="Fast Food Memes",
+            caption=caption,
+            parse_mode=ParseMode.HTML,
+        )
+    if meme_type == MemeType.ANIMATION:
+        return InlineQueryResultCachedGif(
+            id=str(meme["id"]),
+            gif_file_id=meme["telegram_file_id"],
+            caption=caption,
+            parse_mode=ParseMode.HTML,
+        )
+    return None
+
+
+async def answer_exact_meme_inline_query(update: Update, user_info: dict, meme_id: int) -> None:
+    meme = await get_shareable_meme_by_id(meme_id)
+    result = build_inline_meme_result(meme, user_info) if meme else None
+    results = [result] if result else []
+    await update.inline_query.answer(
+        results,
+        cache_time=INLINE_SEARCH_RESULT_CACHE_SECONDS,
+        is_personal=True,
+    )
+
+    await create_inline_search_log(
+        user_id=update.effective_user.id,
+        query=update.inline_query.query.strip().lower(),
+        chat_type=update.inline_query.chat_type,
+    )
 
 
 async def search_inline(update: Update, _: ContextTypes.DEFAULT_TYPE):
@@ -55,6 +114,10 @@ async def search_inline(update: Update, _: ContextTypes.DEFAULT_TYPE):
         return
 
     query = update.inline_query.query.strip().lower()
+
+    exact_meme_id = parse_exact_meme_inline_query(query)
+    if exact_meme_id is not None:
+        return await answer_exact_meme_inline_query(update, user_info, exact_meme_id)
 
     if len(query) == 0:
         # TODO: show trending / recommended memes
@@ -92,15 +155,7 @@ async def search_inline(update: Update, _: ContextTypes.DEFAULT_TYPE):
         await update.inline_query.answer([], button=no_results_button)
         return
 
-    results = [
-        InlineQueryResultCachedPhoto(
-            id=str(meme["id"]),
-            photo_file_id=meme["telegram_file_id"],
-            caption=get_inline_result_caption(meme, user_info),
-            parse_mode=ParseMode.HTML,
-        )
-        for meme in memes
-    ]
+    results = [result for meme in memes if (result := build_inline_meme_result(meme, user_info))]
 
     await update.inline_query.answer(results, cache_time=INLINE_SEARCH_RESULT_CACHE_SECONDS)
 

--- a/src/tgbot/handlers/inline.py
+++ b/src/tgbot/handlers/inline.py
@@ -157,7 +157,11 @@ async def search_inline(update: Update, _: ContextTypes.DEFAULT_TYPE):
 
     results = [result for meme in memes if (result := build_inline_meme_result(meme, user_info))]
 
-    await update.inline_query.answer(results, cache_time=INLINE_SEARCH_RESULT_CACHE_SECONDS)
+    await update.inline_query.answer(
+        results,
+        cache_time=INLINE_SEARCH_RESULT_CACHE_SECONDS,
+        is_personal=True,
+    )
 
     await create_inline_search_log(
         user_id=update.effective_user.id,

--- a/src/tgbot/handlers/reaction.py
+++ b/src/tgbot/handlers/reaction.py
@@ -12,7 +12,9 @@ from src.recommendations.service import (
     update_user_meme_reaction,
 )
 from src.tgbot.handlers.moderator.invite import maybe_send_moderator_invite
+from src.tgbot.handlers.onboarding import onboarding_flow
 from src.tgbot.senders.next_message import next_message
+from src.tgbot.sharing import MEME_REACTION_CONTEXT_ONBOARD
 from src.tgbot.user_info import update_user_info_counters
 
 
@@ -25,7 +27,9 @@ def _fire_and_forget(coro):
 
 async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user_id = update.effective_user.id
-    meme_id, reaction_id = update.callback_query.data[2:].split(":")
+    callback_parts = update.callback_query.data[2:].split(":")
+    meme_id, reaction_id = callback_parts[:2]
+    reaction_context = callback_parts[2] if len(callback_parts) > 2 else None
     logging.info(f"🛜 reaction: user_id={user_id}, meme_id={meme_id}, reaction_id={reaction_id}")
 
     # do that in sync since we'll use counters in next_message
@@ -41,6 +45,9 @@ async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     )
 
     if reaction_is_new:
+        if reaction_context == MEME_REACTION_CONTEXT_ONBOARD:
+            return await onboarding_flow(update, context.bot)
+
         return await next_message(
             context.bot,
             user_id,

--- a/src/tgbot/handlers/start.py
+++ b/src/tgbot/handlers/start.py
@@ -1,14 +1,11 @@
 import asyncio
-import re
 
 from telegram import Bot, Update
 from telegram.ext import ContextTypes
 
-from src.tgbot.handlers.deep_link import (
-    LINK_UNDER_MEME_PATTERN,
-    handle_invited_user,
-    handle_shared_meme_reward,
-)
+from src.recommendations.meme_queue import clear_meme_queue_for_user
+from src.storage.schemas import MemeData
+from src.tgbot.handlers.deep_link import handle_invited_user, handle_shared_meme_reward
 from src.tgbot.handlers.language import (
     handle_language_settings,
     init_user_languages_from_tg_user,
@@ -17,13 +14,20 @@ from src.tgbot.handlers.treasury.commands import (
     handle_show_kitchen,
 )
 from src.tgbot.logs import log
+from src.tgbot.senders.meme import send_meme_to_user
 from src.tgbot.senders.next_message import next_message
 from src.tgbot.service import (
+    add_user_language,
     create_or_update_user,
+    get_shareable_meme_by_id,
     get_tg_user_by_id,
     get_user_languages,
     log_user_deep_link,
     save_tg_user,
+)
+from src.tgbot.sharing import (
+    MEME_REACTION_CONTEXT_ONBOARD,
+    parse_meme_share_deep_link,
 )
 from src.tgbot.user_info import update_user_info_cache
 
@@ -42,7 +46,7 @@ async def save_user_data(user_id: int, update: Update, deep_link: str | None) ->
         deep_link=deep_link
         if tg_user is None
         or tg_user["deep_link"] is None
-        or not re.match(LINK_UNDER_MEME_PATTERN, tg_user["deep_link"])
+        or parse_meme_share_deep_link(tg_user["deep_link"]) is None
         else None,
     )
 
@@ -79,6 +83,44 @@ def _is_blocked_acquisition_channel(deep_link: str | None) -> bool:
     if not deep_link:
         return False
     return deep_link in BLOCKED_ACQUISITION_CHANNELS or deep_link.startswith("tapps")
+
+
+async def _add_meme_language_from_share_click(user_id: int, meme_row: dict) -> None:
+    language_code = meme_row.get("language_code")
+    if not language_code:
+        return
+
+    user_languages = await get_user_languages(user_id)
+    if language_code in user_languages:
+        return
+
+    await add_user_language(user_id, language_code)
+    await clear_meme_queue_for_user(user_id)
+    await update_user_info_cache(user_id)
+
+
+async def _send_shared_meme_from_deep_link(
+    bot: Bot,
+    user_id: int,
+    deep_link: str | None,
+    reaction_context: str | None = None,
+) -> bool:
+    share_link = parse_meme_share_deep_link(deep_link)
+    if share_link is None:
+        return False
+
+    meme_row = await get_shareable_meme_by_id(share_link.meme_id)
+    if meme_row is None:
+        return False
+
+    await _add_meme_language_from_share_click(user_id, meme_row)
+    await send_meme_to_user(
+        bot,
+        user_id,
+        MemeData(**meme_row),
+        reaction_context=reaction_context,
+    )
+    return True
 
 
 async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -133,7 +175,12 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return await handle_wrapped(update, context)
 
     if created:  # new user:
-        await handle_language_settings(update, context)
+        shared_meme_sent = await _send_shared_meme_from_deep_link(
+            context.bot,
+            user_id,
+            deep_link,
+            reaction_context=MEME_REACTION_CONTEXT_ONBOARD,
+        )
 
         await handle_invited_user(
             context.bot,
@@ -141,6 +188,11 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             update.effective_user.name,
             deep_link,
         )
+
+        if shared_meme_sent:
+            return
+
+        await handle_language_settings(update, context)
 
         # handle giveaway after onboarding so user_language rows exist
         if deep_link and deep_link.startswith("giveaway_"):
@@ -153,6 +205,15 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             from src.tgbot.handlers.treasury.giveaway import handle_giveaway
 
             return await handle_giveaway(update, context, deep_link)
+
+        shared_meme_sent = await _send_shared_meme_from_deep_link(
+            context.bot,
+            user_id,
+            deep_link,
+        )
+        if shared_meme_sent:
+            await handle_shared_meme_reward(context.bot, user_id, deep_link)
+            return
 
         await next_message(
             context.bot,

--- a/src/tgbot/handlers/start.py
+++ b/src/tgbot/handlers/start.py
@@ -4,6 +4,7 @@ from telegram import Bot, Update
 from telegram.ext import ContextTypes
 
 from src.recommendations.meme_queue import clear_meme_queue_for_user
+from src.recommendations.service import user_meme_reaction_exists
 from src.storage.schemas import MemeData
 from src.tgbot.handlers.deep_link import handle_invited_user, handle_shared_meme_reward
 from src.tgbot.handlers.language import (
@@ -111,6 +112,9 @@ async def _send_shared_meme_from_deep_link(
 
     meme_row = await get_shareable_meme_by_id(share_link.meme_id)
     if meme_row is None:
+        return False
+
+    if await user_meme_reaction_exists(user_id, share_link.meme_id):
         return False
 
     await _add_meme_language_from_share_click(user_id, meme_row)

--- a/src/tgbot/senders/keyboards.py
+++ b/src/tgbot/senders/keyboards.py
@@ -15,6 +15,7 @@ from src.tgbot.constants import (
     SOURCE_CANDIDATE_VOTE_PATTERN,
     Reaction,
 )
+from src.tgbot.sharing import build_meme_share_button
 
 # IDEA: use sometimes another emoji pair like 🤣/🤮
 
@@ -57,37 +58,53 @@ def meme_reaction_keyboard(
     user_id: int,
     referral_button_text: str,
     visible_like_count: int | None = None,
+    share_button_variant: str | None = None,
+    interface_lang: str | None = None,
+    reaction_context: str | None = None,
+    meme_type: str | None = None,
 ):
     heart = random.choice(HEART_EMOJI)
     like = f"{heart} {visible_like_count}" if visible_like_count is not None else heart
     dislike = "⏬"
     # like, dislike = "👍", "👎"
 
-    return InlineKeyboardMarkup(
-        [
+    def reaction_callback(reaction_id: int) -> str:
+        callback_data = MEME_BUTTON_CALLBACK_DATA_PATTERN.format(
+            meme_id=meme_id,
+            reaction_id=reaction_id,
+        )
+        if reaction_context:
+            callback_data += f":{reaction_context}"
+        return callback_data
+
+    keyboard = []
+    if share_button_variant:
+        keyboard.append(
             [
-                InlineKeyboardButton(
-                    like,
-                    callback_data=MEME_BUTTON_CALLBACK_DATA_PATTERN.format(
-                        meme_id=meme_id, reaction_id=Reaction.LIKE.value
-                    ),
-                ),
-                InlineKeyboardButton(
-                    dislike,
-                    callback_data=MEME_BUTTON_CALLBACK_DATA_PATTERN.format(
-                        meme_id=meme_id, reaction_id=Reaction.DISLIKE.value
-                    ),
-                ),
-            ],
-            # doesn't work: Telegram removes this link
-            #             [
-            #     InlineKeyboardButton(
-            #         referral_button_text,
-            #         url=referral_link,
-            #     ),
-            # ],
+                build_meme_share_button(
+                    meme_id=meme_id,
+                    user_id=user_id,
+                    text=referral_button_text,
+                    variant=share_button_variant,
+                    interface_lang=interface_lang,
+                    meme_type=meme_type,
+                )
+            ]
+        )
+
+    keyboard.append(
+        [
+            InlineKeyboardButton(
+                like,
+                callback_data=reaction_callback(Reaction.LIKE.value),
+            ),
+            InlineKeyboardButton(
+                dislike,
+                callback_data=reaction_callback(Reaction.DISLIKE.value),
+            ),
         ]
     )
+    return InlineKeyboardMarkup(keyboard)
 
 
 def queue_empty_alert_keyboard(emoji: str = "⏳"):

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -18,28 +18,37 @@ from src.storage.schemas import MemeData
 from src.tgbot.bot import bot
 from src.tgbot.senders.keyboards import (
     meme_reaction_keyboard,
-    select_referral_button_text,
 )
 from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
 from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
-from src.tgbot.senders.utils import collect_user_languages, has_russian_language
+from src.tgbot.senders.utils import collect_user_languages
 from src.tgbot.service import mark_user_blocked
+from src.tgbot.sharing import (
+    get_meme_share_button_text,
+    get_or_assign_meme_share_button_variant,
+)
 from src.tgbot.telegram_retry import telegram_call_with_retry
 from src.tgbot.user_info import get_user_info
 
 logger = logging.getLogger(__name__)
 
 
-async def send_meme_to_user(bot: Bot, user_id: int, meme: MemeData):
+async def send_meme_to_user(
+    bot: Bot,
+    user_id: int,
+    meme: MemeData,
+    reaction_context: str | None = None,
+):
     user_info = await get_user_info(user_id)
     languages = await collect_user_languages(user_id, user_info["interface_lang"])
-    has_russian = has_russian_language(languages)
-    referral_button_text = select_referral_button_text(has_russian)
+    referral_button_text = get_meme_share_button_text(user_info["interface_lang"])
+    share_button_variant = await get_or_assign_meme_share_button_variant(user_id)
     logger.debug(
-        "Sending meme %s to user %s with referral button '%s' (languages=%s)",
+        "Sending meme %s to user %s with share button '%s' variant=%s (languages=%s)",
         meme.id,
         user_id,
         referral_button_text,
+        share_button_variant,
         sorted(languages),
     )
     reply_markup = meme_reaction_keyboard(
@@ -47,11 +56,15 @@ async def send_meme_to_user(bot: Bot, user_id: int, meme: MemeData):
         user_id,
         referral_button_text,
         visible_like_count=await get_visible_meme_like_count(user_id, meme.nlikes),
+        share_button_variant=share_button_variant,
+        interface_lang=user_info["interface_lang"],
+        reaction_context=reaction_context,
+        meme_type=meme.type.value,
     )
     meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 
     await send_new_message_with_meme(bot, user_id, meme, reply_markup)
-    await create_user_meme_reaction(user_id, meme.id, meme.recommended_by)
+    await create_user_meme_reaction(user_id, meme.id, meme.recommended_by or "direct")
 
 
 def get_input_media(

--- a/src/tgbot/senders/next_message.py
+++ b/src/tgbot/senders/next_message.py
@@ -17,7 +17,6 @@ from src.tgbot.logs import log
 from src.tgbot.senders.alerts import send_queue_preparing_alert
 from src.tgbot.senders.keyboards import (
     meme_reaction_keyboard,
-    select_referral_button_text,
 )
 from src.tgbot.senders.meme import (
     edit_last_message_with_meme,
@@ -31,7 +30,11 @@ from src.tgbot.senders.popups import (
     maybe_send_first_meme_nudge,
     send_popup,
 )
-from src.tgbot.senders.utils import collect_user_languages, has_russian_language
+from src.tgbot.senders.utils import collect_user_languages
+from src.tgbot.sharing import (
+    get_meme_share_button_text,
+    get_or_assign_meme_share_button_variant,
+)
 from src.tgbot.user_info import get_user_info
 
 logger = logging.getLogger(__name__)
@@ -71,7 +74,6 @@ async def next_message(
 ) -> Message:
     user_info = await get_user_info(user_id)
     languages = await collect_user_languages(user_id, user_info["interface_lang"])
-    has_russian = has_russian_language(languages)
     is_first_meme = (user_info["nmemes_sent"] or 0) == 0
     # TODO: if watched > 30 memes / day show paywall / tasks / donate
 
@@ -98,12 +100,14 @@ async def next_message(
             no_memes_left = True
             break
 
-        referral_button_text = select_referral_button_text(has_russian)
+        referral_button_text = get_meme_share_button_text(user_info["interface_lang"])
+        share_button_variant = await get_or_assign_meme_share_button_variant(user_id)
         logger.debug(
-            "Next meme %s for user %s uses referral button '%s' (languages=%s)",
+            "Next meme %s for user %s uses share button '%s' variant=%s (languages=%s)",
             meme.id,
             user_id,
             referral_button_text,
+            share_button_variant,
             sorted(languages),
         )
         reply_markup = meme_reaction_keyboard(
@@ -111,6 +115,9 @@ async def next_message(
             user_id,
             referral_button_text,
             visible_like_count=await get_visible_meme_like_count(user_id, meme.nlikes),
+            share_button_variant=share_button_variant,
+            interface_lang=user_info["interface_lang"],
+            meme_type=meme.type.value,
         )
         meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 

--- a/src/tgbot/senders/utils.py
+++ b/src/tgbot/senders/utils.py
@@ -4,8 +4,8 @@ from typing import Iterable
 from telegram import Message, Update
 from telegram.constants import ParseMode
 
-from src.tgbot.sharing import get_meme_share_link
 from src.tgbot.service import get_user_languages
+from src.tgbot.sharing import get_meme_share_link
 
 
 def get_random_emoji() -> str:

--- a/src/tgbot/senders/utils.py
+++ b/src/tgbot/senders/utils.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from telegram import Message, Update
 from telegram.constants import ParseMode
 
-from src.config import settings
+from src.tgbot.sharing import get_meme_share_link
 from src.tgbot.service import get_user_languages
 
 
@@ -71,7 +71,7 @@ def get_random_emoji() -> str:
 
 
 def get_referral_link(user_id: int, meme_id: int) -> str:
-    return f"https://t.me/{settings.TELEGRAM_BOT_USERNAME}?start=s_{user_id}_{meme_id}"
+    return get_meme_share_link(user_id, meme_id)
 
 
 def get_referral_html(user_id: int, meme_id: int) -> str:

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -114,6 +114,26 @@ async def get_meme_by_id(
     return await fetch_one(select_statement)
 
 
+async def get_shareable_meme_by_id(id: int) -> dict[str, Any] | None:
+    query = """
+        SELECT
+            M.id,
+            M.type,
+            M.telegram_file_id,
+            M.caption,
+            M.language_code,
+            'share_link' AS recommended_by,
+            COALESCE(MS.nlikes, 0) AS nlikes
+        FROM meme M
+        LEFT JOIN meme_stats MS
+            ON MS.meme_id = M.id
+        WHERE M.id = :id
+            AND M.status = :status
+            AND M.telegram_file_id IS NOT NULL
+    """
+    return await fetch_one(text(query), {"id": id, "status": MemeStatus.OK.value})
+
+
 async def get_or_create_meme_source(
     url: str,
     **kwargs,

--- a/src/tgbot/sharing.py
+++ b/src/tgbot/sharing.py
@@ -1,0 +1,144 @@
+import hashlib
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+from telegram import InlineKeyboardButton, SwitchInlineQueryChosenChat
+
+from src import localizer
+from src.config import settings
+from src.flows.events import safe_emit
+from src.tgbot.service import assign_experiment, get_experiment_variant
+
+logger = logging.getLogger(__name__)
+
+MEME_SHARE_BUTTON_EXPERIMENT_ID = "meme_share_button"
+MEME_SHARE_BUTTON_URL = "url_share"
+MEME_SHARE_BUTTON_INLINE = "inline_query"
+MEME_REACTION_CONTEXT_ONBOARD = "onboard"
+
+_SHARE_DEEP_LINK_RE = re.compile(r"^s_(?P<sharer_user_id>\d+)_(?P<meme_id>\d+)$")
+
+
+@dataclass(frozen=True)
+class MemeShareDeepLink:
+    sharer_user_id: int
+    meme_id: int
+
+
+def parse_meme_share_deep_link(deep_link: str | None) -> MemeShareDeepLink | None:
+    if not deep_link:
+        return None
+
+    match = _SHARE_DEEP_LINK_RE.match(deep_link)
+    if match is None:
+        return None
+
+    return MemeShareDeepLink(
+        sharer_user_id=int(match.group("sharer_user_id")),
+        meme_id=int(match.group("meme_id")),
+    )
+
+
+def get_meme_share_deep_link(user_id: int, meme_id: int) -> str:
+    return f"s_{user_id}_{meme_id}"
+
+
+def get_meme_share_link(user_id: int, meme_id: int) -> str:
+    deep_link = get_meme_share_deep_link(user_id, meme_id)
+    return f"https://t.me/{settings.TELEGRAM_BOT_USERNAME}?start={deep_link}"
+
+
+def get_meme_share_button_text(interface_lang: str | None) -> str:
+    return localizer.t("meme.share_button", interface_lang)
+
+
+def get_meme_share_text(interface_lang: str | None) -> str:
+    return localizer.t("meme.share_text", interface_lang)
+
+
+def get_meme_share_url(user_id: int, meme_id: int, interface_lang: str | None) -> str:
+    params = urlencode(
+        {
+            "url": get_meme_share_link(user_id, meme_id),
+            "text": get_meme_share_text(interface_lang),
+        }
+    )
+    return f"https://t.me/share/url?{params}"
+
+
+def get_meme_inline_query(meme_id: int) -> str:
+    return f"#{meme_id}"
+
+
+def build_meme_share_assignment(user_id: int) -> tuple[str, dict[str, Any]]:
+    key = f"{MEME_SHARE_BUTTON_EXPERIMENT_ID}:{user_id}"
+    bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 2
+    variant = MEME_SHARE_BUTTON_URL if bucket == 0 else MEME_SHARE_BUTTON_INLINE
+    return variant, {
+        "assignment_strategy": "sha256(experiment_id:user_id)%2",
+        "url_share": "t.me/share/url with s_{sharer_user_id}_{meme_id}",
+        "inline_query": "switch_inline_query_chosen_chat with #meme_id",
+    }
+
+
+async def get_or_assign_meme_share_button_variant(user_id: int) -> str:
+    try:
+        variant = await get_experiment_variant(user_id, MEME_SHARE_BUTTON_EXPERIMENT_ID)
+        if variant is not None:
+            return variant
+
+        proposed, metadata = build_meme_share_assignment(user_id)
+        inserted = await assign_experiment(
+            user_id,
+            MEME_SHARE_BUTTON_EXPERIMENT_ID,
+            proposed,
+            metadata,
+        )
+        if inserted:
+            safe_emit(
+                f"ff.experiment.{MEME_SHARE_BUTTON_EXPERIMENT_ID}.evaluated",
+                f"user.{user_id}",
+                {"user_id": user_id, "group": proposed},
+            )
+            return proposed
+
+        return (
+            await get_experiment_variant(user_id, MEME_SHARE_BUTTON_EXPERIMENT_ID)
+            or MEME_SHARE_BUTTON_URL
+        )
+    except Exception:
+        logger.warning("meme share-button assignment failed for user %d", user_id, exc_info=True)
+        return MEME_SHARE_BUTTON_URL
+
+
+def build_meme_share_button(
+    *,
+    meme_id: int,
+    user_id: int,
+    text: str,
+    variant: str,
+    interface_lang: str | None,
+    meme_type: str | None = None,
+) -> InlineKeyboardButton:
+    # Cached inline results are reliable for photos/videos. Animation file IDs
+    # may be GIF or MPEG4, so use the URL adapter until we store the subtype.
+    supports_exact_inline = meme_type not in {"animation"}
+    if variant == MEME_SHARE_BUTTON_INLINE and supports_exact_inline:
+        return InlineKeyboardButton(
+            text,
+            switch_inline_query_chosen_chat=SwitchInlineQueryChosenChat(
+                query=get_meme_inline_query(meme_id),
+                allow_user_chats=True,
+                allow_bot_chats=False,
+                allow_group_chats=True,
+                allow_channel_chats=True,
+            ),
+        )
+
+    return InlineKeyboardButton(
+        text,
+        url=get_meme_share_url(user_id, meme_id, interface_lang),
+    )

--- a/static/localization/service.yml
+++ b/static/localization/service.yml
@@ -59,3 +59,39 @@ service.bot_updated:
     🔄 Бот обновился. Нажми /start, чтобы продолжить.
   uk: |-
     🔄 Бот оновився. Натисни /start, щоб продовжити.
+
+meme.share_button:
+  ru: |-
+    Отправить другу
+  en: |-
+    Send to a friend
+  uk: |-
+    Надіслати другу
+  es: |-
+    Enviar a un amigo
+  pt-br: |-
+    Enviar para um amigo
+  fr: |-
+    Envoyer à un ami
+  it: |-
+    Invia a un amico
+  de: |-
+    An Freund senden
+
+meme.share_text:
+  ru: |-
+    Посмотри мем
+  en: |-
+    Check out this meme
+  uk: |-
+    Подивись мем
+  es: |-
+    Mira este meme
+  pt-br: |-
+    Veja este meme
+  fr: |-
+    Regarde ce meme
+  it: |-
+    Guarda questo meme
+  de: |-
+    Schau dir dieses Meme an

--- a/tests/tgbot/test_inline_search.py
+++ b/tests/tgbot/test_inline_search.py
@@ -1,11 +1,38 @@
 import pytest
 
+from src.storage.constants import MemeType
 from src.tgbot import service
-from src.tgbot.handlers.inline import INLINE_SEARCH_RESULT_LIMIT
+from src.tgbot.handlers.inline import (
+    INLINE_SEARCH_RESULT_LIMIT,
+    build_inline_meme_result,
+    parse_exact_meme_inline_query,
+)
 
 
 def test_inline_search_returns_twenty_results():
     assert INLINE_SEARCH_RESULT_LIMIT == 20
+
+
+def test_parse_exact_meme_inline_query():
+    assert parse_exact_meme_inline_query("#123") == 123
+    assert parse_exact_meme_inline_query("#00123") == 123
+    assert parse_exact_meme_inline_query("123") is None
+    assert parse_exact_meme_inline_query("#abc") is None
+
+
+def test_build_exact_inline_meme_result_uses_share_deep_link():
+    result = build_inline_meme_result(
+        {
+            "id": 123,
+            "type": MemeType.IMAGE.value,
+            "telegram_file_id": "photo-file-id",
+        },
+        {"id": 456},
+    )
+
+    assert result.id == "123"
+    assert result.photo_file_id == "photo-file-id"
+    assert "start=s_456_123" in result.caption
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_meme_like_count_experiment.py
+++ b/tests/tgbot/test_meme_like_count_experiment.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.tgbot.senders import meme_like_count_experiment as experiment
 from src.tgbot.senders.keyboards import meme_reaction_keyboard
+from src.tgbot.sharing import MEME_SHARE_BUTTON_URL
 
 
 def _button_texts(markup) -> list[str]:
@@ -23,6 +24,22 @@ def test_keyboard_keeps_like_button_plain_without_visible_count(monkeypatch):
     assert _button_texts(markup) == ["❤️", "⏬"]
 
 
+def test_keyboard_renders_share_button_above_reactions(monkeypatch):
+    monkeypatch.setattr("src.tgbot.senders.keyboards.random.choice", lambda hearts: "❤️")
+
+    markup = meme_reaction_keyboard(
+        meme_id=1,
+        user_id=2,
+        referral_button_text="Send to a friend",
+        visible_like_count=None,
+        share_button_variant=MEME_SHARE_BUTTON_URL,
+        interface_lang="en",
+    )
+
+    assert _button_texts(markup) == ["Send to a friend", "❤️", "⏬"]
+    assert markup.inline_keyboard[0][0].url.startswith("https://t.me/share/url?")
+
+
 def test_keyboard_renders_visible_like_count(monkeypatch):
     monkeypatch.setattr("src.tgbot.senders.keyboards.random.choice", lambda hearts: "❤️")
 
@@ -34,6 +51,20 @@ def test_keyboard_renders_visible_like_count(monkeypatch):
     )
 
     assert _button_texts(markup) == ["❤️ 12", "⏬"]
+
+
+def test_keyboard_can_mark_reaction_context(monkeypatch):
+    monkeypatch.setattr("src.tgbot.senders.keyboards.random.choice", lambda hearts: "❤️")
+
+    markup = meme_reaction_keyboard(
+        meme_id=1,
+        user_id=2,
+        referral_button_text="Memes",
+        reaction_context="onboard",
+    )
+
+    assert markup.inline_keyboard[0][0].callback_data == "r:1:1:onboard"
+    assert markup.inline_keyboard[0][1].callback_data == "r:1:2:onboard"
 
 
 def test_like_count_assignment_is_stable():

--- a/tests/tgbot/test_reaction_handler.py
+++ b/tests/tgbot/test_reaction_handler.py
@@ -35,11 +35,19 @@ async def setup():
         await cleanup_test_data(conn)
 
 
-def _make_update(meme_id: int, reaction_id: int, user_id: int = 10001):
+def _make_update(
+    meme_id: int,
+    reaction_id: int,
+    user_id: int = 10001,
+    reaction_context: str | None = None,
+):
+    data = f"r:{meme_id}:{reaction_id}"
+    if reaction_context:
+        data += f":{reaction_context}"
     return SimpleNamespace(
         effective_user=SimpleNamespace(id=user_id),
         callback_query=SimpleNamespace(
-            data=f"r:{meme_id}:{reaction_id}",
+            data=data,
             message=SimpleNamespace(message_id=999, chat=SimpleNamespace(id=user_id)),
         ),
     )
@@ -72,6 +80,35 @@ async def test_new_reaction_calls_next_message(
     await handle_reaction(update, context)
 
     mock_next.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch(f"{HANDLER_MODULE}.onboarding_flow", new_callable=AsyncMock)
+@patch(f"{HANDLER_MODULE}.next_message", new_callable=AsyncMock)
+@patch(f"{HANDLER_MODULE}.reward_user_for_daily_activity", new_callable=AsyncMock)
+@patch(f"{HANDLER_MODULE}.update_user_last_active_at", new_callable=AsyncMock)
+@patch(f"{HANDLER_MODULE}.maybe_send_moderator_invite", new_callable=AsyncMock)
+@patch(f"{HANDLER_MODULE}.update_user_info_counters", new_callable=AsyncMock)
+async def test_onboard_reaction_context_calls_onboarding(
+    mock_counters,
+    mock_mod_invite,
+    mock_active,
+    mock_reward,
+    mock_next,
+    mock_onboarding,
+    setup,
+):
+    from src.tgbot.handlers.reaction import handle_reaction
+
+    await create_user_meme_reaction(10001, 10001, "share_link")
+    mock_counters.return_value = {"nmemes_sent": 1, "memes_watched_today": 1}
+
+    update = _make_update(meme_id=10001, reaction_id=1, reaction_context="onboard")
+    context = _make_context()
+    await handle_reaction(update, context)
+
+    mock_onboarding.assert_called_once()
+    mock_next.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_sharing.py
+++ b/tests/tgbot/test_sharing.py
@@ -1,0 +1,63 @@
+from urllib.parse import parse_qs, urlparse
+
+from src.tgbot.sharing import (
+    MEME_SHARE_BUTTON_INLINE,
+    MEME_SHARE_BUTTON_URL,
+    build_meme_share_button,
+    get_meme_inline_query,
+    get_meme_share_link,
+    get_meme_share_url,
+    parse_meme_share_deep_link,
+)
+
+
+def test_parse_meme_share_deep_link():
+    parsed = parse_meme_share_deep_link("s_10001_20002")
+
+    assert parsed is not None
+    assert parsed.sharer_user_id == 10001
+    assert parsed.meme_id == 20002
+    assert parse_meme_share_deep_link("s_10001_20002_extra") is None
+    assert parse_meme_share_deep_link("ir_10001_20002") is None
+
+
+def test_get_meme_share_url_wraps_start_deep_link():
+    share_url = get_meme_share_url(10001, 20002, "en")
+    parsed = urlparse(share_url)
+    query = parse_qs(parsed.query)
+
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "t.me"
+    assert parsed.path == "/share/url"
+    assert query["url"] == [get_meme_share_link(10001, 20002)]
+    assert query["text"] == ["Check out this meme"]
+
+
+def test_build_url_share_button():
+    button = build_meme_share_button(
+        meme_id=20002,
+        user_id=10001,
+        text="Send to a friend",
+        variant=MEME_SHARE_BUTTON_URL,
+        interface_lang="en",
+    )
+
+    assert button.text == "Send to a friend"
+    assert button.url.startswith("https://t.me/share/url?")
+    assert button.switch_inline_query_chosen_chat is None
+
+
+def test_build_inline_share_button_prefills_exact_meme_query():
+    button = build_meme_share_button(
+        meme_id=20002,
+        user_id=10001,
+        text="Send to a friend",
+        variant=MEME_SHARE_BUTTON_INLINE,
+        interface_lang="en",
+    )
+
+    assert button.url is None
+    assert button.switch_inline_query_chosen_chat.query == get_meme_inline_query(20002)
+    assert button.switch_inline_query_chosen_chat.allow_user_chats is True
+    assert button.switch_inline_query_chosen_chat.allow_group_chats is True
+    assert button.switch_inline_query_chosen_chat.allow_channel_chats is True

--- a/tests/tgbot/test_start.py
+++ b/tests/tgbot/test_start.py
@@ -78,13 +78,18 @@ async def cleanup():
 HANDLER_MODULE = "src.tgbot.handlers.start"
 
 
-def _patch_handlers():
+def _patch_handlers(shared_meme_sent: bool = False):
     """Patch every downstream handler so we test orchestration only."""
     return [
         patch(f"{HANDLER_MODULE}.handle_show_kitchen", new_callable=AsyncMock),
         patch(f"{HANDLER_MODULE}.handle_language_settings", new_callable=AsyncMock),
         patch(f"{HANDLER_MODULE}.handle_invited_user", new_callable=AsyncMock),
         patch(f"{HANDLER_MODULE}.handle_shared_meme_reward", new_callable=AsyncMock),
+        patch(
+            f"{HANDLER_MODULE}._send_shared_meme_from_deep_link",
+            new_callable=AsyncMock,
+            return_value=shared_meme_sent,
+        ),
         patch(f"{HANDLER_MODULE}.next_message", new_callable=AsyncMock),
         patch(f"{HANDLER_MODULE}.log_start_event", new_callable=AsyncMock),
         patch("src.tgbot.handlers.stats.wrapped.handle_wrapped", new_callable=AsyncMock),
@@ -116,13 +121,17 @@ async def _assert_universal_side_effects(user_id: int, expected_deep_link: str |
     assert dl_rows[0]._asdict()["deep_link"] == expected_deep_link
 
 
-async def _run_handle_start(deep_link: str | None, user_id: int = NEW_USER_ID):
+async def _run_handle_start(
+    deep_link: str | None,
+    user_id: int = NEW_USER_ID,
+    shared_meme_sent: bool = False,
+):
     from src.tgbot.handlers.start import handle_start
 
     update = _make_update(deep_link, user_id)
     context = _make_context(deep_link)
 
-    patches = _patch_handlers()
+    patches = _patch_handlers(shared_meme_sent=shared_meme_sent)
     started = [p.start() for p in patches]
     try:
         await handle_start(update, context)
@@ -136,6 +145,7 @@ async def _run_handle_start(deep_link: str | None, user_id: int = NEW_USER_ID):
                 "lang_settings",
                 "invited",
                 "shared_reward",
+                "shared_meme",
                 "next_message",
                 "log_start",
                 "wrapped",
@@ -186,9 +196,11 @@ async def test_new_user_giveaway_branch_inits_languages(cleanup):
 
 @pytest.mark.asyncio
 async def test_new_user_share_link_branch_inits_languages(cleanup):
-    mocks = await _run_handle_start(deep_link="s_12345_678")
+    mocks = await _run_handle_start(deep_link="s_12345_678", shared_meme_sent=True)
     await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link="s_12345_678")
-    mocks["lang_settings"].assert_called_once()
+    mocks["shared_meme"].assert_called_once()
+    assert mocks["shared_meme"].call_args.kwargs["reaction_context"] == "onboard"
+    mocks["lang_settings"].assert_not_called()
     mocks["invited"].assert_called_once()
 
 
@@ -218,6 +230,22 @@ async def test_existing_user_no_deep_link_serves_meme(cleanup):
     # Second /start: same user → existing-user branch.
     mocks = await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
     mocks["next_message"].assert_called_once()
+    mocks["lang_settings"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_user_share_link_serves_shared_meme(cleanup):
+    await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
+
+    mocks = await _run_handle_start(
+        deep_link="s_12345_678",
+        user_id=EXISTING_USER_ID,
+        shared_meme_sent=True,
+    )
+
+    mocks["shared_meme"].assert_called_once()
+    mocks["shared_reward"].assert_called_once()
+    mocks["next_message"].assert_not_called()
     mocks["lang_settings"].assert_not_called()
 
 

--- a/tests/tgbot/test_start.py
+++ b/tests/tgbot/test_start.py
@@ -14,12 +14,16 @@ import pytest_asyncio
 from sqlalchemy import delete, select
 from telegram import User
 from telegram.ext import ContextTypes
+from tests.factories import create_meme, create_meme_source, create_reaction
 
 from src.database import (
     engine,
+    meme,
+    meme_source,
     user,
     user_deep_link_log,
     user_language,
+    user_meme_reaction,
     user_tg,
 )
 
@@ -60,17 +64,30 @@ async def _cleanup_user(user_id: int) -> None:
         await conn.execute(
             delete(user_deep_link_log).where(user_deep_link_log.c.user_id == user_id)
         )
+        await conn.execute(
+            delete(user_meme_reaction).where(user_meme_reaction.c.user_id == user_id)
+        )
         await conn.execute(delete(user_language).where(user_language.c.user_id == user_id))
         await conn.execute(delete(user).where(user.c.id == user_id))
         await conn.execute(delete(user_tg).where(user_tg.c.id == user_id))
         await conn.commit()
 
 
+async def _cleanup_shared_meme_fixture() -> None:
+    async with engine.connect() as conn:
+        await conn.execute(delete(user_meme_reaction).where(user_meme_reaction.c.meme_id == 10001))
+        await conn.execute(delete(meme).where(meme.c.id == 10001))
+        await conn.execute(delete(meme_source).where(meme_source.c.id == 10001))
+        await conn.commit()
+
+
 @pytest_asyncio.fixture()
 async def cleanup():
+    await _cleanup_shared_meme_fixture()
     await _cleanup_user(NEW_USER_ID)
     await _cleanup_user(EXISTING_USER_ID)
     yield
+    await _cleanup_shared_meme_fixture()
     await _cleanup_user(NEW_USER_ID)
     await _cleanup_user(EXISTING_USER_ID)
 
@@ -247,6 +264,77 @@ async def test_existing_user_share_link_serves_shared_meme(cleanup):
     mocks["shared_reward"].assert_called_once()
     mocks["next_message"].assert_not_called()
     mocks["lang_settings"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_user_share_link_with_prior_reaction_serves_next_meme(cleanup):
+    from src.tgbot.handlers.start import handle_start
+
+    await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
+    async with engine.begin() as conn:
+        await create_meme_source(conn, id=10001, language_code="en")
+        await create_meme(
+            conn,
+            id=10001,
+            meme_source_id=10001,
+            language_code="en",
+            telegram_file_id="test_shared_file_id",
+        )
+        await create_reaction(
+            conn,
+            user_id=EXISTING_USER_ID,
+            meme_id=10001,
+            reaction_id=1,
+            recommended_by="share_link",
+        )
+
+    update = _make_update("s_12345_10001", EXISTING_USER_ID)
+    context = _make_context("s_12345_10001")
+
+    patches = [
+        patch(f"{HANDLER_MODULE}.handle_show_kitchen", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.handle_language_settings", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.handle_invited_user", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.handle_shared_meme_reward", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.send_meme_to_user", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.next_message", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.log_start_event", new_callable=AsyncMock),
+        patch("src.tgbot.handlers.stats.wrapped.handle_wrapped", new_callable=AsyncMock),
+        patch(
+            "src.tgbot.handlers.treasury.giveaway.handle_giveaway",
+            new_callable=AsyncMock,
+        ),
+    ]
+    started = [p.start() for p in patches]
+    try:
+        await handle_start(update, context)
+    finally:
+        for p in patches:
+            p.stop()
+
+    mocks = dict(
+        zip(
+            [
+                "kitchen",
+                "lang_settings",
+                "invited",
+                "shared_reward",
+                "send_meme",
+                "next_message",
+                "log_start",
+                "wrapped",
+                "giveaway",
+            ],
+            started,
+        )
+    )
+    mocks["send_meme"].assert_not_called()
+    mocks["next_message"].assert_called_once()
+    mocks["shared_reward"].assert_called_once_with(
+        context.bot,
+        EXISTING_USER_ID,
+        "s_12345_10001",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds a localized share button above private-feed like/skip buttons.
- Supports two Telegram-native share adapters: t.me/share/url deep-link sharing and switch_inline_query_chosen_chat with #meme_id exact inline results.
- Makes /start s_{sharer_user_id}_{meme_id} send the clicked meme first, add the meme language to the user, and defer new-user onboarding until after the first reaction.
- Keeps share parsing and button construction behind src/tgbot/sharing.py so Share Attribution logic has one interface.

## Telegram API notes
- t.me/share/url officially supports url + optional text: https://core.telegram.org/api/links#share-links
- switch_inline_query_chosen_chat can prefill query text after chat selection: https://core.telegram.org/bots/api#switchinlinequerychosenchat
- Deep-link start payload is capped at 64 chars and limited to A-Z/a-z/0-9/_/-: https://core.telegram.org/bots/features#deep-linking

## Verification
- ruff check src/tgbot/sharing.py src/tgbot/senders/keyboards.py src/tgbot/senders/meme.py src/tgbot/senders/next_message.py src/tgbot/handlers/start.py src/tgbot/handlers/reaction.py src/tgbot/handlers/inline.py src/tgbot/handlers/deep_link.py src/tgbot/service.py src/storage/schemas.py tests/tgbot/test_sharing.py tests/tgbot/test_inline_search.py tests/tgbot/test_meme_like_count_experiment.py tests/tgbot/test_reaction_handler.py tests/tgbot/test_start.py
- pytest -q tests/tgbot/test_sharing.py tests/tgbot/test_inline_search.py tests/tgbot/test_meme_like_count_experiment.py

## Not run
- DB-backed tests tests/tgbot/test_reaction_handler.py and tests/tgbot/test_start.py need the docker-compose Postgres hostname app_db; local host run failed with socket.gaierror for app_db.