### PR TITLE
Fix FFM-1501: schedule first-meme nudge for direct sends

### DIFF
--- a/src/flows/broadcasts/meme.py
+++ b/src/flows/broadcasts/meme.py
@@ -11,6 +11,8 @@ from src.recommendations.meme_queue import check_queue, get_next_meme_for_user
 from src.tgbot.bot import bot
 from src.tgbot.senders.meme import send_meme_to_user
 
+FIRST_MEME_NUDGE_DRAIN_TIMEOUT_SECONDS = 10
+
 _BROADCAST_FLOW_OPTS = dict(
     retries=1,
     retry_delay_seconds=30,
@@ -19,11 +21,52 @@ _BROADCAST_FLOW_OPTS = dict(
 )
 
 
-async def _send_to_user(user_id: int) -> None:
+async def _send_to_user(
+    user_id: int,
+    first_meme_nudge_tasks: list[asyncio.Task[None]],
+) -> None:
     await check_queue(user_id)
     meme = await get_next_meme_for_user(user_id)
     if meme:
-        await send_meme_to_user(bot, user_id, meme)
+        await send_meme_to_user(
+            bot,
+            user_id,
+            meme,
+            first_meme_nudge_tasks=first_meme_nudge_tasks,
+        )
+
+
+async def _drain_first_meme_nudge_tasks(
+    tasks: list[asyncio.Task[None]],
+    logger,
+) -> None:
+    if not tasks:
+        return
+
+    done, pending = await asyncio.wait(
+        tasks,
+        timeout=FIRST_MEME_NUDGE_DRAIN_TIMEOUT_SECONDS,
+    )
+    if pending:
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        logger.warning(
+            "Timed out sending %s first-meme nudge(s); released leases for retry",
+            len(pending),
+        )
+
+    for task in done:
+        if task.cancelled():
+            continue
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(
+                "Failed to send first-meme nudge after broadcast meme delivery",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+
+    tasks.clear()
 
 
 async def broadcast_next_meme_to_users(user_ids: list[int]):
@@ -31,13 +74,18 @@ async def broadcast_next_meme_to_users(user_ids: list[int]):
     logger.info(f"Going to sent next meme to {len(user_ids)} users")
 
     for user_id in user_ids:
+        first_meme_nudge_tasks: list[asyncio.Task[None]] = []
         try:
-            await asyncio.wait_for(_send_to_user(user_id), timeout=20)
+            await asyncio.wait_for(
+                _send_to_user(user_id, first_meme_nudge_tasks),
+                timeout=20,
+            )
             logger.info(f"Sent meme to #{user_id}")
         except asyncio.TimeoutError:
             logger.warning(f"Timed out processing user #{user_id} (>20s), skipping")
         except Exception:
             logger.warning(f"Failed to send meme to #{user_id}", exc_info=True)
+        await _drain_first_meme_nudge_tasks(first_meme_nudge_tasks, logger)
         await asyncio.sleep(0.2)  # flood control
 
 

--- a/src/recommendations/pipeline.py
+++ b/src/recommendations/pipeline.py
@@ -134,6 +134,7 @@ class RecommendationBatchDiagnostics:
     user_type: str | None
     queue_len_before: int
     exclude_count: int
+    cold_start_nsessions_gate_enabled: bool = False
     diagnostics_sample_rate: float = 0.01
     maturity_stage: str | None = None
     duration_ms: int = 0
@@ -175,6 +176,7 @@ class RecommendationBatchDiagnostics:
             "limit": self.limit,
             "nmemes_sent": self.nmemes_sent,
             "nsessions": self.nsessions,
+            "cold_start_nsessions_gate_enabled": self.cold_start_nsessions_gate_enabled,
             "queue_len_before": self.queue_len_before,
             "exclude_count": self.exclude_count,
             "selected_count": self.selected_count,
@@ -284,6 +286,7 @@ class RecommendationBatchPipeline:
             user_type=request.user_type,
             queue_len_before=len(request.meme_ids_in_queue),
             exclude_count=len(request.meme_ids_in_queue),
+            cold_start_nsessions_gate_enabled=request.cold_start_nsessions_gate_enabled,
             diagnostics_sample_rate=request.diagnostics_sample_rate,
             source_diversity_enabled=request.source_diversity_enabled,
             shadow_scoring_enabled=request.shadow_scoring_enabled,

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -94,8 +94,32 @@ async def _record_delivered_meme_reaction(user_id: int, meme: MemeData) -> None:
     try:
         await asyncio.shield(reaction_task)
     except asyncio.CancelledError:
-        await reaction_task
+        reaction_task.add_done_callback(
+            lambda task: _log_delivered_meme_reaction_result(task, user_id, meme.id)
+        )
         raise
+
+
+def _log_delivered_meme_reaction_result(
+    task: asyncio.Task[None],
+    user_id: int,
+    meme_id: int,
+) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        logger.warning(
+            "Delivered meme reaction recording was cancelled for user %s meme %s",
+            user_id,
+            meme_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to record delivered meme reaction for user %s meme %s after cancellation",
+            user_id,
+            meme_id,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
 
 
 def get_input_media(

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Tuple
 
@@ -21,6 +22,10 @@ from src.tgbot.senders.keyboards import (
 )
 from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
 from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
+from src.tgbot.senders.popups import (
+    get_or_assign_first_meme_nudge_variant,
+    maybe_send_first_meme_nudge,
+)
 from src.tgbot.senders.utils import collect_user_languages
 from src.tgbot.service import mark_user_blocked
 from src.tgbot.sharing import (
@@ -41,6 +46,7 @@ async def send_meme_to_user(
 ):
     user_info = await get_user_info(user_id)
     languages = await collect_user_languages(user_id, user_info["interface_lang"])
+    is_first_meme = (user_info["nmemes_sent"] or 0) == 0
     referral_button_text = get_meme_share_button_text(user_info["interface_lang"])
     share_button_variant = await get_or_assign_meme_share_button_variant(user_id)
     logger.debug(
@@ -64,7 +70,13 @@ async def send_meme_to_user(
     meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 
     await send_new_message_with_meme(bot, user_id, meme, reply_markup)
+    nudge_variant: str | None = None
+    if is_first_meme:
+        nudge_variant = await get_or_assign_first_meme_nudge_variant(user_id)
+
     await create_user_meme_reaction(user_id, meme.id, meme.recommended_by or "direct")
+    if nudge_variant == "treatment":
+        asyncio.create_task(maybe_send_first_meme_nudge(user_id, user_info))
 
 
 def get_input_media(

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -70,19 +70,32 @@ async def send_meme_to_user(
     )
     meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 
-    await send_new_message_with_meme(bot, user_id, meme, reply_markup)
     nudge_variant = await get_first_meme_nudge_variant_to_send(
         user_id,
         is_first_meme=is_first_meme,
     )
 
-    await create_user_meme_reaction(user_id, meme.id, meme.recommended_by or "direct")
+    await send_new_message_with_meme(bot, user_id, meme, reply_markup)
+    await _record_delivered_meme_reaction(user_id, meme)
     if nudge_variant == "treatment":
         nudge_task = asyncio.create_task(maybe_send_first_meme_nudge(user_id, user_info))
         if first_meme_nudge_tasks is None:
             await nudge_task
         else:
             first_meme_nudge_tasks.append(nudge_task)
+
+
+async def _record_delivered_meme_reaction(user_id: int, meme: MemeData) -> None:
+    # Once Telegram accepts a direct send, cancellation must not skip the row
+    # that lets reaction callbacks and recommendation dedupe find that delivery.
+    reaction_task = asyncio.create_task(
+        create_user_meme_reaction(user_id, meme.id, meme.recommended_by or "direct")
+    )
+    try:
+        await asyncio.shield(reaction_task)
+    except asyncio.CancelledError:
+        await reaction_task
+        raise
 
 
 def get_input_media(

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Tuple
 
@@ -22,7 +23,7 @@ from src.tgbot.senders.keyboards import (
 from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
 from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
 from src.tgbot.senders.popups import (
-    get_or_assign_first_meme_nudge_variant,
+    get_first_meme_nudge_variant_to_send,
     maybe_send_first_meme_nudge,
 )
 from src.tgbot.senders.utils import collect_user_languages
@@ -42,6 +43,7 @@ async def send_meme_to_user(
     user_id: int,
     meme: MemeData,
     reaction_context: str | None = None,
+    first_meme_nudge_tasks: list[asyncio.Task[None]] | None = None,
 ):
     user_info = await get_user_info(user_id)
     languages = await collect_user_languages(user_id, user_info["interface_lang"])
@@ -69,13 +71,18 @@ async def send_meme_to_user(
     meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 
     await send_new_message_with_meme(bot, user_id, meme, reply_markup)
-    nudge_variant: str | None = None
-    if is_first_meme:
-        nudge_variant = await get_or_assign_first_meme_nudge_variant(user_id)
+    nudge_variant = await get_first_meme_nudge_variant_to_send(
+        user_id,
+        is_first_meme=is_first_meme,
+    )
 
     await create_user_meme_reaction(user_id, meme.id, meme.recommended_by or "direct")
     if nudge_variant == "treatment":
-        await maybe_send_first_meme_nudge(user_id, user_info)
+        nudge_task = asyncio.create_task(maybe_send_first_meme_nudge(user_id, user_info))
+        if first_meme_nudge_tasks is None:
+            await nudge_task
+        else:
+            first_meme_nudge_tasks.append(nudge_task)
 
 
 def get_input_media(

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import Tuple
 
@@ -76,7 +75,7 @@ async def send_meme_to_user(
 
     await create_user_meme_reaction(user_id, meme.id, meme.recommended_by or "direct")
     if nudge_variant == "treatment":
-        asyncio.create_task(maybe_send_first_meme_nudge(user_id, user_info))
+        await maybe_send_first_meme_nudge(user_id, user_info)
 
 
 def get_input_media(

--- a/src/tgbot/senders/popups.py
+++ b/src/tgbot/senders/popups.py
@@ -249,11 +249,27 @@ async def get_or_assign_first_meme_nudge_variant(user_id: int) -> str | None:
     return proposed
 
 
+async def get_first_meme_nudge_variant_to_send(
+    user_id: int,
+    *,
+    is_first_meme: bool,
+) -> str | None:
+    if is_first_meme:
+        return await get_or_assign_first_meme_nudge_variant(user_id)
+
+    if await user_popup_already_sent(user_id, FIRST_MEME_NUDGE_POPUP_ID):
+        return None
+
+    variant = await get_experiment_variant(user_id, FIRST_MEME_NUDGE_EXPERIMENT_ID)
+    if variant == "treatment":
+        return variant
+    return None
+
+
 async def maybe_send_first_meme_nudge(user_id: int, user_info: dict) -> None:
-    # Treatment-only sender. Caller is expected to have already invoked
-    # get_or_assign_first_meme_nudge_variant synchronously (in the meme
-    # delivery path, before create_user_meme_reaction) so the cohort row
-    # is locked in.
+    # Treatment-only sender. First-meme callers must assign synchronously before
+    # create_user_meme_reaction; later callers may retry only if that assignment
+    # already exists and the popup log is still missing.
     variant = await get_experiment_variant(user_id, FIRST_MEME_NUDGE_EXPERIMENT_ID)
     if variant != "treatment":
         return

--- a/src/tgbot/senders/popups.py
+++ b/src/tgbot/senders/popups.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections.abc import Callable
 
@@ -252,8 +253,7 @@ async def maybe_send_first_meme_nudge(user_id: int, user_info: dict) -> None:
     # Treatment-only sender. Caller is expected to have already invoked
     # get_or_assign_first_meme_nudge_variant synchronously (in the meme
     # delivery path, before create_user_meme_reaction) so the cohort row
-    # is locked in. Safe to dispatch as a background asyncio task — only
-    # the slow Telegram I/O lives here.
+    # is locked in.
     variant = await get_experiment_variant(user_id, FIRST_MEME_NUDGE_EXPERIMENT_ID)
     if variant != "treatment":
         return
@@ -277,6 +277,12 @@ async def maybe_send_first_meme_nudge(user_id: int, user_info: dict) -> None:
         # user can't receive messages anyway, and nmemes_sent will advance past 0
         # so this code path won't re-enter for this user.
         return
+    except asyncio.CancelledError:
+        # Broadcast callers may wrap direct sends in asyncio.wait_for. If that
+        # cancellation lands after the lease insert but before Telegram confirms
+        # delivery, release the lease so a later retry can send the nudge.
+        await delete_user_popup_log(user_id, FIRST_MEME_NUDGE_POPUP_ID)
+        raise
     except TelegramError as exc:
         # Transient delivery failure (timeout, rate-limit, etc.). Release the
         # lease so a future meme #1 attempt can re-fire the nudge.

--- a/tests/flows/test_broadcasts_meme.py
+++ b/tests/flows/test_broadcasts_meme.py
@@ -1,0 +1,34 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.flows.broadcasts import meme as broadcast_meme
+
+
+@pytest.mark.asyncio
+async def test_broadcast_drains_deferred_first_meme_nudge(monkeypatch):
+    nudge_started = asyncio.Event()
+    nudge_can_finish = asyncio.Event()
+
+    async def nudge_task() -> None:
+        nudge_started.set()
+        await nudge_can_finish.wait()
+
+    async def send_to_user(_user_id: int, first_meme_nudge_tasks: list[asyncio.Task[None]]) -> None:
+        first_meme_nudge_tasks.append(asyncio.create_task(nudge_task()))
+
+    logger = MagicMock()
+    monkeypatch.setattr(broadcast_meme, "get_run_logger", lambda: logger)
+    monkeypatch.setattr(broadcast_meme, "_send_to_user", send_to_user)
+    monkeypatch.setattr(broadcast_meme.asyncio, "sleep", AsyncMock())
+
+    broadcast_task = asyncio.create_task(broadcast_meme.broadcast_next_meme_to_users([12001]))
+    await nudge_started.wait()
+    await asyncio.sleep(0)
+
+    assert not broadcast_task.done()
+
+    nudge_can_finish.set()
+    await asyncio.wait_for(broadcast_task, timeout=0.2)
+    logger.info.assert_any_call("Sent meme to #12001")

--- a/tests/tgbot/test_first_meme_nudge.py
+++ b/tests/tgbot/test_first_meme_nudge.py
@@ -18,6 +18,7 @@ from src.tgbot.senders import popups
 from src.tgbot.senders.popups import (
     FIRST_MEME_NUDGE_EXPERIMENT_ID,
     FIRST_MEME_NUDGE_POPUP_ID,
+    get_first_meme_nudge_variant_to_send,
     get_or_assign_first_meme_nudge_variant,
     maybe_send_first_meme_nudge,
 )
@@ -223,6 +224,37 @@ async def test_assignment_helper_is_idempotent(setup):
         )
         rows = result.fetchall()
     assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_delivery_helper_retries_only_existing_treatment_assignment(monkeypatch):
+    assign_variant = AsyncMock(return_value="treatment")
+    popup_sent = AsyncMock(return_value=False)
+    get_variant = AsyncMock(return_value=None)
+    monkeypatch.setattr(popups, "get_or_assign_first_meme_nudge_variant", assign_variant)
+    monkeypatch.setattr(popups, "user_popup_already_sent", popup_sent)
+    monkeypatch.setattr(popups, "get_experiment_variant", get_variant)
+
+    assert (
+        await get_first_meme_nudge_variant_to_send(TREATMENT_USER_ID, is_first_meme=True)
+        == "treatment"
+    )
+    assign_variant.assert_awaited_once_with(TREATMENT_USER_ID)
+
+    assert await get_first_meme_nudge_variant_to_send(CONTROL_USER_ID, is_first_meme=False) is None
+    assign_variant.assert_awaited_once()
+    get_variant.assert_awaited_once_with(CONTROL_USER_ID, FIRST_MEME_NUDGE_EXPERIMENT_ID)
+
+    get_variant.return_value = "treatment"
+    assert (
+        await get_first_meme_nudge_variant_to_send(TREATMENT_USER_ID, is_first_meme=False)
+        == "treatment"
+    )
+
+    popup_sent.return_value = True
+    assert (
+        await get_first_meme_nudge_variant_to_send(TREATMENT_USER_ID, is_first_meme=False) is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_first_meme_nudge.py
+++ b/tests/tgbot/test_first_meme_nudge.py
@@ -14,6 +14,7 @@ from src.database import (
     experiment_assignment,
     user,
 )
+from src.tgbot.senders import popups
 from src.tgbot.senders.popups import (
     FIRST_MEME_NUDGE_EXPERIMENT_ID,
     FIRST_MEME_NUDGE_POPUP_ID,
@@ -147,6 +148,22 @@ async def test_send_failure_releases_lease(setup):
 
     ok_bot.send_message.assert_called_once()
     assert await user_popup_already_sent(TREATMENT_USER_ID, FIRST_MEME_NUDGE_POPUP_ID)
+
+
+@pytest.mark.asyncio
+async def test_send_cancellation_releases_lease(monkeypatch):
+    delete_user_popup_log = AsyncMock()
+    monkeypatch.setattr(popups, "get_experiment_variant", AsyncMock(return_value="treatment"))
+    monkeypatch.setattr(popups, "create_user_popup_log", AsyncMock(return_value=True))
+    monkeypatch.setattr(popups, "delete_user_popup_log", delete_user_popup_log)
+
+    cancelled_bot = _mock_bot(AsyncMock(side_effect=asyncio.CancelledError))
+    monkeypatch.setattr(popups, "bot", cancelled_bot)
+
+    with pytest.raises(asyncio.CancelledError):
+        await maybe_send_first_meme_nudge(TREATMENT_USER_ID, _user_info("en"))
+
+    delete_user_popup_log.assert_awaited_once_with(TREATMENT_USER_ID, FIRST_MEME_NUDGE_POPUP_ID)
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -5,6 +5,7 @@ from telegram.error import BadRequest, NetworkError
 
 from src.storage.constants import MemeType
 from src.storage.schemas import MemeData
+from src.tgbot.senders import meme as meme_sender
 from src.tgbot.senders.meme import edit_last_message_with_meme, send_new_message_with_meme
 
 
@@ -82,3 +83,89 @@ async def test_send_new_message_does_not_retry_ambiguous_transport_error(monkeyp
 
     assert bot.send_photo_calls == 1
     sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_schedules_first_meme_nudge_before_reaction(monkeypatch):
+    calls: list[str] = []
+    scheduled = []
+
+    async def assign_nudge(_user_id: int) -> str:
+        calls.append("assign_nudge")
+        return "treatment"
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction")
+
+    def create_task(coro):
+        scheduled.append(coro)
+        coro.close()
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
+    monkeypatch.setattr(meme_sender, "get_or_assign_first_meme_nudge_variant", assign_nudge)
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", AsyncMock())
+    monkeypatch.setattr(meme_sender.asyncio, "create_task", create_task)
+
+    await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+
+    assert calls == ["assign_nudge", "create_reaction"]
+    assert len(scheduled) == 1
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_skips_first_meme_nudge_for_returning_user(monkeypatch):
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 2}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
+    assign_nudge = AsyncMock()
+    monkeypatch.setattr(meme_sender, "get_or_assign_first_meme_nudge_variant", assign_nudge)
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", AsyncMock())
+
+    await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+
+    assign_nudge.assert_not_awaited()

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -142,9 +142,10 @@ async def test_send_meme_to_user_assigns_first_meme_nudge_before_delivery(monkey
 
 
 @pytest.mark.asyncio
-async def test_send_meme_to_user_records_delivery_before_cancellation(monkeypatch):
+async def test_send_meme_to_user_continues_recording_after_cancellation(monkeypatch):
     calls: list[str] = []
     reaction_started = asyncio.Event()
+    reaction_finished = asyncio.Event()
     reaction_can_finish = asyncio.Event()
 
     async def create_reaction(*_args):
@@ -152,6 +153,7 @@ async def test_send_meme_to_user_records_delivery_before_cancellation(monkeypatc
         reaction_started.set()
         await reaction_can_finish.wait()
         calls.append("create_reaction_finished")
+        reaction_finished.set()
 
     async def send_meme(*_args):
         calls.append("send_meme")
@@ -193,12 +195,13 @@ async def test_send_meme_to_user_records_delivery_before_cancellation(monkeypatc
     await reaction_started.wait()
 
     send_task.cancel()
-    await asyncio.sleep(0)
-    assert not send_task.done()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(send_task, timeout=0.1)
+
+    assert calls == ["send_meme", "create_reaction_started"]
 
     reaction_can_finish.set()
-    with pytest.raises(asyncio.CancelledError):
-        await send_task
+    await asyncio.wait_for(reaction_finished.wait(), timeout=0.1)
 
     assert calls == ["send_meme", "create_reaction_started", "create_reaction_finished"]
 

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -87,7 +87,7 @@ async def test_send_new_message_does_not_retry_ambiguous_transport_error(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_send_meme_to_user_awaits_first_meme_nudge_after_reaction(monkeypatch):
+async def test_send_meme_to_user_assigns_first_meme_nudge_before_delivery(monkeypatch):
     calls: list[str] = []
 
     async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> str:
@@ -100,6 +100,9 @@ async def test_send_meme_to_user_awaits_first_meme_nudge_after_reaction(monkeypa
 
     async def send_nudge(*_args):
         calls.append("send_nudge")
+
+    async def send_meme(*_args):
+        calls.append("send_meme")
 
     monkeypatch.setattr(
         meme_sender,
@@ -124,7 +127,7 @@ async def test_send_meme_to_user_awaits_first_meme_nudge_after_reaction(monkeypa
         "get_meme_caption_for_user_id",
         AsyncMock(return_value="<b>caption</b>"),
     )
-    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
     monkeypatch.setattr(
         meme_sender,
         "get_first_meme_nudge_variant_to_send",
@@ -135,7 +138,69 @@ async def test_send_meme_to_user_awaits_first_meme_nudge_after_reaction(monkeypa
 
     await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
 
-    assert calls == ["assign_nudge", "create_reaction", "send_nudge"]
+    assert calls == ["assign_nudge", "send_meme", "create_reaction", "send_nudge"]
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_records_delivery_before_cancellation(monkeypatch):
+    calls: list[str] = []
+    reaction_started = asyncio.Event()
+    reaction_can_finish = asyncio.Event()
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction_started")
+        reaction_started.set()
+        await reaction_can_finish.wait()
+        calls.append("create_reaction_finished")
+
+    async def send_meme(*_args):
+        calls.append("send_meme")
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+
+    send_task = asyncio.create_task(
+        meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+    )
+    await reaction_started.wait()
+
+    send_task.cancel()
+    await asyncio.sleep(0)
+    assert not send_task.done()
+
+    reaction_can_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await send_task
+
+    assert calls == ["send_meme", "create_reaction_started", "create_reaction_finished"]
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -86,9 +86,8 @@ async def test_send_new_message_does_not_retry_ambiguous_transport_error(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_send_meme_to_user_schedules_first_meme_nudge_before_reaction(monkeypatch):
+async def test_send_meme_to_user_awaits_first_meme_nudge_after_reaction(monkeypatch):
     calls: list[str] = []
-    scheduled = []
 
     async def assign_nudge(_user_id: int) -> str:
         calls.append("assign_nudge")
@@ -97,9 +96,8 @@ async def test_send_meme_to_user_schedules_first_meme_nudge_before_reaction(monk
     async def create_reaction(*_args):
         calls.append("create_reaction")
 
-    def create_task(coro):
-        scheduled.append(coro)
-        coro.close()
+    async def send_nudge(*_args):
+        calls.append("send_nudge")
 
     monkeypatch.setattr(
         meme_sender,
@@ -127,13 +125,11 @@ async def test_send_meme_to_user_schedules_first_meme_nudge_before_reaction(monk
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
     monkeypatch.setattr(meme_sender, "get_or_assign_first_meme_nudge_variant", assign_nudge)
     monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
-    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", AsyncMock())
-    monkeypatch.setattr(meme_sender.asyncio, "create_task", create_task)
+    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", send_nudge)
 
     await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
 
-    assert calls == ["assign_nudge", "create_reaction"]
-    assert len(scheduled) == 1
+    assert calls == ["assign_nudge", "create_reaction", "send_nudge"]
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -89,7 +90,8 @@ async def test_send_new_message_does_not_retry_ambiguous_transport_error(monkeyp
 async def test_send_meme_to_user_awaits_first_meme_nudge_after_reaction(monkeypatch):
     calls: list[str] = []
 
-    async def assign_nudge(_user_id: int) -> str:
+    async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> str:
+        assert is_first_meme is True
         calls.append("assign_nudge")
         return "treatment"
 
@@ -123,7 +125,11 @@ async def test_send_meme_to_user_awaits_first_meme_nudge_after_reaction(monkeypa
         AsyncMock(return_value="<b>caption</b>"),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
-    monkeypatch.setattr(meme_sender, "get_or_assign_first_meme_nudge_variant", assign_nudge)
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
     monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
     monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", send_nudge)
 
@@ -133,7 +139,96 @@ async def test_send_meme_to_user_awaits_first_meme_nudge_after_reaction(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_send_meme_to_user_skips_first_meme_nudge_for_returning_user(monkeypatch):
+async def test_send_meme_to_user_can_defer_first_meme_nudge_after_reaction(monkeypatch):
+    calls: list[str] = []
+    nudge_can_finish = asyncio.Event()
+
+    async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> str:
+        assert is_first_meme is True
+        calls.append("assign_nudge")
+        return "treatment"
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction")
+
+    async def send_nudge(*_args):
+        calls.append("send_nudge_started")
+        await nudge_can_finish.wait()
+        calls.append("send_nudge_finished")
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", send_nudge)
+
+    nudge_tasks: list[asyncio.Task[None]] = []
+    await asyncio.wait_for(
+        meme_sender.send_meme_to_user(
+            bot=object(),
+            user_id=12001,
+            meme=_meme(),
+            first_meme_nudge_tasks=nudge_tasks,
+        ),
+        timeout=0.1,
+    )
+    await asyncio.sleep(0)
+
+    assert calls == ["assign_nudge", "create_reaction", "send_nudge_started"]
+    assert len(nudge_tasks) == 1
+    assert not nudge_tasks[0].done()
+
+    nudge_can_finish.set()
+    await nudge_tasks[0]
+    assert calls == [
+        "assign_nudge",
+        "create_reaction",
+        "send_nudge_started",
+        "send_nudge_finished",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_retries_assigned_undelivered_nudge(monkeypatch):
+    calls: list[str] = []
+
+    async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> str:
+        assert is_first_meme is False
+        calls.append("pending_nudge")
+        return "treatment"
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction")
+
+    async def send_nudge(*_args):
+        calls.append("send_nudge")
+
     monkeypatch.setattr(
         meme_sender,
         "get_user_info",
@@ -158,10 +253,53 @@ async def test_send_meme_to_user_skips_first_meme_nudge_for_returning_user(monke
         AsyncMock(return_value="<b>caption</b>"),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
-    assign_nudge = AsyncMock()
-    monkeypatch.setattr(meme_sender, "get_or_assign_first_meme_nudge_variant", assign_nudge)
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", send_nudge)
+
+    await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+
+    assert calls == ["pending_nudge", "create_reaction", "send_nudge"]
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_does_not_assign_new_nudge_for_returning_user(monkeypatch):
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 2}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
+    first_meme_nudge_variant = AsyncMock()
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
     monkeypatch.setattr(meme_sender, "create_user_meme_reaction", AsyncMock())
 
     await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
 
-    assign_nudge.assert_not_awaited()
+    first_meme_nudge_variant.assert_awaited_once_with(12001, is_first_meme=False)


### PR DESCRIPTION
Fixes FFM-1501.

## Root cause
`next_message()` scheduled the `first_meme_nudge` experiment for a user's first recommendation-path meme, but direct delivery paths use `send_meme_to_user()` instead. That includes the active-15m broadcast flow, shared meme deep links, and moderator manual sends, so a user whose first meme came through one of those paths could bypass the onboarding nudge assignment.

## Change
- Teach `send_meme_to_user()` to detect `nmemes_sent == 0`, assign the first-meme nudge before creating the `user_meme_reaction`, and schedule the treatment nudge after the reaction row is created.
- Add regression coverage proving direct first sends schedule the nudge before reaction persistence and returning users do not enter the experiment path.
- Add `cold_start_nsessions_gate_enabled` to recommendation batch diagnostics so Analyst can confirm the live production flag from existing recommendation logs/Sentry payloads after deploy. Code default is `False`; I could not safely verify the deployed env value from this runtime.

## Verification
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `DATABASE_URL=postgresql+asyncpg://app:app@app_db:5432/app TELEGRAM_BOT_TOKEN=123456:ABCdefghijklmnopqrstuvwxyz pytest tests/tgbot/test_meme_sender.py tests/recommendations/test_pipeline.py::test_compact_diagnostics_exclude_candidate_ids`

Note: the plain pytest command inherited an invalid ambient `postgres://` URL and dummy Telegram token from the harness, so the targeted tests were run with explicit test env overrides.