### PR TITLE
Fix FFM-1520: cover direct first-meme nudge sends

### DIFF
--- a/src/flows/broadcasts/meme.py
+++ b/src/flows/broadcasts/meme.py
@@ -11,6 +11,8 @@ from src.recommendations.meme_queue import check_queue, get_next_meme_for_user
 from src.tgbot.bot import bot
 from src.tgbot.senders.meme import send_meme_to_user
 
+FIRST_MEME_NUDGE_DRAIN_TIMEOUT_SECONDS = 10
+
 _BROADCAST_FLOW_OPTS = dict(
     retries=1,
     retry_delay_seconds=30,
@@ -19,11 +21,52 @@ _BROADCAST_FLOW_OPTS = dict(
 )
 
 
-async def _send_to_user(user_id: int) -> None:
+async def _send_to_user(
+    user_id: int,
+    first_meme_nudge_tasks: list[asyncio.Task[None]],
+) -> None:
     await check_queue(user_id)
     meme = await get_next_meme_for_user(user_id)
     if meme:
-        await send_meme_to_user(bot, user_id, meme)
+        await send_meme_to_user(
+            bot,
+            user_id,
+            meme,
+            first_meme_nudge_tasks=first_meme_nudge_tasks,
+        )
+
+
+async def _drain_first_meme_nudge_tasks(
+    tasks: list[asyncio.Task[None]],
+    logger,
+) -> None:
+    if not tasks:
+        return
+
+    done, pending = await asyncio.wait(
+        tasks,
+        timeout=FIRST_MEME_NUDGE_DRAIN_TIMEOUT_SECONDS,
+    )
+    if pending:
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        logger.warning(
+            "Timed out sending %s first-meme nudge(s); released leases for retry",
+            len(pending),
+        )
+
+    for task in done:
+        if task.cancelled():
+            continue
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(
+                "Failed to send first-meme nudge after broadcast meme delivery",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+
+    tasks.clear()
 
 
 async def broadcast_next_meme_to_users(user_ids: list[int]):
@@ -31,13 +74,18 @@ async def broadcast_next_meme_to_users(user_ids: list[int]):
     logger.info(f"Going to sent next meme to {len(user_ids)} users")
 
     for user_id in user_ids:
+        first_meme_nudge_tasks: list[asyncio.Task[None]] = []
         try:
-            await asyncio.wait_for(_send_to_user(user_id), timeout=20)
+            await asyncio.wait_for(
+                _send_to_user(user_id, first_meme_nudge_tasks),
+                timeout=20,
+            )
             logger.info(f"Sent meme to #{user_id}")
         except asyncio.TimeoutError:
             logger.warning(f"Timed out processing user #{user_id} (>20s), skipping")
         except Exception:
             logger.warning(f"Failed to send meme to #{user_id}", exc_info=True)
+        await _drain_first_meme_nudge_tasks(first_meme_nudge_tasks, logger)
         await asyncio.sleep(0.2)  # flood control
 
 

--- a/src/flows/broadcasts/meme.py
+++ b/src/flows/broadcasts/meme.py
@@ -49,24 +49,30 @@ async def _drain_first_meme_nudge_tasks(
     )
     if pending:
         for task in pending:
-            task.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
+            task.add_done_callback(
+                lambda done_task: _log_first_meme_nudge_task_result(done_task, logger)
+            )
         logger.warning(
-            "Timed out sending %s first-meme nudge(s); kept leases to avoid duplicate nudges",
+            "Timed out waiting for %s first-meme nudge(s); left in-flight sends running",
             len(pending),
         )
 
     for task in done:
-        if task.cancelled():
-            continue
-        exc = task.exception()
-        if exc is not None:
-            logger.warning(
-                "Failed to send first-meme nudge after broadcast meme delivery",
-                exc_info=(type(exc), exc, exc.__traceback__),
-            )
+        _log_first_meme_nudge_task_result(task, logger)
 
     tasks.clear()
+
+
+def _log_first_meme_nudge_task_result(task: asyncio.Task[None], logger) -> None:
+    if task.cancelled():
+        return
+
+    exc = task.exception()
+    if exc is not None:
+        logger.warning(
+            "Failed to send first-meme nudge after broadcast meme delivery",
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
 
 
 async def broadcast_next_meme_to_users(user_ids: list[int]):

--- a/src/flows/broadcasts/meme.py
+++ b/src/flows/broadcasts/meme.py
@@ -21,6 +21,32 @@ _BROADCAST_FLOW_OPTS = dict(
 )
 
 
+class _FirstMemeNudgeTaskList(list[asyncio.Task[None]]):
+    def __init__(self, logger):
+        super().__init__()
+        self._logger = logger
+        self._closed = False
+
+    def append(self, task: asyncio.Task[None]) -> None:
+        if self._closed:
+            task.add_done_callback(
+                lambda done_task: _log_first_meme_nudge_task_result(
+                    done_task,
+                    self._logger,
+                )
+            )
+            self._logger.warning(
+                "Registered first-meme nudge task after broadcast drain; "
+                "left in-flight send running"
+            )
+            return
+
+        super().append(task)
+
+    def close(self) -> None:
+        self._closed = True
+
+
 async def _send_to_user(
     user_id: int,
     first_meme_nudge_tasks: list[asyncio.Task[None]],
@@ -40,27 +66,47 @@ async def _drain_first_meme_nudge_tasks(
     tasks: list[asyncio.Task[None]],
     logger,
 ) -> None:
-    if not tasks:
-        return
+    try:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + FIRST_MEME_NUDGE_DRAIN_TIMEOUT_SECONDS
 
-    done, pending = await asyncio.wait(
-        tasks,
-        timeout=FIRST_MEME_NUDGE_DRAIN_TIMEOUT_SECONDS,
-    )
-    if pending:
-        for task in pending:
-            task.add_done_callback(
-                lambda done_task: _log_first_meme_nudge_task_result(done_task, logger)
-            )
-        logger.warning(
-            "Timed out waiting for %s first-meme nudge(s); left in-flight sends running",
-            len(pending),
-        )
+        while tasks:
+            current_tasks = list(tasks)
+            tasks.clear()
+            timeout = max(0, deadline - loop.time())
 
-    for task in done:
-        _log_first_meme_nudge_task_result(task, logger)
+            if timeout == 0:
+                done: set[asyncio.Task[None]] = set()
+                pending = set(current_tasks)
+            else:
+                done, pending = await asyncio.wait(
+                    current_tasks,
+                    timeout=timeout,
+                )
 
-    tasks.clear()
+            for task in done:
+                _log_first_meme_nudge_task_result(task, logger)
+
+            if pending:
+                timed_out_tasks = set(pending)
+                timed_out_tasks.update(tasks)
+                tasks.clear()
+                for task in timed_out_tasks:
+                    task.add_done_callback(
+                        lambda done_task: _log_first_meme_nudge_task_result(
+                            done_task,
+                            logger,
+                        )
+                    )
+                logger.warning(
+                    "Timed out waiting for %s first-meme nudge(s); left in-flight sends running",
+                    len(timed_out_tasks),
+                )
+                return
+    finally:
+        close = getattr(tasks, "close", None)
+        if close is not None:
+            close()
 
 
 def _log_first_meme_nudge_task_result(task: asyncio.Task[None], logger) -> None:
@@ -80,7 +126,7 @@ async def broadcast_next_meme_to_users(user_ids: list[int]):
     logger.info(f"Going to sent next meme to {len(user_ids)} users")
 
     for user_id in user_ids:
-        first_meme_nudge_tasks: list[asyncio.Task[None]] = []
+        first_meme_nudge_tasks: list[asyncio.Task[None]] = _FirstMemeNudgeTaskList(logger)
         try:
             await asyncio.wait_for(
                 _send_to_user(user_id, first_meme_nudge_tasks),

--- a/src/flows/broadcasts/meme.py
+++ b/src/flows/broadcasts/meme.py
@@ -26,18 +26,16 @@ class _FirstMemeNudgeTaskList(list[asyncio.Task[None]]):
         super().__init__()
         self._logger = logger
         self._closed = False
+        self._late_observers: set[asyncio.Task[None]] = set()
 
     def append(self, task: asyncio.Task[None]) -> None:
         if self._closed:
-            task.add_done_callback(
-                lambda done_task: _log_first_meme_nudge_task_result(
-                    done_task,
-                    self._logger,
-                )
-            )
+            observer = asyncio.create_task(_observe_first_meme_nudge_task(task, self._logger))
+            self._late_observers.add(observer)
+            observer.add_done_callback(self._late_observers.discard)
             self._logger.warning(
                 "Registered first-meme nudge task after broadcast drain; "
-                "left in-flight send running"
+                "observing in-flight send to completion"
             )
             return
 
@@ -119,6 +117,20 @@ def _log_first_meme_nudge_task_result(task: asyncio.Task[None], logger) -> None:
             "Failed to send first-meme nudge after broadcast meme delivery",
             exc_info=(type(exc), exc, exc.__traceback__),
         )
+
+
+async def _observe_first_meme_nudge_task(task: asyncio.Task[None], logger) -> None:
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.add_done_callback(
+            lambda done_task: _log_first_meme_nudge_task_result(done_task, logger)
+        )
+        raise
+    except Exception:
+        pass
+
+    _log_first_meme_nudge_task_result(task, logger)
 
 
 async def broadcast_next_meme_to_users(user_ids: list[int]):

--- a/src/flows/broadcasts/meme.py
+++ b/src/flows/broadcasts/meme.py
@@ -52,7 +52,7 @@ async def _drain_first_meme_nudge_tasks(
             task.cancel()
         await asyncio.gather(*pending, return_exceptions=True)
         logger.warning(
-            "Timed out sending %s first-meme nudge(s); released leases for retry",
+            "Timed out sending %s first-meme nudge(s); kept leases to avoid duplicate nudges",
             len(pending),
         )
 

--- a/src/recommendations/pipeline.py
+++ b/src/recommendations/pipeline.py
@@ -134,6 +134,7 @@ class RecommendationBatchDiagnostics:
     user_type: str | None
     queue_len_before: int
     exclude_count: int
+    cold_start_nsessions_gate_enabled: bool = False
     diagnostics_sample_rate: float = 0.01
     maturity_stage: str | None = None
     duration_ms: int = 0
@@ -175,6 +176,7 @@ class RecommendationBatchDiagnostics:
             "limit": self.limit,
             "nmemes_sent": self.nmemes_sent,
             "nsessions": self.nsessions,
+            "cold_start_nsessions_gate_enabled": self.cold_start_nsessions_gate_enabled,
             "queue_len_before": self.queue_len_before,
             "exclude_count": self.exclude_count,
             "selected_count": self.selected_count,
@@ -284,6 +286,7 @@ class RecommendationBatchPipeline:
             user_type=request.user_type,
             queue_len_before=len(request.meme_ids_in_queue),
             exclude_count=len(request.meme_ids_in_queue),
+            cold_start_nsessions_gate_enabled=request.cold_start_nsessions_gate_enabled,
             diagnostics_sample_rate=request.diagnostics_sample_rate,
             source_diversity_enabled=request.source_diversity_enabled,
             shadow_scoring_enabled=request.shadow_scoring_enabled,

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -70,12 +70,11 @@ async def send_meme_to_user(
     )
     meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 
+    await send_new_message_with_meme(bot, user_id, meme, reply_markup)
     nudge_variant = await get_first_meme_nudge_variant_to_send(
         user_id,
         is_first_meme=is_first_meme,
     )
-
-    await send_new_message_with_meme(bot, user_id, meme, reply_markup)
     await _record_delivered_meme_reaction(user_id, meme)
     if nudge_variant == "treatment":
         nudge_task = asyncio.create_task(maybe_send_first_meme_nudge(user_id, user_info))

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -100,11 +100,11 @@ async def _complete_direct_meme_delivery(
     is_first_meme: bool,
     first_meme_nudge_tasks: list[asyncio.Task[None]] | None,
 ) -> None:
+    await _record_delivered_meme_reaction(user_id, meme)
     nudge_variant = await get_first_meme_nudge_variant_to_send(
         user_id,
         is_first_meme=is_first_meme,
     )
-    await _record_delivered_meme_reaction(user_id, meme)
     if nudge_variant == "treatment":
         nudge_task = asyncio.create_task(maybe_send_first_meme_nudge(user_id, user_info))
         if first_meme_nudge_tasks is None:

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -83,6 +83,8 @@ async def send_meme_to_user(
             first_meme_nudge_tasks=first_meme_nudge_tasks,
         )
     )
+    if first_meme_nudge_tasks is not None:
+        first_meme_nudge_tasks.append(delivery_task)
     try:
         await asyncio.shield(delivery_task)
     except asyncio.CancelledError:
@@ -100,11 +102,26 @@ async def _complete_direct_meme_delivery(
     is_first_meme: bool,
     first_meme_nudge_tasks: list[asyncio.Task[None]] | None,
 ) -> None:
+    nudge_assignment_error: Exception | None = None
+    try:
+        nudge_variant = await get_first_meme_nudge_variant_to_send(
+            user_id,
+            is_first_meme=is_first_meme,
+        )
+    except Exception as exc:
+        nudge_variant = None
+        nudge_assignment_error = exc
+        logger.warning(
+            "Failed to assign first-meme nudge before recording delivered meme for user %s meme %s",
+            user_id,
+            meme.id,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
     await _record_delivered_meme_reaction(user_id, meme)
-    nudge_variant = await get_first_meme_nudge_variant_to_send(
-        user_id,
-        is_first_meme=is_first_meme,
-    )
+    if nudge_assignment_error is not None:
+        raise nudge_assignment_error
+
     if nudge_variant == "treatment":
         nudge_task = asyncio.create_task(maybe_send_first_meme_nudge(user_id, user_info))
         if first_meme_nudge_tasks is None:

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -70,7 +70,36 @@ async def send_meme_to_user(
     )
     meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 
-    await send_new_message_with_meme(bot, user_id, meme, reply_markup)
+    sent_message = await send_new_message_with_meme(bot, user_id, meme, reply_markup)
+    if sent_message is None:
+        return
+
+    delivery_task = asyncio.create_task(
+        _complete_direct_meme_delivery(
+            user_id,
+            meme,
+            user_info,
+            is_first_meme=is_first_meme,
+            first_meme_nudge_tasks=first_meme_nudge_tasks,
+        )
+    )
+    try:
+        await asyncio.shield(delivery_task)
+    except asyncio.CancelledError:
+        delivery_task.add_done_callback(
+            lambda task: _log_direct_meme_delivery_result(task, user_id, meme.id)
+        )
+        raise
+
+
+async def _complete_direct_meme_delivery(
+    user_id: int,
+    meme: MemeData,
+    user_info: dict,
+    *,
+    is_first_meme: bool,
+    first_meme_nudge_tasks: list[asyncio.Task[None]] | None,
+) -> None:
     nudge_variant = await get_first_meme_nudge_variant_to_send(
         user_id,
         is_first_meme=is_first_meme,
@@ -82,6 +111,28 @@ async def send_meme_to_user(
             await nudge_task
         else:
             first_meme_nudge_tasks.append(nudge_task)
+
+
+def _log_direct_meme_delivery_result(
+    task: asyncio.Task[None],
+    user_id: int,
+    meme_id: int,
+) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        logger.warning(
+            "Post-delivery work was cancelled for user %s meme %s",
+            user_id,
+            meme_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to complete post-delivery work for user %s meme %s after cancellation",
+            user_id,
+            meme_id,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
 
 
 async def _record_delivered_meme_reaction(user_id: int, meme: MemeData) -> None:
@@ -178,7 +229,7 @@ async def send_new_message_with_meme(
     user_id: int,
     meme: MemeData,
     reply_markup: InlineKeyboardMarkup | None = None,
-) -> Message:
+) -> Message | None:
     async def _do_send(parse_mode):
         if meme.type == MemeType.IMAGE:
             return await bot.send_photo(

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Tuple
 
@@ -21,6 +22,10 @@ from src.tgbot.senders.keyboards import (
 )
 from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
 from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
+from src.tgbot.senders.popups import (
+    get_first_meme_nudge_variant_to_send,
+    maybe_send_first_meme_nudge,
+)
 from src.tgbot.senders.utils import collect_user_languages
 from src.tgbot.service import mark_user_blocked
 from src.tgbot.sharing import (
@@ -38,9 +43,11 @@ async def send_meme_to_user(
     user_id: int,
     meme: MemeData,
     reaction_context: str | None = None,
+    first_meme_nudge_tasks: list[asyncio.Task[None]] | None = None,
 ):
     user_info = await get_user_info(user_id)
     languages = await collect_user_languages(user_id, user_info["interface_lang"])
+    is_first_meme = (user_info["nmemes_sent"] or 0) == 0
     referral_button_text = get_meme_share_button_text(user_info["interface_lang"])
     share_button_variant = await get_or_assign_meme_share_button_variant(user_id)
     logger.debug(
@@ -63,8 +70,56 @@ async def send_meme_to_user(
     )
     meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
 
+    nudge_variant = await get_first_meme_nudge_variant_to_send(
+        user_id,
+        is_first_meme=is_first_meme,
+    )
+
     await send_new_message_with_meme(bot, user_id, meme, reply_markup)
-    await create_user_meme_reaction(user_id, meme.id, meme.recommended_by or "direct")
+    await _record_delivered_meme_reaction(user_id, meme)
+    if nudge_variant == "treatment":
+        nudge_task = asyncio.create_task(maybe_send_first_meme_nudge(user_id, user_info))
+        if first_meme_nudge_tasks is None:
+            await nudge_task
+        else:
+            first_meme_nudge_tasks.append(nudge_task)
+
+
+async def _record_delivered_meme_reaction(user_id: int, meme: MemeData) -> None:
+    # Once Telegram accepts a direct send, cancellation must not skip the row
+    # that lets reaction callbacks and recommendation dedupe find that delivery.
+    reaction_task = asyncio.create_task(
+        create_user_meme_reaction(user_id, meme.id, meme.recommended_by or "direct")
+    )
+    try:
+        await asyncio.shield(reaction_task)
+    except asyncio.CancelledError:
+        reaction_task.add_done_callback(
+            lambda task: _log_delivered_meme_reaction_result(task, user_id, meme.id)
+        )
+        raise
+
+
+def _log_delivered_meme_reaction_result(
+    task: asyncio.Task[None],
+    user_id: int,
+    meme_id: int,
+) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        logger.warning(
+            "Delivered meme reaction recording was cancelled for user %s meme %s",
+            user_id,
+            meme_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to record delivered meme reaction for user %s meme %s after cancellation",
+            user_id,
+            meme_id,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
 
 
 def get_input_media(

--- a/src/tgbot/senders/popups.py
+++ b/src/tgbot/senders/popups.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections.abc import Callable
 
@@ -248,12 +249,27 @@ async def get_or_assign_first_meme_nudge_variant(user_id: int) -> str | None:
     return proposed
 
 
+async def get_first_meme_nudge_variant_to_send(
+    user_id: int,
+    *,
+    is_first_meme: bool,
+) -> str | None:
+    if is_first_meme:
+        return await get_or_assign_first_meme_nudge_variant(user_id)
+
+    if await user_popup_already_sent(user_id, FIRST_MEME_NUDGE_POPUP_ID):
+        return None
+
+    variant = await get_experiment_variant(user_id, FIRST_MEME_NUDGE_EXPERIMENT_ID)
+    if variant == "treatment":
+        return variant
+    return None
+
+
 async def maybe_send_first_meme_nudge(user_id: int, user_info: dict) -> None:
-    # Treatment-only sender. Caller is expected to have already invoked
-    # get_or_assign_first_meme_nudge_variant synchronously (in the meme
-    # delivery path, before create_user_meme_reaction) so the cohort row
-    # is locked in. Safe to dispatch as a background asyncio task — only
-    # the slow Telegram I/O lives here.
+    # Treatment-only sender. First-meme callers must assign synchronously before
+    # create_user_meme_reaction; later callers may retry only if that assignment
+    # already exists and the popup log is still missing.
     variant = await get_experiment_variant(user_id, FIRST_MEME_NUDGE_EXPERIMENT_ID)
     if variant != "treatment":
         return
@@ -277,6 +293,12 @@ async def maybe_send_first_meme_nudge(user_id: int, user_info: dict) -> None:
         # user can't receive messages anyway, and nmemes_sent will advance past 0
         # so this code path won't re-enter for this user.
         return
+    except asyncio.CancelledError:
+        # Broadcast callers may wrap direct sends in asyncio.wait_for. If that
+        # cancellation lands after the lease insert but before Telegram confirms
+        # delivery, release the lease so a later retry can send the nudge.
+        await delete_user_popup_log(user_id, FIRST_MEME_NUDGE_POPUP_ID)
+        raise
     except TelegramError as exc:
         # Transient delivery failure (timeout, rate-limit, etc.). Release the
         # lease so a future meme #1 attempt can re-fire the nudge.

--- a/src/tgbot/senders/popups.py
+++ b/src/tgbot/senders/popups.py
@@ -295,9 +295,9 @@ async def maybe_send_first_meme_nudge(user_id: int, user_info: dict) -> None:
         return
     except asyncio.CancelledError:
         # Broadcast callers may wrap direct sends in asyncio.wait_for. If that
-        # cancellation lands after the lease insert but before Telegram confirms
-        # delivery, release the lease so a later retry can send the nudge.
-        await delete_user_popup_log(user_id, FIRST_MEME_NUDGE_POPUP_ID)
+        # cancellation lands after the lease insert, the Telegram send outcome
+        # is ambiguous. Keep the lease so a later retry cannot duplicate a
+        # nudge Telegram may already have accepted.
         raise
     except TelegramError as exc:
         # Transient delivery failure (timeout, rate-limit, etc.). Release the

--- a/tests/flows/test_broadcasts_meme.py
+++ b/tests/flows/test_broadcasts_meme.py
@@ -32,3 +32,21 @@ async def test_broadcast_drains_deferred_first_meme_nudge(monkeypatch):
     nudge_can_finish.set()
     await asyncio.wait_for(broadcast_task, timeout=0.2)
     logger.info.assert_any_call("Sent meme to #12001")
+
+
+@pytest.mark.asyncio
+async def test_broadcast_drain_timeout_keeps_first_meme_nudge_lease(monkeypatch):
+    async def nudge_task() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(nudge_task())
+    logger = MagicMock()
+    monkeypatch.setattr(broadcast_meme, "FIRST_MEME_NUDGE_DRAIN_TIMEOUT_SECONDS", 0.001)
+
+    await broadcast_meme._drain_first_meme_nudge_tasks([task], logger)
+
+    assert task.cancelled()
+    logger.warning.assert_called_once_with(
+        "Timed out sending %s first-meme nudge(s); kept leases to avoid duplicate nudges",
+        1,
+    )

--- a/tests/flows/test_broadcasts_meme.py
+++ b/tests/flows/test_broadcasts_meme.py
@@ -52,3 +52,28 @@ async def test_broadcast_drain_timeout_keeps_first_meme_nudge_lease(monkeypatch)
     )
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_logs_first_meme_nudge_appended_after_drain():
+    async def nudge_task() -> None:
+        raise RuntimeError("late nudge failed")
+
+    logger = MagicMock()
+    tasks = broadcast_meme._FirstMemeNudgeTaskList(logger)
+
+    await broadcast_meme._drain_first_meme_nudge_tasks(tasks, logger)
+
+    task = asyncio.create_task(nudge_task())
+    tasks.append(task)
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    logger.warning.assert_any_call(
+        "Registered first-meme nudge task after broadcast drain; left in-flight send running"
+    )
+    assert any(
+        call.args == ("Failed to send first-meme nudge after broadcast meme delivery",)
+        and "exc_info" in call.kwargs
+        for call in logger.warning.call_args_list
+    )

--- a/tests/flows/test_broadcasts_meme.py
+++ b/tests/flows/test_broadcasts_meme.py
@@ -45,8 +45,10 @@ async def test_broadcast_drain_timeout_keeps_first_meme_nudge_lease(monkeypatch)
 
     await broadcast_meme._drain_first_meme_nudge_tasks([task], logger)
 
-    assert task.cancelled()
+    assert not task.done()
     logger.warning.assert_called_once_with(
-        "Timed out sending %s first-meme nudge(s); kept leases to avoid duplicate nudges",
+        "Timed out waiting for %s first-meme nudge(s); left in-flight sends running",
         1,
     )
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)

--- a/tests/flows/test_broadcasts_meme.py
+++ b/tests/flows/test_broadcasts_meme.py
@@ -1,0 +1,34 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.flows.broadcasts import meme as broadcast_meme
+
+
+@pytest.mark.asyncio
+async def test_broadcast_drains_deferred_first_meme_nudge(monkeypatch):
+    nudge_started = asyncio.Event()
+    nudge_can_finish = asyncio.Event()
+
+    async def nudge_task() -> None:
+        nudge_started.set()
+        await nudge_can_finish.wait()
+
+    async def send_to_user(_user_id: int, first_meme_nudge_tasks: list[asyncio.Task[None]]) -> None:
+        first_meme_nudge_tasks.append(asyncio.create_task(nudge_task()))
+
+    logger = MagicMock()
+    monkeypatch.setattr(broadcast_meme, "get_run_logger", lambda: logger)
+    monkeypatch.setattr(broadcast_meme, "_send_to_user", send_to_user)
+    monkeypatch.setattr(broadcast_meme.asyncio, "sleep", AsyncMock())
+
+    broadcast_task = asyncio.create_task(broadcast_meme.broadcast_next_meme_to_users([12001]))
+    await nudge_started.wait()
+    await asyncio.sleep(0)
+
+    assert not broadcast_task.done()
+
+    nudge_can_finish.set()
+    await asyncio.wait_for(broadcast_task, timeout=0.2)
+    logger.info.assert_any_call("Sent meme to #12001")

--- a/tests/flows/test_broadcasts_meme.py
+++ b/tests/flows/test_broadcasts_meme.py
@@ -70,10 +70,12 @@ async def test_broadcast_logs_first_meme_nudge_appended_after_drain():
     await asyncio.sleep(0)
 
     logger.warning.assert_any_call(
-        "Registered first-meme nudge task after broadcast drain; left in-flight send running"
+        "Registered first-meme nudge task after broadcast drain; "
+        "observing in-flight send to completion"
     )
     assert any(
         call.args == ("Failed to send first-meme nudge after broadcast meme delivery",)
         and "exc_info" in call.kwargs
         for call in logger.warning.call_args_list
     )
+    assert not tasks._late_observers

--- a/tests/tgbot/test_first_meme_nudge.py
+++ b/tests/tgbot/test_first_meme_nudge.py
@@ -152,7 +152,7 @@ async def test_send_failure_releases_lease(setup):
 
 
 @pytest.mark.asyncio
-async def test_send_cancellation_releases_lease(monkeypatch):
+async def test_send_cancellation_keeps_lease(monkeypatch):
     delete_user_popup_log = AsyncMock()
     monkeypatch.setattr(popups, "get_experiment_variant", AsyncMock(return_value="treatment"))
     monkeypatch.setattr(popups, "create_user_popup_log", AsyncMock(return_value=True))
@@ -164,7 +164,7 @@ async def test_send_cancellation_releases_lease(monkeypatch):
     with pytest.raises(asyncio.CancelledError):
         await maybe_send_first_meme_nudge(TREATMENT_USER_ID, _user_info("en"))
 
-    delete_user_popup_log.assert_awaited_once_with(TREATMENT_USER_ID, FIRST_MEME_NUDGE_POPUP_ID)
+    delete_user_popup_log.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_first_meme_nudge.py
+++ b/tests/tgbot/test_first_meme_nudge.py
@@ -14,9 +14,11 @@ from src.database import (
     experiment_assignment,
     user,
 )
+from src.tgbot.senders import popups
 from src.tgbot.senders.popups import (
     FIRST_MEME_NUDGE_EXPERIMENT_ID,
     FIRST_MEME_NUDGE_POPUP_ID,
+    get_first_meme_nudge_variant_to_send,
     get_or_assign_first_meme_nudge_variant,
     maybe_send_first_meme_nudge,
 )
@@ -150,6 +152,22 @@ async def test_send_failure_releases_lease(setup):
 
 
 @pytest.mark.asyncio
+async def test_send_cancellation_releases_lease(monkeypatch):
+    delete_user_popup_log = AsyncMock()
+    monkeypatch.setattr(popups, "get_experiment_variant", AsyncMock(return_value="treatment"))
+    monkeypatch.setattr(popups, "create_user_popup_log", AsyncMock(return_value=True))
+    monkeypatch.setattr(popups, "delete_user_popup_log", delete_user_popup_log)
+
+    cancelled_bot = _mock_bot(AsyncMock(side_effect=asyncio.CancelledError))
+    monkeypatch.setattr(popups, "bot", cancelled_bot)
+
+    with pytest.raises(asyncio.CancelledError):
+        await maybe_send_first_meme_nudge(TREATMENT_USER_ID, _user_info("en"))
+
+    delete_user_popup_log.assert_awaited_once_with(TREATMENT_USER_ID, FIRST_MEME_NUDGE_POPUP_ID)
+
+
+@pytest.mark.asyncio
 async def test_existing_popup_log_short_circuits(setup):
     # Simulate a backfill / prior run that already logged the nudge.
     await create_user_popup_log(TREATMENT_USER_ID, FIRST_MEME_NUDGE_POPUP_ID)
@@ -206,6 +224,37 @@ async def test_assignment_helper_is_idempotent(setup):
         )
         rows = result.fetchall()
     assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_delivery_helper_retries_only_existing_treatment_assignment(monkeypatch):
+    assign_variant = AsyncMock(return_value="treatment")
+    popup_sent = AsyncMock(return_value=False)
+    get_variant = AsyncMock(return_value=None)
+    monkeypatch.setattr(popups, "get_or_assign_first_meme_nudge_variant", assign_variant)
+    monkeypatch.setattr(popups, "user_popup_already_sent", popup_sent)
+    monkeypatch.setattr(popups, "get_experiment_variant", get_variant)
+
+    assert (
+        await get_first_meme_nudge_variant_to_send(TREATMENT_USER_ID, is_first_meme=True)
+        == "treatment"
+    )
+    assign_variant.assert_awaited_once_with(TREATMENT_USER_ID)
+
+    assert await get_first_meme_nudge_variant_to_send(CONTROL_USER_ID, is_first_meme=False) is None
+    assign_variant.assert_awaited_once()
+    get_variant.assert_awaited_once_with(CONTROL_USER_ID, FIRST_MEME_NUDGE_EXPERIMENT_ID)
+
+    get_variant.return_value = "treatment"
+    assert (
+        await get_first_meme_nudge_variant_to_send(TREATMENT_USER_ID, is_first_meme=False)
+        == "treatment"
+    )
+
+    popup_sent.return_value = True
+    assert (
+        await get_first_meme_nudge_variant_to_send(TREATMENT_USER_ID, is_first_meme=False) is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -87,7 +87,7 @@ async def test_send_new_message_does_not_retry_ambiguous_transport_error(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_send_meme_to_user_assigns_first_meme_nudge_before_delivery(monkeypatch):
+async def test_send_meme_to_user_assigns_first_meme_nudge_after_delivery(monkeypatch):
     calls: list[str] = []
 
     async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> str:
@@ -138,7 +138,56 @@ async def test_send_meme_to_user_assigns_first_meme_nudge_before_delivery(monkey
 
     await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
 
-    assert calls == ["assign_nudge", "send_meme", "create_reaction", "send_nudge"]
+    assert calls == ["send_meme", "assign_nudge", "create_reaction", "send_nudge"]
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_does_not_assign_first_meme_nudge_on_failed_delivery(monkeypatch):
+    nudge_variant = AsyncMock(return_value="treatment")
+    create_reaction = AsyncMock()
+    send_nudge = AsyncMock()
+
+    async def send_meme(*_args):
+        raise NetworkError("All connection attempts failed")
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", send_nudge)
+
+    with pytest.raises(NetworkError):
+        await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+
+    nudge_variant.assert_not_awaited()
+    create_reaction.assert_not_awaited()
+    send_nudge.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -139,7 +139,7 @@ async def test_send_meme_to_user_assigns_first_meme_nudge_after_delivery(monkeyp
 
     await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
 
-    assert calls == ["send_meme", "assign_nudge", "create_reaction", "send_nudge"]
+    assert calls == ["send_meme", "create_reaction", "assign_nudge", "send_nudge"]
 
 
 @pytest.mark.asyncio
@@ -239,6 +239,61 @@ async def test_send_meme_to_user_does_not_assign_first_meme_nudge_on_rejected_de
 
 
 @pytest.mark.asyncio
+async def test_send_meme_to_user_records_delivery_before_nudge_assignment_error(
+    monkeypatch,
+):
+    calls: list[str] = []
+
+    async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> str:
+        assert is_first_meme is True
+        calls.append("assign_nudge")
+        raise RuntimeError("experiment storage unavailable")
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction")
+
+    async def send_meme(*_args):
+        calls.append("send_meme")
+        return object()
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+
+    with pytest.raises(RuntimeError, match="experiment storage unavailable"):
+        await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+
+    assert calls == ["send_meme", "create_reaction", "assign_nudge"]
+
+
+@pytest.mark.asyncio
 async def test_send_meme_to_user_continues_recording_after_cancellation(monkeypatch):
     calls: list[str] = []
     reaction_started = asyncio.Event()
@@ -310,8 +365,8 @@ async def test_send_meme_to_user_continues_post_delivery_after_nudge_assignment_
 ):
     calls: list[str] = []
     nudge_assignment_started = asyncio.Event()
+    nudge_assignment_finished = asyncio.Event()
     nudge_assignment_can_finish = asyncio.Event()
-    reaction_finished = asyncio.Event()
 
     async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> None:
         assert is_first_meme is True
@@ -319,11 +374,11 @@ async def test_send_meme_to_user_continues_post_delivery_after_nudge_assignment_
         nudge_assignment_started.set()
         await nudge_assignment_can_finish.wait()
         calls.append("assign_nudge_finished")
+        nudge_assignment_finished.set()
         return None
 
     async def create_reaction(*_args):
         calls.append("create_reaction")
-        reaction_finished.set()
 
     async def send_meme(*_args):
         calls.append("send_meme")
@@ -369,16 +424,16 @@ async def test_send_meme_to_user_continues_post_delivery_after_nudge_assignment_
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(send_task, timeout=0.1)
 
-    assert calls == ["send_meme", "assign_nudge_started"]
+    assert calls == ["send_meme", "create_reaction", "assign_nudge_started"]
 
     nudge_assignment_can_finish.set()
-    await asyncio.wait_for(reaction_finished.wait(), timeout=0.1)
+    await asyncio.wait_for(nudge_assignment_finished.wait(), timeout=0.1)
 
     assert calls == [
         "send_meme",
+        "create_reaction",
         "assign_nudge_started",
         "assign_nudge_finished",
-        "create_reaction",
     ]
 
 
@@ -444,15 +499,15 @@ async def test_send_meme_to_user_can_defer_first_meme_nudge_after_reaction(monke
     )
     await asyncio.sleep(0)
 
-    assert calls == ["assign_nudge", "create_reaction", "send_nudge_started"]
+    assert calls == ["create_reaction", "assign_nudge", "send_nudge_started"]
     assert len(nudge_tasks) == 1
     assert not nudge_tasks[0].done()
 
     nudge_can_finish.set()
     await nudge_tasks[0]
     assert calls == [
-        "assign_nudge",
         "create_reaction",
+        "assign_nudge",
         "send_nudge_started",
         "send_nudge_finished",
     ]
@@ -507,7 +562,7 @@ async def test_send_meme_to_user_retries_assigned_undelivered_nudge(monkeypatch)
 
     await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
 
-    assert calls == ["pending_nudge", "create_reaction", "send_nudge"]
+    assert calls == ["create_reaction", "pending_nudge", "send_nudge"]
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -5,6 +6,7 @@ from telegram.error import BadRequest, NetworkError
 
 from src.storage.constants import MemeType
 from src.storage.schemas import MemeData
+from src.tgbot.senders import meme as meme_sender
 from src.tgbot.senders.meme import edit_last_message_with_meme, send_new_message_with_meme
 
 
@@ -82,3 +84,290 @@ async def test_send_new_message_does_not_retry_ambiguous_transport_error(monkeyp
 
     assert bot.send_photo_calls == 1
     sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_assigns_first_meme_nudge_before_delivery(monkeypatch):
+    calls: list[str] = []
+
+    async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> str:
+        assert is_first_meme is True
+        calls.append("assign_nudge")
+        return "treatment"
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction")
+
+    async def send_nudge(*_args):
+        calls.append("send_nudge")
+
+    async def send_meme(*_args):
+        calls.append("send_meme")
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", send_nudge)
+
+    await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+
+    assert calls == ["assign_nudge", "send_meme", "create_reaction", "send_nudge"]
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_continues_recording_after_cancellation(monkeypatch):
+    calls: list[str] = []
+    reaction_started = asyncio.Event()
+    reaction_finished = asyncio.Event()
+    reaction_can_finish = asyncio.Event()
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction_started")
+        reaction_started.set()
+        await reaction_can_finish.wait()
+        calls.append("create_reaction_finished")
+        reaction_finished.set()
+
+    async def send_meme(*_args):
+        calls.append("send_meme")
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+
+    send_task = asyncio.create_task(
+        meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+    )
+    await reaction_started.wait()
+
+    send_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(send_task, timeout=0.1)
+
+    assert calls == ["send_meme", "create_reaction_started"]
+
+    reaction_can_finish.set()
+    await asyncio.wait_for(reaction_finished.wait(), timeout=0.1)
+
+    assert calls == ["send_meme", "create_reaction_started", "create_reaction_finished"]
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_can_defer_first_meme_nudge_after_reaction(monkeypatch):
+    calls: list[str] = []
+    nudge_can_finish = asyncio.Event()
+
+    async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> str:
+        assert is_first_meme is True
+        calls.append("assign_nudge")
+        return "treatment"
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction")
+
+    async def send_nudge(*_args):
+        calls.append("send_nudge_started")
+        await nudge_can_finish.wait()
+        calls.append("send_nudge_finished")
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", send_nudge)
+
+    nudge_tasks: list[asyncio.Task[None]] = []
+    await asyncio.wait_for(
+        meme_sender.send_meme_to_user(
+            bot=object(),
+            user_id=12001,
+            meme=_meme(),
+            first_meme_nudge_tasks=nudge_tasks,
+        ),
+        timeout=0.1,
+    )
+    await asyncio.sleep(0)
+
+    assert calls == ["assign_nudge", "create_reaction", "send_nudge_started"]
+    assert len(nudge_tasks) == 1
+    assert not nudge_tasks[0].done()
+
+    nudge_can_finish.set()
+    await nudge_tasks[0]
+    assert calls == [
+        "assign_nudge",
+        "create_reaction",
+        "send_nudge_started",
+        "send_nudge_finished",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_retries_assigned_undelivered_nudge(monkeypatch):
+    calls: list[str] = []
+
+    async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> str:
+        assert is_first_meme is False
+        calls.append("pending_nudge")
+        return "treatment"
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction")
+
+    async def send_nudge(*_args):
+        calls.append("send_nudge")
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 2}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", send_nudge)
+
+    await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+
+    assert calls == ["pending_nudge", "create_reaction", "send_nudge"]
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_does_not_assign_new_nudge_for_returning_user(monkeypatch):
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 2}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
+    first_meme_nudge_variant = AsyncMock()
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", AsyncMock())
+
+    await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+
+    first_meme_nudge_variant.assert_awaited_once_with(12001, is_first_meme=False)

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -139,7 +139,7 @@ async def test_send_meme_to_user_assigns_first_meme_nudge_after_delivery(monkeyp
 
     await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
 
-    assert calls == ["send_meme", "create_reaction", "assign_nudge", "send_nudge"]
+    assert calls == ["send_meme", "assign_nudge", "create_reaction", "send_nudge"]
 
 
 @pytest.mark.asyncio
@@ -239,7 +239,7 @@ async def test_send_meme_to_user_does_not_assign_first_meme_nudge_on_rejected_de
 
 
 @pytest.mark.asyncio
-async def test_send_meme_to_user_records_delivery_before_nudge_assignment_error(
+async def test_send_meme_to_user_records_delivery_after_nudge_assignment_error(
     monkeypatch,
 ):
     calls: list[str] = []
@@ -290,7 +290,7 @@ async def test_send_meme_to_user_records_delivery_before_nudge_assignment_error(
     with pytest.raises(RuntimeError, match="experiment storage unavailable"):
         await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
 
-    assert calls == ["send_meme", "create_reaction", "assign_nudge"]
+    assert calls == ["send_meme", "assign_nudge", "create_reaction"]
 
 
 @pytest.mark.asyncio
@@ -367,6 +367,7 @@ async def test_send_meme_to_user_continues_post_delivery_after_nudge_assignment_
     nudge_assignment_started = asyncio.Event()
     nudge_assignment_finished = asyncio.Event()
     nudge_assignment_can_finish = asyncio.Event()
+    reaction_finished = asyncio.Event()
 
     async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> None:
         assert is_first_meme is True
@@ -379,6 +380,7 @@ async def test_send_meme_to_user_continues_post_delivery_after_nudge_assignment_
 
     async def create_reaction(*_args):
         calls.append("create_reaction")
+        reaction_finished.set()
 
     async def send_meme(*_args):
         calls.append("send_meme")
@@ -424,16 +426,17 @@ async def test_send_meme_to_user_continues_post_delivery_after_nudge_assignment_
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(send_task, timeout=0.1)
 
-    assert calls == ["send_meme", "create_reaction", "assign_nudge_started"]
+    assert calls == ["send_meme", "assign_nudge_started"]
 
     nudge_assignment_can_finish.set()
     await asyncio.wait_for(nudge_assignment_finished.wait(), timeout=0.1)
+    await asyncio.wait_for(reaction_finished.wait(), timeout=0.1)
 
     assert calls == [
         "send_meme",
-        "create_reaction",
         "assign_nudge_started",
         "assign_nudge_finished",
+        "create_reaction",
     ]
 
 
@@ -499,15 +502,16 @@ async def test_send_meme_to_user_can_defer_first_meme_nudge_after_reaction(monke
     )
     await asyncio.sleep(0)
 
-    assert calls == ["create_reaction", "assign_nudge", "send_nudge_started"]
-    assert len(nudge_tasks) == 1
-    assert not nudge_tasks[0].done()
+    assert calls == ["assign_nudge", "create_reaction", "send_nudge_started"]
+    assert len(nudge_tasks) == 2
+    assert nudge_tasks[0].done()
+    assert not nudge_tasks[1].done()
 
     nudge_can_finish.set()
-    await nudge_tasks[0]
+    await nudge_tasks[1]
     assert calls == [
-        "create_reaction",
         "assign_nudge",
+        "create_reaction",
         "send_nudge_started",
         "send_nudge_finished",
     ]
@@ -562,7 +566,7 @@ async def test_send_meme_to_user_retries_assigned_undelivered_nudge(monkeypatch)
 
     await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
 
-    assert calls == ["create_reaction", "pending_nudge", "send_nudge"]
+    assert calls == ["pending_nudge", "create_reaction", "send_nudge"]
 
 
 @pytest.mark.asyncio

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -103,6 +103,7 @@ async def test_send_meme_to_user_assigns_first_meme_nudge_after_delivery(monkeyp
 
     async def send_meme(*_args):
         calls.append("send_meme")
+        return object()
 
     monkeypatch.setattr(
         meme_sender,
@@ -191,6 +192,53 @@ async def test_send_meme_to_user_does_not_assign_first_meme_nudge_on_failed_deli
 
 
 @pytest.mark.asyncio
+async def test_send_meme_to_user_does_not_assign_first_meme_nudge_on_rejected_delivery(
+    monkeypatch,
+):
+    nudge_variant = AsyncMock(return_value="treatment")
+    create_reaction = AsyncMock()
+    send_nudge = AsyncMock()
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+    monkeypatch.setattr(meme_sender, "maybe_send_first_meme_nudge", send_nudge)
+
+    await meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+
+    nudge_variant.assert_not_awaited()
+    create_reaction.assert_not_awaited()
+    send_nudge.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_send_meme_to_user_continues_recording_after_cancellation(monkeypatch):
     calls: list[str] = []
     reaction_started = asyncio.Event()
@@ -206,6 +254,7 @@ async def test_send_meme_to_user_continues_recording_after_cancellation(monkeypa
 
     async def send_meme(*_args):
         calls.append("send_meme")
+        return object()
 
     monkeypatch.setattr(
         meme_sender,
@@ -253,6 +302,84 @@ async def test_send_meme_to_user_continues_recording_after_cancellation(monkeypa
     await asyncio.wait_for(reaction_finished.wait(), timeout=0.1)
 
     assert calls == ["send_meme", "create_reaction_started", "create_reaction_finished"]
+
+
+@pytest.mark.asyncio
+async def test_send_meme_to_user_continues_post_delivery_after_nudge_assignment_cancellation(
+    monkeypatch,
+):
+    calls: list[str] = []
+    nudge_assignment_started = asyncio.Event()
+    nudge_assignment_can_finish = asyncio.Event()
+    reaction_finished = asyncio.Event()
+
+    async def first_meme_nudge_variant(_user_id: int, *, is_first_meme: bool) -> None:
+        assert is_first_meme is True
+        calls.append("assign_nudge_started")
+        nudge_assignment_started.set()
+        await nudge_assignment_can_finish.wait()
+        calls.append("assign_nudge_finished")
+        return None
+
+    async def create_reaction(*_args):
+        calls.append("create_reaction")
+        reaction_finished.set()
+
+    async def send_meme(*_args):
+        calls.append("send_meme")
+        return object()
+
+    monkeypatch.setattr(
+        meme_sender,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
+    )
+    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
+    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
+    monkeypatch.setattr(
+        meme_sender,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        meme_sender,
+        "meme_reaction_keyboard",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        meme_sender,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="<b>caption</b>"),
+    )
+    monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
+    monkeypatch.setattr(
+        meme_sender,
+        "get_first_meme_nudge_variant_to_send",
+        first_meme_nudge_variant,
+    )
+    monkeypatch.setattr(meme_sender, "create_user_meme_reaction", create_reaction)
+
+    send_task = asyncio.create_task(
+        meme_sender.send_meme_to_user(bot=object(), user_id=12001, meme=_meme())
+    )
+    await nudge_assignment_started.wait()
+
+    send_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(send_task, timeout=0.1)
+
+    assert calls == ["send_meme", "assign_nudge_started"]
+
+    nudge_assignment_can_finish.set()
+    await asyncio.wait_for(reaction_finished.wait(), timeout=0.1)
+
+    assert calls == [
+        "send_meme",
+        "assign_nudge_started",
+        "assign_nudge_finished",
+        "create_reaction",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes FFM-1520.

## Root cause
Production current-week data showed 17 delivered new users, with 3 delivered users missing `first_meme_nudge` assignment. The three misses were all direct-send paths that bypass the original `next_message()` first-meme assignment path:

- 2 first deliveries from `cold_start_explore` via broadcast/direct send
- 1 first delivery from `share_link`

Those paths call `send_meme_to_user()`, which recorded `user_meme_reaction` without assigning the first-meme nudge experiment for confirmed first deliveries.

## Change
- Assigns first-meme nudge cohort in `send_meme_to_user()` only after `send_new_message_with_meme()` succeeds, and before `_record_delivered_meme_reaction()` records the measured delivery.
- Defers optional nudge delivery outside the broadcast 20s meme-send timeout, then waits briefly for those tasks without cancelling ambiguous in-flight Telegram sends.
- Keeps nudge lease cleanup cancellation-safe so ambiguous send outcomes cannot duplicate first-meme nudges.
- Shields post-Telegram delivery recording so accepted direct sends are still recorded even if the broadcast timeout cancels the per-user task.
- Adds regression coverage for direct sender ordering, failed direct sends not assigning cohorts, broadcast nudge draining, cancellation cleanup, and retry behavior.

This is the production-targeted version of the reviewed PR #305 fix, applied on top of current `origin/production` without unrelated local comms/experiment workspace changes.

## Verification
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `git diff --check origin/production...HEAD`
- `DATABASE_URL=postgresql+asyncpg://app:app@app_db:5432/app TELEGRAM_BOT_TOKEN=123456:ABCdefghijklmnopqrstuvwxyz pytest tests/tgbot/test_meme_sender.py tests/flows/test_broadcasts_meme.py tests/tgbot/test_first_meme_nudge.py::test_send_cancellation_keeps_lease tests/tgbot/test_first_meme_nudge.py::test_delivery_helper_retries_only_existing_treatment_assignment tests/recommendations/test_pipeline.py::test_compact_diagnostics_exclude_candidate_ids`

Result: 14 passed.