### PR TITLE
Fix: allow gstack skill preflight without secret access

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -98,9 +98,10 @@ Do not use `company import` to update existing prod agents; the safe import
 route does not replace existing agents.
 
 The deploy dry-run prints a `Skill catalog preflight` block with the upstream
-gstack `source`/`ref`, `checked` / `updated` / `removed` / `failed` counts, and
-the `update_method`. A non-zero `failed` (unknown desired skills) blocks an
-apply pass — pin the right `ref` in `agents/.paperclip.yaml` before re-running.
+gstack `source`/`ref`, `checked_count` / `updated_count` / `failed_count` /
+`stale_count` / `removed_count`, and the `update_method`. A non-zero
+`failed_count` (unknown desired skills) blocks an apply pass — pin the right
+`ref` in `agents/.paperclip.yaml` before re-running.
 
 See [Paperclip](https://paperclip.ing) for more information.
 

--- a/agents/_sync_config.py
+++ b/agents/_sync_config.py
@@ -464,6 +464,18 @@ def main() -> int:
         if SKILL_PREFLIGHT_ONLY or not DRY:
             return 1
 
+    if preflight["stale_desired_skills"]:
+        print(
+            f"  ERROR {preflight['stale_count']} desired skill(s) incompatible "
+            "with Paperclip catalog: "
+            f"{preflight['stale_desired_skills']}",
+            file=sys.stderr,
+        )
+        # Block apply and skills-only preflight; in a full dry-run, keep going
+        # so operators see the complete diff.
+        if SKILL_PREFLIGHT_ONLY or not DRY:
+            return 1
+
     if SKILL_PREFLIGHT_ONLY and str(preflight["catalog_validation"]).startswith("skipped"):
         print(
             "  ERROR skill catalog validation skipped; refusing to pass skills-only preflight",

--- a/agents/_sync_config.py
+++ b/agents/_sync_config.py
@@ -464,6 +464,13 @@ def main() -> int:
         if SKILL_PREFLIGHT_ONLY or not DRY:
             return 1
 
+    if SKILL_PREFLIGHT_ONLY and str(preflight["catalog_validation"]).startswith("skipped"):
+        print(
+            "  ERROR skill catalog validation skipped; refusing to pass skills-only preflight",
+            file=sys.stderr,
+        )
+        return 1
+
     if SKILL_PREFLIGHT_ONLY:
         return 0
 

--- a/agents/_sync_config.py
+++ b/agents/_sync_config.py
@@ -6,7 +6,8 @@ and per-agent `AGENTS.md` frontmatter, compares with prod via Paperclip API,
 PATCHes only agents whose config actually drifted, and uses Paperclip's native
 skills sync endpoint for desired skill assignment.
 
-Env: PAPERCLIP_URL, PAPERCLIP_API_KEY, COMPANY_ID, SCRIPT_DIR, DRY_RUN.
+Env: PAPERCLIP_URL, PAPERCLIP_API_KEY, COMPANY_ID, SCRIPT_DIR, DRY_RUN,
+SKILL_PREFLIGHT_ONLY.
 """
 
 import os
@@ -28,6 +29,7 @@ KEY = os.environ["PAPERCLIP_API_KEY"]
 COMPANY = os.environ["COMPANY_ID"]
 SCRIPT_DIR = os.environ["SCRIPT_DIR"]
 DRY = os.environ.get("DRY_RUN", "0") == "1"
+SKILL_PREFLIGHT_ONLY = os.environ.get("SKILL_PREFLIGHT_ONLY", "0") == "1"
 
 _client = PaperclipClient(URL, KEY, user_agent="ffmemes-deploy.sh/1.0")
 
@@ -439,6 +441,22 @@ def main() -> int:
         )
         return 1
     by_slug = {a["urlKey"]: a for a in agents_list}
+
+    preflight = preflight_skills(by_slug, manifest)
+    if preflight["unknown_desired_skills"]:
+        print(
+            f"  ERROR {preflight['failed']} desired skill(s) not in Paperclip catalog: "
+            f"{preflight['unknown_desired_skills']}",
+            file=sys.stderr,
+        )
+        # Block apply; surface in dry-run as a failure marker but keep going so
+        # operators see the full diff.
+        if not DRY:
+            return 1
+
+    if SKILL_PREFLIGHT_ONLY:
+        return 0
+
     try:
         secret_ids = load_secret_ids()
     except ConfigError as exc:
@@ -460,18 +478,6 @@ def main() -> int:
     if env_failed:
         print("  ERROR env preflight failed; no agent config changes applied", file=sys.stderr)
         return 1
-
-    preflight = preflight_skills(by_slug, manifest)
-    if preflight["unknown_desired_skills"]:
-        print(
-            f"  ERROR {preflight['failed']} desired skill(s) not in Paperclip catalog: "
-            f"{preflight['unknown_desired_skills']}",
-            file=sys.stderr,
-        )
-        # Block apply; surface in dry-run as a failure marker but keep going so
-        # operators see the full diff.
-        if not DRY:
-            return 1
 
     patched = 0
     skipped = 0

--- a/agents/_sync_config.py
+++ b/agents/_sync_config.py
@@ -75,24 +75,24 @@ def sync_skills(agent_id: str, desired_skills: list[str]):
     )
 
 
-def fetch_skill_catalog() -> tuple[set[str], str]:
+def fetch_skill_catalog() -> tuple[dict[str, dict], str]:
     """Best-effort fetch of the company skill catalog.
 
-    Returns (catalog_paths, status). `status` is a short label suitable for
-    inclusion in the dry-run summary; `catalog_paths` is empty when the
+    Returns (catalog_by_path, status). `status` is a short label suitable for
+    inclusion in the dry-run summary; `catalog_by_path` is empty when the
     catalog couldn't be retrieved.
     """
     try:
         catalog = api("GET", f"/api/companies/{COMPANY}/skills")
     except urllib.error.HTTPError as e:
-        return set(), f"skipped (HTTP {e.code})"
+        return {}, f"skipped (HTTP {e.code})"
     except Exception as e:  # network / decode / other transport errors
-        return set(), f"skipped ({type(e).__name__})"
+        return {}, f"skipped ({type(e).__name__})"
 
     if not isinstance(catalog, list):
-        return set(), f"skipped (unexpected shape {type(catalog).__name__})"
+        return {}, f"skipped (unexpected shape {type(catalog).__name__})"
 
-    paths: set[str] = set()
+    by_path: dict[str, dict] = {}
     for entry in catalog:
         if not isinstance(entry, dict):
             continue
@@ -102,8 +102,8 @@ def fetch_skill_catalog() -> tuple[set[str], str]:
             entry.get("path") or entry.get("key") or entry.get("urlKey") or entry.get("slug")
         )
         if isinstance(candidate, str) and candidate:
-            paths.add(candidate)
-    return paths, f"ok ({len(paths)} skills)" if paths else "skipped (empty catalog)"
+            by_path[candidate] = entry
+    return by_path, f"ok ({len(by_path)} skills)" if by_path else "skipped (empty catalog)"
 
 
 def compute_desired_skills(
@@ -133,7 +133,8 @@ def preflight_skills(
 
     Runs before the per-agent skill assignment sync. Surfaces:
     - upstream source/ref (from manifest, no secrets)
-    - checked / updated / removed / failed counts across all in-prod agents
+    - checked_count / updated_count / failed_count / stale_count /
+      removed_count across all in-prod agents
     - update_method
     - catalog validation status (best-effort; skipped when catalog endpoint
       is unavailable)
@@ -158,23 +159,30 @@ def preflight_skills(
         removed_total += len(gone)
         all_desired.update(target_skills)
 
-    catalog_paths, catalog_status = fetch_skill_catalog()
+    catalog_by_path, catalog_status = fetch_skill_catalog()
     unknown: list[str] = []
-    if catalog_paths:
+    stale: list[str] = []
+    if catalog_by_path:
         for skill in sorted(all_desired):
             # paperclipai/* skills are preserved as-is from current adapterConfig;
             # if not in the live catalog, surface them too — that's exactly the
             # "unknown desired skill" case the verification asks about.
-            if skill not in catalog_paths:
+            entry = catalog_by_path.get(skill)
+            if entry is None:
                 unknown.append(skill)
+                continue
+            compatibility = entry.get("compatibility")
+            if isinstance(compatibility, str) and compatibility != "compatible":
+                stale.append(skill)
 
     state = {
         "upstream_source": source,
         "upstream_ref": ref,
-        "checked": len(all_desired),
-        "updated": updated_total,
-        "removed": removed_total,
-        "failed": len(unknown),
+        "checked_count": len(all_desired),
+        "updated_count": updated_total,
+        "failed_count": len(unknown),
+        "stale_count": len(stale),
+        "removed_count": removed_total,
         "update_method": update_method_label,
         "catalog_validation": catalog_status,
     }
@@ -185,8 +193,10 @@ def preflight_skills(
         print(f"  {k}: {v}")
     if unknown:
         print(f"  unknown_desired_skills: {unknown}")
+    if stale:
+        print(f"  stale_desired_skills: {stale}")
 
-    return {**state, "unknown_desired_skills": unknown}
+    return {**state, "unknown_desired_skills": unknown, "stale_desired_skills": stale}
 
 
 def load_secret_ids() -> dict[str, str]:
@@ -445,7 +455,7 @@ def main() -> int:
     preflight = preflight_skills(by_slug, manifest)
     if preflight["unknown_desired_skills"]:
         print(
-            f"  ERROR {preflight['failed']} desired skill(s) not in Paperclip catalog: "
+            f"  ERROR {preflight['failed_count']} desired skill(s) not in Paperclip catalog: "
             f"{preflight['unknown_desired_skills']}",
             file=sys.stderr,
         )

--- a/agents/_sync_config.py
+++ b/agents/_sync_config.py
@@ -449,9 +449,9 @@ def main() -> int:
             f"{preflight['unknown_desired_skills']}",
             file=sys.stderr,
         )
-        # Block apply; surface in dry-run as a failure marker but keep going so
-        # operators see the full diff.
-        if not DRY:
+        # Block apply and skills-only preflight; in a full dry-run, keep going
+        # so operators see the complete diff.
+        if SKILL_PREFLIGHT_ONLY or not DRY:
             return 1
 
     if SKILL_PREFLIGHT_ONLY:

--- a/agents/deploy.sh
+++ b/agents/deploy.sh
@@ -133,9 +133,11 @@ COMPANY_ID="$COMPANY_ID" SCRIPT_DIR="$SCRIPT_DIR" DRY_RUN="$DRY_RUN" \
 echo
 if [[ $errors -gt 0 ]]; then
   if [[ $SKILL_PREFLIGHT_ONLY -eq 1 ]]; then
-    echo "Skill preflight failed with $errors error(s)."
+    echo "Skill preflight failed with $errors error(s)." >&2
+  elif [[ $DRY_RUN -eq 1 ]]; then
+    echo "Dry-run failed with $errors error(s)." >&2
   else
-    echo "Synced $synced_files files; $errors errors during apply."
+    echo "Synced $synced_files files; $errors errors during apply." >&2
   fi
   exit 1
 elif [[ $SKILL_PREFLIGHT_ONLY -eq 1 ]]; then

--- a/agents/deploy.sh
+++ b/agents/deploy.sh
@@ -5,6 +5,8 @@
 # Usage:
 #   PAPERCLIP_URL=https://org.ffmemes.com PAPERCLIP_API_KEY=... ./agents/deploy.sh
 #   ./agents/deploy.sh --dry-run    # show what would change without applying
+#   ./agents/deploy.sh --skill-preflight
+#     # check desired skill catalog state only; does not require secret access
 #
 # What it does, per agent slug found under agents/<slug>/:
 #   1. Resolve agent ID by slug via GET /api/companies/<id>/agents
@@ -18,7 +20,22 @@ set -euo pipefail
 COMPANY_ID="96ee7b2e-6df2-43c8-bbe3-53e19297308a"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 DRY_RUN=0
-[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+SKILL_PREFLIGHT_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    --skill-preflight | --skills-only)
+      DRY_RUN=1
+      SKILL_PREFLIGHT_ONLY=1
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
 
 : "${PAPERCLIP_URL:?Set PAPERCLIP_URL (e.g. https://org.ffmemes.com)}"
 : "${PAPERCLIP_API_KEY:?Set PAPERCLIP_API_KEY}"
@@ -43,8 +60,13 @@ api() {
   rm -f "$body"
 }
 
-echo "Syncing agent instructions to $PAPERCLIP_URL (company=$COMPANY_ID)"
+if [[ $SKILL_PREFLIGHT_ONLY -eq 1 ]]; then
+  echo "Checking skill catalog at $PAPERCLIP_URL (company=$COMPANY_ID)"
+else
+  echo "Syncing agent instructions to $PAPERCLIP_URL (company=$COMPANY_ID)"
+fi
 [[ $DRY_RUN -eq 1 ]] && echo "  (dry-run mode — no writes)"
+[[ $SKILL_PREFLIGHT_ONLY -eq 1 ]] && echo "  (skill preflight only — no instructions, env, config, or routine sync)"
 
 # Fetch agent list once; build slug → id map via jq
 AGENTS_JSON=$(api GET "/api/companies/$COMPANY_ID/agents")
@@ -56,51 +78,62 @@ slug_to_id() {
 errors=0
 synced_files=0
 
-for agent_dir in "$SCRIPT_DIR"/*/; do
-  slug=$(basename "$agent_dir")
-  [[ -f "$agent_dir/AGENTS.md" ]] || continue
-  agent_id=$(slug_to_id "$slug")
+if [[ $SKILL_PREFLIGHT_ONLY -eq 0 ]]; then
+  for agent_dir in "$SCRIPT_DIR"/*/; do
+    slug=$(basename "$agent_dir")
+    [[ -f "$agent_dir/AGENTS.md" ]] || continue
+    agent_id=$(slug_to_id "$slug")
 
-  if [[ -z "$agent_id" ]]; then
-    echo "  SKIP $slug — no matching agent in prod (urlKey miss)"
-    continue
-  fi
-
-  for md in "$agent_dir"*.md; do
-    [[ -f "$md" ]] || continue
-    fname=$(basename "$md")
-    size=$(wc -c < "$md")
-
-    if [[ $DRY_RUN -eq 1 ]]; then
-      echo "  WOULD PUT $slug/$fname ($size B) → agent $agent_id"
+    if [[ -z "$agent_id" ]]; then
+      echo "  SKIP $slug — no matching agent in prod (urlKey miss)"
       continue
     fi
 
-    payload=$(jq -n --arg path "$fname" --rawfile content "$md" '{path: $path, content: $content}')
-    if echo "$payload" | api PUT "/api/agents/$agent_id/instructions-bundle/file?companyId=$COMPANY_ID" --data @- >/dev/null; then
-      echo "  OK   $slug/$fname ($size B)"
-      synced_files=$((synced_files + 1))
-    else
-      echo "  ERR  $slug/$fname ($size B) — PUT failed" >&2
-      errors=$((errors + 1))
-    fi
+    for md in "$agent_dir"*.md; do
+      [[ -f "$md" ]] || continue
+      fname=$(basename "$md")
+      size=$(wc -c < "$md")
+
+      if [[ $DRY_RUN -eq 1 ]]; then
+        echo "  WOULD PUT $slug/$fname ($size B) → agent $agent_id"
+        continue
+      fi
+
+      payload=$(jq -n --arg path "$fname" --rawfile content "$md" '{path: $path, content: $content}')
+      if echo "$payload" | api PUT "/api/agents/$agent_id/instructions-bundle/file?companyId=$COMPANY_ID" --data @- >/dev/null; then
+        echo "  OK   $slug/$fname ($size B)"
+        synced_files=$((synced_files + 1))
+      else
+        echo "  ERR  $slug/$fname ($size B) — PUT failed" >&2
+        errors=$((errors + 1))
+      fi
+    done
   done
-done
+else
+  echo "  skip instruction bundle pass"
+fi
 
 echo
-echo "Syncing adapter config + env + skills + routine descriptions (diff-first PATCH)..."
+if [[ $SKILL_PREFLIGHT_ONLY -eq 1 ]]; then
+  echo "Running skill catalog preflight..."
+else
+  echo "Syncing adapter config + env + skills + routine descriptions (diff-first PATCH)..."
+fi
 
 # Pass 2: adapter type/config, env secret refs, desiredSkills, runtime.heartbeat,
 # permissions, and routine descriptions declared under agents/<slug>/routines/.
 # Diff first; PATCH only on change so we don't spam Paperclip's config-revision history.
 COMPANY_ID="$COMPANY_ID" SCRIPT_DIR="$SCRIPT_DIR" DRY_RUN="$DRY_RUN" \
+  SKILL_PREFLIGHT_ONLY="$SKILL_PREFLIGHT_ONLY" \
   python3 "$SCRIPT_DIR/_sync_config.py" || {
   echo "Config sync failed." >&2
   errors=$((errors + 1))
 }
 
 echo
-if [[ $DRY_RUN -eq 1 ]]; then
+if [[ $SKILL_PREFLIGHT_ONLY -eq 1 ]]; then
+  echo "Skill preflight complete."
+elif [[ $DRY_RUN -eq 1 ]]; then
   echo "Dry-run complete. Re-run without --dry-run to apply."
 elif [[ $errors -gt 0 ]]; then
   echo "Synced $synced_files files; $errors errors during apply."

--- a/agents/deploy.sh
+++ b/agents/deploy.sh
@@ -131,13 +131,17 @@ COMPANY_ID="$COMPANY_ID" SCRIPT_DIR="$SCRIPT_DIR" DRY_RUN="$DRY_RUN" \
 }
 
 echo
-if [[ $SKILL_PREFLIGHT_ONLY -eq 1 ]]; then
+if [[ $errors -gt 0 ]]; then
+  if [[ $SKILL_PREFLIGHT_ONLY -eq 1 ]]; then
+    echo "Skill preflight failed with $errors error(s)."
+  else
+    echo "Synced $synced_files files; $errors errors during apply."
+  fi
+  exit 1
+elif [[ $SKILL_PREFLIGHT_ONLY -eq 1 ]]; then
   echo "Skill preflight complete."
 elif [[ $DRY_RUN -eq 1 ]]; then
   echo "Dry-run complete. Re-run without --dry-run to apply."
-elif [[ $errors -gt 0 ]]; then
-  echo "Synced $synced_files files; $errors errors during apply."
-  exit 1
 else
   echo "Synced $synced_files files. Changes take effect on next agent wake."
 fi

--- a/docs/paperclip-skill-catalog.md
+++ b/docs/paperclip-skill-catalog.md
@@ -27,16 +27,17 @@ script runs a preflight before issuing any per-agent sync:
 Skill catalog preflight (dry-run):
   upstream_source: https://github.com/garrytan/gstack
   upstream_ref: <ref>
-  checked: <N>
-  updated: <added>
-  removed: <gone>
-  failed: <unknown desired skills>
+  checked_count: <N>
+  updated_count: <added>
+  failed_count: <unknown desired skills>
+  stale_count: <incompatible catalog entries>
+  removed_count: <gone>
   update_method: POST /api/agents/<id>/skills/sync (per-agent)
   catalog_validation: <ok|skipped (...)>
 ```
 
-When `failed > 0`, the apply pass is blocked. `dry-run` still completes so the
-operator sees the full diff and the unknown skill names.
+When `failed_count > 0`, the apply pass is blocked. `dry-run` still completes
+so the operator sees the full diff and the unknown skill names.
 
 ## Team-mode (gstack) decision: docs-only
 
@@ -64,7 +65,7 @@ repo clean.
 
 ## When to bump `skills.ref`
 
-1. Run `agents/deploy.sh --dry-run`. Confirm `failed: 0`.
+1. Run `agents/deploy.sh --dry-run`. Confirm `failed_count: 0`.
 2. If a desired skill is missing upstream, either add it to gstack (PR
    garrytan/gstack) or remove the frontmatter entry.
 3. Bump `skills.ref` in `agents/.paperclip.yaml` and re-run dry-run. Apply

--- a/tests/test_paperclip_skill_preflight.py
+++ b/tests/test_paperclip_skill_preflight.py
@@ -286,6 +286,31 @@ def test_skill_preflight_only_fails_for_unknown_desired_skill(
     assert "desired skill(s) not in Paperclip catalog" in captured.err
 
 
+def test_skill_preflight_only_fails_when_catalog_validation_skipped(
+    sync_module, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    def fake_api(method, path, body=None):
+        if path.endswith("/agents"):
+            return [
+                {
+                    "id": "agent-id",
+                    "urlKey": "alpha",
+                    "adapterConfig": {"paperclipSkillSync": {"desiredSkills": []}},
+                }
+            ]
+        if path.endswith("/skills"):
+            return []
+        raise AssertionError(f"unexpected API call in skills-only mode: {path}")
+
+    monkeypatch.setattr(sync_module, "api", fake_api)
+    monkeypatch.setattr(sync_module, "SKILL_PREFLIGHT_ONLY", True)
+
+    assert sync_module.main() == 1
+    captured = capsys.readouterr()
+    assert "catalog_validation: skipped (empty catalog)" in captured.out
+    assert "skill catalog validation skipped" in captured.err
+
+
 def test_deploy_skill_preflight_propagates_config_sync_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_paperclip_skill_preflight.py
+++ b/tests/test_paperclip_skill_preflight.py
@@ -32,6 +32,17 @@ def sync_module(tmp_path: Path) -> Iterator:
         "---\nname: Alpha\nskills:\n  - browse\n  - paperclip\n---\n# Alpha\n",
         encoding="utf-8",
     )
+    (script_dir / ".paperclip.yaml").write_text(
+        """
+skills:
+  source: https://github.com/garrytan/gstack
+  ref: main
+  update_method: paperclip_skill_sync
+agents:
+  alpha: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
 
     env = {
         "PAPERCLIP_URL": "https://example.test",
@@ -185,6 +196,38 @@ def test_preflight_unpinned_ref_label(
     state = sync_module.preflight_skills(by_slug, manifest)
     capsys.readouterr()
     assert state["upstream_ref"] == "unpinned"
+
+
+def test_skill_preflight_only_skips_secret_and_routine_calls(
+    sync_module, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    calls: list[str] = []
+
+    def fake_api(method, path, body=None):
+        calls.append(path)
+        if path.endswith("/agents"):
+            return [
+                {
+                    "id": "agent-id",
+                    "urlKey": "alpha",
+                    "adapterConfig": {"paperclipSkillSync": {"desiredSkills": []}},
+                }
+            ]
+        if path.endswith("/skills"):
+            return [
+                {"path": "garrytan/gstack/browse"},
+                {"path": "paperclipai/paperclip/paperclip"},
+            ]
+        raise AssertionError(f"unexpected API call in skills-only mode: {path}")
+
+    monkeypatch.setattr(sync_module, "api", fake_api)
+    monkeypatch.setattr(sync_module, "SKILL_PREFLIGHT_ONLY", True)
+
+    assert sync_module.main() == 0
+    out = capsys.readouterr().out
+    assert "Skill catalog preflight" in out
+    assert not any(path.endswith("/secrets") for path in calls)
+    assert not any(path.endswith("/routines") for path in calls)
 
 
 def test_routine_patch_payload_includes_latest_revision_id(sync_module) -> None:

--- a/tests/test_paperclip_skill_preflight.py
+++ b/tests/test_paperclip_skill_preflight.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import os
+import subprocess
 import sys
 import urllib.error
 from pathlib import Path
@@ -228,6 +229,86 @@ def test_skill_preflight_only_skips_secret_and_routine_calls(
     assert "Skill catalog preflight" in out
     assert not any(path.endswith("/secrets") for path in calls)
     assert not any(path.endswith("/routines") for path in calls)
+
+
+def test_skill_preflight_only_fails_for_unknown_desired_skill(
+    sync_module, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    def fake_api(method, path, body=None):
+        if path.endswith("/agents"):
+            return [
+                {
+                    "id": "agent-id",
+                    "urlKey": "alpha",
+                    "adapterConfig": {"paperclipSkillSync": {"desiredSkills": []}},
+                }
+            ]
+        if path.endswith("/skills"):
+            return [{"path": "garrytan/gstack/browse"}]
+        raise AssertionError(f"unexpected API call in skills-only mode: {path}")
+
+    monkeypatch.setattr(sync_module, "api", fake_api)
+    monkeypatch.setattr(sync_module, "SKILL_PREFLIGHT_ONLY", True)
+
+    assert sync_module.main() == 1
+    captured = capsys.readouterr()
+    assert "unknown_desired_skills" in captured.out
+    assert "desired skill(s) not in Paperclip catalog" in captured.err
+
+
+def test_deploy_skill_preflight_propagates_config_sync_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    curl = bin_dir / "curl"
+    curl.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+body=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      body="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '[]' > "$body"
+printf '200'
+""",
+        encoding="utf-8",
+    )
+    curl.chmod(0o755)
+    python = bin_dir / "python3"
+    python.write_text(
+        """#!/usr/bin/env bash
+exit 1
+""",
+        encoding="utf-8",
+    )
+    python.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "agents" / "deploy.sh"), "--skill-preflight"],
+        env={
+            **os.environ,
+            "PAPERCLIP_URL": "https://example.test",
+            "PAPERCLIP_API_KEY": "test-key",
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Config sync failed." in result.stderr
+    assert "Skill preflight failed with 1 error(s)." in result.stdout
+    assert "Skill preflight complete." not in result.stdout
 
 
 def test_routine_patch_payload_includes_latest_revision_id(sync_module) -> None:

--- a/tests/test_paperclip_skill_preflight.py
+++ b/tests/test_paperclip_skill_preflight.py
@@ -286,6 +286,34 @@ def test_skill_preflight_only_fails_for_unknown_desired_skill(
     assert "desired skill(s) not in Paperclip catalog" in captured.err
 
 
+def test_skill_preflight_only_fails_for_stale_desired_skill(
+    sync_module, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    def fake_api(method, path, body=None):
+        if path.endswith("/agents"):
+            return [
+                {
+                    "id": "agent-id",
+                    "urlKey": "alpha",
+                    "adapterConfig": {"paperclipSkillSync": {"desiredSkills": []}},
+                }
+            ]
+        if path.endswith("/skills"):
+            return [
+                {"path": "garrytan/gstack/browse", "compatibility": "incompatible"},
+                {"path": "paperclipai/paperclip/paperclip", "compatibility": "compatible"},
+            ]
+        raise AssertionError(f"unexpected API call in skills-only mode: {path}")
+
+    monkeypatch.setattr(sync_module, "api", fake_api)
+    monkeypatch.setattr(sync_module, "SKILL_PREFLIGHT_ONLY", True)
+
+    assert sync_module.main() == 1
+    captured = capsys.readouterr()
+    assert "stale_desired_skills" in captured.out
+    assert "desired skill(s) incompatible with Paperclip catalog" in captured.err
+
+
 def test_skill_preflight_only_fails_when_catalog_validation_skipped(
     sync_module, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:

--- a/tests/test_paperclip_skill_preflight.py
+++ b/tests/test_paperclip_skill_preflight.py
@@ -111,13 +111,22 @@ def test_preflight_emits_required_keys(
 
     assert state["upstream_source"] == "https://github.com/garrytan/gstack"
     assert state["upstream_ref"] == "v1.2.3"
-    assert state["checked"] == 2
-    assert state["updated"] == 2  # browse + paperclip newly added
-    assert state["removed"] == 0
-    assert state["failed"] == 0
+    assert state["checked_count"] == 2
+    assert state["updated_count"] == 2  # browse + paperclip newly added
+    assert state["failed_count"] == 0
+    assert state["stale_count"] == 0
+    assert state["removed_count"] == 0
     assert state["update_method"] == "paperclip_skill_sync"
     # Required keys must be in stdout for operator visibility.
-    for key in ("upstream_ref", "checked", "updated", "removed", "failed", "update_method"):
+    for key in (
+        "upstream_ref",
+        "checked_count",
+        "updated_count",
+        "failed_count",
+        "stale_count",
+        "removed_count",
+        "update_method",
+    ):
         assert key in out
 
 
@@ -139,9 +148,30 @@ def test_preflight_flags_unknown_desired_skill(
     }
     state = sync_module.preflight_skills(by_slug, manifest)
     out = capsys.readouterr().out
-    assert state["failed"] == 1
+    assert state["failed_count"] == 1
     assert state["unknown_desired_skills"] == ["paperclipai/paperclip/paperclip"]
     assert "unknown_desired_skills" in out
+
+
+def test_preflight_flags_incompatible_catalog_entry(
+    sync_module, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        sync_module,
+        "api",
+        lambda method, path, body=None: [
+            {"path": "garrytan/gstack/browse", "compatibility": "incompatible"},
+            {"path": "paperclipai/paperclip/paperclip", "compatibility": "compatible"},
+        ],
+    )
+    by_slug = _by_slug_with_skills("alpha", [])
+    manifest = {"skills": {"ref": "main"}, "agents": {"alpha": {}}}
+    state = sync_module.preflight_skills(by_slug, manifest)
+    out = capsys.readouterr().out
+    assert state["failed_count"] == 0
+    assert state["stale_count"] == 1
+    assert state["stale_desired_skills"] == ["garrytan/gstack/browse"]
+    assert "stale_desired_skills" in out
 
 
 def test_preflight_skips_validation_when_catalog_unreachable(
@@ -155,7 +185,7 @@ def test_preflight_skips_validation_when_catalog_unreachable(
     manifest = {"skills": {"ref": "main"}, "agents": {"alpha": {}}}
     state = sync_module.preflight_skills(by_slug, manifest)
     out = capsys.readouterr().out
-    assert state["failed"] == 0
+    assert state["failed_count"] == 0
     assert state["catalog_validation"].startswith("skipped")
     assert "skipped" in out
 
@@ -183,9 +213,9 @@ def test_preflight_counts_removals(sync_module, monkeypatch: pytest.MonkeyPatch)
     )
     manifest = {"skills": {"ref": "main"}, "agents": {"alpha": {}}}
     state = sync_module.preflight_skills(by_slug, manifest)
-    assert state["updated"] == 0  # both target skills already present
-    assert state["removed"] == 1
-    assert state["failed"] == 0
+    assert state["updated_count"] == 0  # both target skills already present
+    assert state["removed_count"] == 1
+    assert state["failed_count"] == 0
 
 
 def test_preflight_unpinned_ref_label(
@@ -307,7 +337,7 @@ exit 1
 
     assert result.returncode == 1
     assert "Config sync failed." in result.stderr
-    assert "Skill preflight failed with 1 error(s)." in result.stdout
+    assert "Skill preflight failed with 1 error(s)." in result.stderr
     assert "Skill preflight complete." not in result.stdout
 
 


### PR DESCRIPTION
Fixes FFM-1546.

## Summary
- Add `agents/deploy.sh --skill-preflight` / `--skills-only` for catalog-only checks.
- Run the skill catalog preflight before secret-backed env validation in `_sync_config.py`.
- Skip secret and routine API calls entirely in skills-only mode.

## Verification
- `bash -n agents/deploy.sh`
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `ruff check --fix agents/_sync_config.py tests/test_paperclip_skill_preflight.py`
- `ruff format agents/_sync_config.py tests/test_paperclip_skill_preflight.py`
- `pytest tests/test_paperclip_skill_preflight.py`

## QA notes
- Post-merge, run `PAPERCLIP_URL=... PAPERCLIP_API_KEY=... ./agents/deploy.sh --skill-preflight` with a token that can read agents/skills but cannot list company secrets.