### PR TITLE
Improve comms editorial selection prompts

### DIFF
--- a/agents/analyst/AGENTS.md
+++ b/agents/analyst/AGENTS.md
@@ -153,6 +153,12 @@ fires before the 10:00 MSK Comms cron), write a second file:
 This file is **Comms Agent's primary input**. It must rank the day's most
 surprising findings so Comms can pick one and turn it into a post.
 
+Comms is optimizing for a public build-in-public channel, not an internal
+metrics dashboard. Rank findings by **editorial usefulness first** and raw
+statistical magnitude second. A 7σ source_id spike is not automatically a good
+post if the public story is "one internal source moved"; a smaller product,
+research, cohort, or user-facing learning can be the better lead.
+
 Format:
 ```markdown
 # Anomalies YYYY-MM-DD
@@ -167,6 +173,11 @@ Format:
 - **Suggested visual**: stat_slide | line_chart | bar_chart | none
 - **HARD BAN risk**: yes | no  (set yes if this is about describe_memes, infra,
   circuit breakers, deploys, a/b tests in progress — Comms will skip these)
+- **Public story score**: 0-5  (5 = a stranger immediately gets why this matters)
+- **Reader payoff**: [what the reader learns, can try, or can laugh at]
+- **Novelty vs last 14 posts**: new | similar | duplicate
+- **Post eligibility**: post-ready | research-only | skip
+- **Suggested framing**: [one casual Russian angle without source_id/internal jargon]
 
 ## Finding 2: ...
 (up to 5-8 findings, ranked strongest first)
@@ -182,15 +193,29 @@ Format:
 - **Unexpected popular content** — a single meme, source, or language doing far
   better than expected
 - **Recurring patterns** — anything that's been weird for 3+ days now
+- **Recent user-facing product changes** — if a shipped change creates a good
+  public story, include it as an `other` finding even when it is not a metric
+  outlier yet. Translate `git log --since="7 days"` / CEO decisions into human
+  language: share button, inline meme search, moderator source voting, upload
+  feedback, giveaways, burger economy, group-chat behavior. Do not list PRs or
+  commits in the finding.
 
 **What NOT to include** (set `HARD BAN risk: yes` and deprioritize):
 - describe_memes coverage dropping (Comms will skip it)
 - circuit breaker trips, flow pauses, deploy issues (firefighting)
 - running A/B tests mid-flight (no conclusive result yet)
+- raw `source_id` movements unless they teach a broader lesson: user uploads
+  suddenly work, moderators found a new content vein, one language/community is
+  behaving differently, or a single meme is broadly funny enough to stand alone.
+- the same public topic family that appeared in the last 14 posts. Mark it
+  `duplicate` and `research-only` unless there is a genuinely new conclusion.
 
 If NO findings cross the 2σ threshold today, still write the file with a
-`# Anomalies YYYY-MM-DD` header and a note: `No strong anomalies today — Comms
-should fall back to B-Historical or D-Engagement categories.`
+`# Anomalies YYYY-MM-DD` header and a short **Editorial fallback slate**:
+2-3 post-ready alternatives from recent product changes, lore, recurring meme
+formats, or research follow-ups. If there is truly nothing, write:
+`No strong anomalies today — Comms should fall back to B-Historical,
+D-Engagement, E-Recurring, or weekly shipped-digest categories.`
 
 ### 9. Log to JSONL
 Append an entry to `experiments/log.jsonl`:

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -142,7 +142,16 @@ Read `experiments/active/`. For each experiment:
 - Create task for **CTO** to implement
 
 **If there's something worth sharing publicly:**
-- Create a task for Comms Manager with what to announce and why it matters
+- Create a task for Comms Manager with the public angle, reader payoff, and what
+  to avoid. Do not just hand over a raw anomaly.
+- Include whether this is a product update, research learning, meme/content
+  story, engagement CTA, lore, or weekly digest.
+- Do not delegate raw `source_id` movement unless it teaches a broader product
+  lesson. "Source 123 spiked" is internal; "user uploads suddenly produced a
+  meme people loved" can be public.
+- If using `/retro`, git history, or shipped work as the source, frame it as
+  what changed for users or what the team learned. No public PR numbers, commit
+  hashes, release-note bullets, or internal agent coordination details.
 
 ### 5. Weekly Review (Mondays)
 First run the outcome audit:

--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -73,19 +73,52 @@ beyond that.
 If the file is missing (first run, or cron failed), proceed without it —
 the rotation check still runs against the database.
 
-### Step 1 — Read today's anomaly report (primary input)
+### Step 1 — Build today's editorial slate
 Read `experiments/reports/anomalies-YYYY-MM-DD.md` written by the Analyst agent
-earlier this morning. This file ranks the day's most surprising findings
-(DAU delta, source climbers, like-rate outliers, language shifts, session length
-moves, cohort anomalies). Pick the strongest finding with `Chart-worthy: yes`.
+earlier this morning. This file ranks the day's most surprising findings and
+may include an editorial fallback slate. Do not mechanically publish Finding 1.
+Build a short candidate slate and pick the best public story.
+
+Priority order:
+1. **User-facing product change people can try today** — share button, inline
+   search, upload feedback, source voting, giveaway, burger flow, group-chat
+   behavior.
+2. **Conclusive product/research learning** — what we believed, what the data
+   changed, what we will do differently. No in-flight A/B status updates.
+3. **Build-in-public before/after** — a clear product/process change without
+   infra drama or release-note prose.
+4. **Funny meme/content finding** — meme of the day/week/month, language niche,
+   source/community story that works for a stranger.
+5. **Raw data anomaly** — only if it has a non-obvious public takeaway.
+
+Use Analyst's `Public story score`, `Reader payoff`, `Novelty vs last 14 posts`,
+and `Post eligibility` fields when present. A higher z-score does not beat a
+better public story.
+
+Hard editorial caps:
+- raw source_id/source-burst post: max 1 per 7 days;
+- session-length/North-Star post: max 1 per 10 days;
+- language-share or meme-type gap post: max 1 per 7 days;
+- "fresh meme fast start" / top-meme stat card: max 1 per 7 days per channel.
+
+If all anomalies are duplicates, research-only, hard-ban risky, or just "one
+internal metric moved", use Step 1b fallback even when the anomaly file exists.
 
 If the anomaly file is missing (Analyst failed), fall back to Step 1b.
 
-### Step 1b — Fallback topics (ONLY when anomaly file is missing)
+### Step 1b — Fallback topics
 Pick ONE from:
+- **A-Feature** — a user-facing feature now available in the bot. Explain what
+  a reader can try, not how the implementation works.
 - **B-Historical** — a milestone, throwback, or lore moment from `docs/comms/lore/`
 - **D-Engagement** — a giveaway, CTA, or voting prompt (not more than 1/month)
 - **E-Recurring** — meme of the day from DB (query `meme_stats` ORDER BY lr_smoothed)
+- **E-Weekly digest** — what changed this week in plain language. You may use
+  recent git/Paperclip history only as input, then translate it into product
+  outcomes. No PR numbers, commit hashes, internal agent names, or release-note
+  bullets in the public post.
+- **F-Behind-the-scenes** — how a product mechanism works, explained without
+  infra or stack details.
 
 **Never fall back to topics from the HARD BAN list below.**
 
@@ -145,13 +178,26 @@ Write in the voice: "чуваки, мы тут на данных нашли ст
 explorer, not press release. Make a stranger without infra knowledge find this
 exciting in under 3 seconds.
 
-Structure:
-1. **Hook** (first line): name the surprise. "Интересное: {what} за {timeframe}"
-2. **Number or comparison** (one sentence): the concrete finding, 1-3 numbers max
-3. **Plain-language why** (one-two sentences): explain WHY this might be
-   happening, in words a non-technical friend would understand. No jargon.
-4. **Context or CTA** (optional, one line): what we're going to dig into, or
-   "заходи в @ffmemesbot посмотреть"
+Pick exactly one editorial format before drafting:
+- **Launch**: what users can try now + why it exists.
+- **Learning**: "думали X, данные показали Y, теперь делаем Z".
+- **Artifact**: one meme, screenshot, chart, or user-visible result carries the
+  post.
+- **Behind-the-scenes**: how a bot mechanic works in simple product language.
+- **Digest**: 2-3 things that changed this week, phrased as user/product
+  outcomes.
+- **Anomaly**: a surprising number with a real reader payoff.
+
+Default structure:
+1. **Hook** (first line): name the public surprise or change.
+2. **Concrete evidence**: 1-3 numbers max, or one crisp before/after.
+3. **Plain-language why**: why this matters to a person using or following the bot.
+4. **Context or CTA** (optional): what we're trying next, or "заходи в @ffmemesbot".
+
+Do not repeat the botty template:
+`Интересное: X vs baseline. Похоже Y. На графике Z.`
+Vary the opening, verb, and payoff. If the post still reads like a daily
+analyst card, choose a different format or fallback topic.
 
 **Length cap: ~400 characters of text** (excluding image). Strict.
 


### PR DESCRIPTION
## Summary
- add editorial usefulness fields to Analyst anomaly handoffs
- make Comms build a candidate slate instead of auto-publishing the strongest anomaly
- require CEO Comms handoffs to include public angle, reader payoff, and avoidance notes

## Verification
- git diff --check
- agents/deploy.sh --dry-run