### PR TITLE
Fix: accept channel post publish links in audit

### DIFF
--- a/scripts/paperclip_contracts.py
+++ b/scripts/paperclip_contracts.py
@@ -136,11 +136,11 @@ PUBLISHED_OUTCOME_MARKERS: tuple[re.Pattern[str], ...] = (
 PUBLISHED_LINK_MARKERS: tuple[re.Pattern[str], ...] = (
     re.compile(
         r"\b(?:published|posted|publication|channel preview confirmed)"
-        r"[^\n]{0,200}\bhttps?://t\.me/ffmemes/\d+\b",
+        r"[\s\S]{0,200}\bhttps?://t\.me/ffmemes/\d+\b",
         re.IGNORECASE,
     ),
     re.compile(
-        r"\bhttps?://t\.me/ffmemes/\d+\b[^\n]{0,200}"
+        r"\bhttps?://t\.me/ffmemes/\d+\b[\s\S]{0,200}"
         r"\b(?:published|posted|publication|channel preview confirmed)\b",
         re.IGNORECASE,
     ),

--- a/scripts/paperclip_contracts.py
+++ b/scripts/paperclip_contracts.py
@@ -129,6 +129,28 @@ PUBLISHED_MARKERS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b(?:telegram_message_id|telegram message id)\b", re.IGNORECASE),
 )
 
+PUBLISHED_OUTCOME_MARKERS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\boutcome\s*=\s*(?:daily_channel_post|post_published)\b", re.IGNORECASE),
+)
+
+PUBLISHED_LINK_MARKERS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"\b(?:published|posted|publication|channel preview confirmed)"
+        r"[^\n]{0,200}\bhttps?://t\.me/ffmemes/\d+\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bhttps?://t\.me/ffmemes/\d+\b[^\n]{0,200}"
+        r"\b(?:published|posted|publication|channel preview confirmed)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:published_archive|archive_path|published\s+archive|archived\s+at)"
+        r"\s*[:=]?\s*`?docs/comms/published/[\w.-]+\.md\b",
+        re.IGNORECASE,
+    ),
+)
+
 # Intermediate approval signals. New Comms drafts use a CEO-authored
 # `decision=approved_to_publish` marker bound to the reviewed draft revision.
 # `APPROVED_TO_PUBLISH` remains a legacy fallback for old drafts.
@@ -189,6 +211,15 @@ def _all(patterns: Iterable[re.Pattern[str]], text: str) -> bool:
     return all(p.search(text) for p in patterns)
 
 
+def has_published_evidence(text: str) -> bool:
+    """Return True when post text contains terminal publication evidence."""
+    return (
+        _all(PUBLISHED_MARKERS, text)
+        or _any(PUBLISHED_OUTCOME_MARKERS, text)
+        or _any(PUBLISHED_LINK_MARKERS, text)
+    )
+
+
 def nested_state(text: str, *, slug: str | None = None) -> str:
     """Classify a child issue's text into one of `NESTED_STATES`.
 
@@ -197,7 +228,7 @@ def nested_state(text: str, *, slug: str | None = None) -> str:
     `[post:...]` issues and `unknown` otherwise. That keeps the
     parent-cannot-be-green-with-non-terminal-child rule conservative.
     """
-    if _all(PUBLISHED_MARKERS, text):
+    if has_published_evidence(text):
         return "published"
     if _any(MERGED_WITHOUT_CLOSE_MARKERS, text):
         return "merged_without_close"

--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -34,9 +34,7 @@ if str(SCRIPT_DIR) not in sys.path:
 
 try:
     from paperclip_contracts import (
-        PUBLISHED_MARKERS as PUBLISHED_MARKER_PATTERNS,
-    )
-    from paperclip_contracts import (
+        has_published_evidence,
         issue_slug,
         nested_state,
         parent_child_status_violation,
@@ -50,9 +48,7 @@ try:
     )
 except ModuleNotFoundError:
     from scripts.paperclip_contracts import (
-        PUBLISHED_MARKERS as PUBLISHED_MARKER_PATTERNS,
-    )
-    from scripts.paperclip_contracts import (
+        has_published_evidence,
         issue_slug,
         nested_state,
         parent_child_status_violation,
@@ -340,7 +336,8 @@ def classify_issue(
     interactions: list[dict[str, Any]] | None = None,
     interactions_degraded: bool = False,
 ) -> tuple[list[str], str]:
-    text = "\n".join([issue.get("description") or ""] + [c.get("body") or "" for c in comments])
+    comment_text = "\n".join(c.get("body") or "" for c in comments)
+    text = "\n".join([issue.get("description") or "", comment_text])
     lower = text.lower()
     title = (issue.get("title") or "").lower()
     flags: list[str] = []
@@ -364,12 +361,14 @@ def classify_issue(
     # often mention approvals, posts, or prior watchdog flags while summarizing
     # their work; those must not inherit the channel-publication contract.
     is_publish_flow = title.startswith("[post:") or "daily channel post" in title
+    approval_text = text if title.startswith("[post:") else comment_text
+    approval_lower = approval_text.lower()
     has_approval_signal = (
-        "decision=approved_to_publish" in lower
-        or "approved_to_publish" in lower
+        "decision=approved_to_publish" in approval_lower
+        or "approved_to_publish" in approval_lower
         or has_accepted_confirmation(interactions or [])
     )
-    has_publish_marker = all(pattern.search(text) for pattern in PUBLISHED_MARKER_PATTERNS)
+    has_publish_marker = has_published_evidence(text)
     if is_publish_flow and has_approval_signal and not has_publish_marker:
         flags.append("approved_without_publish_marker")
     elif is_publish_flow and interactions_degraded and not has_publish_marker:
@@ -520,6 +519,10 @@ def audit_routines(client: Paperclip, company_id: str, focus: str) -> list[dict[
         refs = referenced_post_issues(client, issue or {}, comments)
         if refs:
             row["referencedPostIssues"] = refs
+            if any(ref.get("nestedState") == "published" for ref in refs):
+                row["flags"] = [
+                    flag for flag in row["flags"] if flag != "approved_without_publish_marker"
+                ]
             # Parent cannot be reported green while a referenced child is
             # non-terminal. Surface the child identifiers explicitly so
             # downstream consumers can route them.

--- a/scripts/paperclip_routine_audit.py
+++ b/scripts/paperclip_routine_audit.py
@@ -35,6 +35,7 @@ if str(SCRIPT_DIR) not in sys.path:
 try:
     from paperclip_contracts import (
         has_published_evidence,
+        is_terminal_nested_state,
         issue_slug,
         nested_state,
         parent_child_status_violation,
@@ -49,6 +50,7 @@ try:
 except ModuleNotFoundError:
     from scripts.paperclip_contracts import (
         has_published_evidence,
+        is_terminal_nested_state,
         issue_slug,
         nested_state,
         parent_child_status_violation,
@@ -519,7 +521,7 @@ def audit_routines(client: Paperclip, company_id: str, focus: str) -> list[dict[
         refs = referenced_post_issues(client, issue or {}, comments)
         if refs:
             row["referencedPostIssues"] = refs
-            if any(ref.get("nestedState") == "published" for ref in refs):
+            if all(is_terminal_nested_state(ref.get("nestedState") or "") for ref in refs):
                 row["flags"] = [
                     flag for flag in row["flags"] if flag != "approved_without_publish_marker"
                 ]

--- a/tests/scripts/test_paperclip_routine_audit.py
+++ b/tests/scripts/test_paperclip_routine_audit.py
@@ -175,6 +175,85 @@ def test_daily_channel_post_parent_is_green_when_linked_post_is_published():
     assert rows[0]["referencedPostIssues"][0]["nestedState"] == "published"
 
 
+def test_daily_channel_post_parent_stays_flagged_with_mixed_referenced_posts():
+    parent = {
+        "id": "parent-id",
+        "identifier": "FFM-1558",
+        "title": "Daily Channel Post",
+        "status": "done",
+        "description": "Linked drafts: FFM-1559 and FFM-1560.",
+    }
+    published_child = {
+        "id": "published-child-id",
+        "identifier": "FFM-1559",
+        "title": "[post:2026-06-15-text-heavy-memes] Text-heavy memes beat no-text images",
+        "status": "done",
+        "description": "",
+        "assigneeAgentId": "comms-agent",
+        "updatedAt": "2026-06-15T12:00:00Z",
+    }
+    approved_child = {
+        "id": "approved-child-id",
+        "identifier": "FFM-1560",
+        "title": "[post:2026-06-15-reactions-lore] Reaction lore",
+        "status": "done",
+        "description": "",
+        "assigneeAgentId": "comms-agent",
+        "updatedAt": "2026-06-15T12:30:00Z",
+    }
+    routes = {
+        "/api/companies/company-id/routines": [
+            {
+                "id": "routine-id",
+                "status": "active",
+                "title": "Daily Channel Post",
+                "lastRun": {
+                    "status": "completed",
+                    "linkedIssueId": "parent-id",
+                    "linkedIssue": {
+                        "identifier": "FFM-1558",
+                        "title": "Daily Channel Post",
+                        "status": "done",
+                    },
+                },
+            }
+        ],
+        "/api/issues/parent-id": parent,
+        ("/api/issues/parent-id/comments", (("limit", "100"),)): [
+            {
+                "body": (
+                    "decision=approved_to_publish before publishing.\n"
+                    "Linked drafts: FFM-1559 and FFM-1560."
+                )
+            }
+        ],
+        ("/api/issues/parent-id/interactions", (("limit", "100"),)): [],
+        "/api/issues/FFM-1559": published_child,
+        ("/api/issues/published-child-id/comments", (("limit", "100"),)): [
+            {
+                "body": (
+                    "outcome=published channel=ffmemes telegram_message_id=262 editorial_post_id=30"
+                )
+            }
+        ],
+        ("/api/issues/published-child-id/interactions", (("limit", "100"),)): [],
+        "/api/issues/FFM-1560": approved_child,
+        ("/api/issues/approved-child-id/comments", (("limit", "100"),)): [
+            {"body": "decision=approved_to_publish\ndraft_revision=2"}
+        ],
+        ("/api/issues/approved-child-id/interactions", (("limit", "100"),)): [],
+    }
+
+    rows = audit.audit_routines(FakePaperclip(routes), "company-id", "comms")
+
+    assert "approved_without_publish_marker" in rows[0]["flags"]
+    assert "parent_done_child_non_terminal" not in rows[0]["flags"]
+    assert [ref["nestedState"] for ref in rows[0]["referencedPostIssues"]] == [
+        "published",
+        "approved_unpublished",
+    ]
+
+
 def test_daily_channel_post_telegram_permalink_counts_as_published():
     issue = {"title": "[post:2026-06-15-text-heavy-memes] Daily Channel Post", "description": ""}
     comments = [

--- a/tests/scripts/test_paperclip_routine_audit.py
+++ b/tests/scripts/test_paperclip_routine_audit.py
@@ -191,6 +191,15 @@ def test_daily_channel_post_telegram_permalink_counts_as_published():
     assert "approved_without_publish_marker" not in flags
 
 
+def test_daily_channel_post_newline_telegram_permalink_counts_as_published():
+    issue = {"title": "[post:2026-06-15-text-heavy-memes] Daily Channel Post", "description": ""}
+    comments = [{"body": ("decision=approved_to_publish\nPublished:\nhttps://t.me/ffmemes/262")}]
+
+    flags, _latest = audit.classify_issue(issue, comments)
+
+    assert "approved_without_publish_marker" not in flags
+
+
 def test_daily_channel_post_published_archive_counts_as_published():
     issue = {"title": "[post:2026-06-15-text-heavy-memes] Daily Channel Post", "description": ""}
     comments = [

--- a/tests/scripts/test_paperclip_routine_audit.py
+++ b/tests/scripts/test_paperclip_routine_audit.py
@@ -23,6 +23,20 @@ def load_audit_module():
 audit = load_audit_module()
 
 
+class FakePaperclip:
+    def __init__(self, routes):
+        self.routes = routes
+
+    def get(self, path, query=None):
+        key = (path, tuple(sorted((query or {}).items())))
+        if key in self.routes:
+            return self.routes[key]
+        if path in self.routes:
+            return self.routes[path]
+        msg = f"missing fake route: {path} {query}"
+        raise AssertionError(msg)
+
+
 def test_pr_review_approval_comment_does_not_require_publish_markers():
     issue = {"title": "[pr:241] Review", "description": ""}
     comments = [
@@ -84,6 +98,113 @@ def test_daily_channel_post_approval_still_requires_publish_markers():
     flags, _latest = audit.classify_issue(issue, comments)
 
     assert "approved_without_publish_marker" in flags
+
+
+def test_daily_channel_post_parent_static_approval_instruction_is_not_live_approval():
+    issue = {
+        "title": "Daily Channel Post",
+        "description": (
+            "Publication gate: requires CEO-authored issue update containing "
+            "decision=approved_to_publish before publishing."
+        ),
+    }
+    comments = [{"body": "outcome=draft_created; draft issue FFM-1559 was created."}]
+
+    flags, _latest = audit.classify_issue(issue, comments)
+
+    assert "approved_without_publish_marker" not in flags
+
+
+def test_daily_channel_post_parent_is_green_when_linked_post_is_published():
+    parent = {
+        "id": "parent-id",
+        "identifier": "FFM-1558",
+        "title": "Daily Channel Post",
+        "status": "done",
+        "description": (
+            "Publication gate: requires CEO-authored issue update containing "
+            "decision=approved_to_publish before publishing.\n"
+            "Linked draft: FFM-1559."
+        ),
+    }
+    child = {
+        "id": "child-id",
+        "identifier": "FFM-1559",
+        "title": "[post:2026-06-15-text-heavy-memes] Text-heavy memes beat no-text images",
+        "status": "done",
+        "description": "",
+        "assigneeAgentId": "comms-agent",
+        "updatedAt": "2026-06-15T12:00:00Z",
+    }
+    routes = {
+        "/api/companies/company-id/routines": [
+            {
+                "id": "routine-id",
+                "status": "active",
+                "title": "Daily Channel Post",
+                "lastRun": {
+                    "status": "completed",
+                    "linkedIssueId": "parent-id",
+                    "linkedIssue": {
+                        "identifier": "FFM-1558",
+                        "title": "Daily Channel Post",
+                        "status": "done",
+                    },
+                },
+            }
+        ],
+        "/api/issues/parent-id": parent,
+        ("/api/issues/parent-id/comments", (("limit", "100"),)): [
+            {"body": "outcome=draft_created; draft issue FFM-1559 was created."}
+        ],
+        ("/api/issues/parent-id/interactions", (("limit", "100"),)): [],
+        "/api/issues/FFM-1559": child,
+        ("/api/issues/child-id/comments", (("limit", "100"),)): [
+            {
+                "body": (
+                    "outcome=published channel=ffmemes telegram_message_id=262 editorial_post_id=30"
+                )
+            }
+        ],
+        ("/api/issues/child-id/interactions", (("limit", "100"),)): [],
+    }
+
+    rows = audit.audit_routines(FakePaperclip(routes), "company-id", "comms")
+
+    assert rows[0]["flags"] == []
+    assert rows[0]["referencedPostIssues"][0]["nestedState"] == "published"
+
+
+def test_daily_channel_post_telegram_permalink_counts_as_published():
+    issue = {"title": "[post:2026-06-15-text-heavy-memes] Daily Channel Post", "description": ""}
+    comments = [
+        {
+            "body": (
+                "decision=approved_to_publish\n"
+                "Public channel preview confirmed the published post at https://t.me/ffmemes/262."
+            )
+        }
+    ]
+
+    flags, _latest = audit.classify_issue(issue, comments)
+
+    assert "approved_without_publish_marker" not in flags
+
+
+def test_daily_channel_post_published_archive_counts_as_published():
+    issue = {"title": "[post:2026-06-15-text-heavy-memes] Daily Channel Post", "description": ""}
+    comments = [
+        {
+            "body": (
+                "decision=approved_to_publish\n"
+                "published_archive=docs/comms/published/2026-06-15-text-heavy-memes.md"
+            )
+        }
+    ]
+
+    flags, _latest = audit.classify_issue(issue, comments)
+
+    assert "approved_without_publish_marker" not in flags
 
 
 def test_freeform_approval_comment_is_not_publish_approval_signal():

--- a/tests/test_paperclip_contracts.py
+++ b/tests/test_paperclip_contracts.py
@@ -29,6 +29,7 @@ from paperclip_contracts import (  # noqa: E402
     OUTCOME_ALIASES,
     agent_workflow_invariant_violations,
     canonical_action,
+    has_published_evidence,
     is_decision_action,
     is_outcome_action,
     issue_slug,
@@ -131,6 +132,21 @@ def test_is_outcome_and_decision_helpers_agree_with_canonical():
 
 def test_nested_state_published_terminal():
     text = "Posted to channel.\noutcome=published telegram_message_id=42 editorial_post_id=ep-9"
+    assert nested_state(text, slug="post") == "published"
+
+
+def test_published_evidence_accepts_public_channel_permalink():
+    text = (
+        "Public channel preview confirmed the post at https://t.me/ffmemes/262; "
+        "the linked issue can now close."
+    )
+    assert has_published_evidence(text) is True
+    assert nested_state(text, slug="post") == "published"
+
+
+def test_published_evidence_accepts_published_archive_path():
+    text = "published_archive=docs/comms/published/2026-06-15-text-heavy-memes.md"
+    assert has_published_evidence(text) is True
     assert nested_state(text, slug="post") == "published"
 
 

--- a/tests/test_paperclip_contracts.py
+++ b/tests/test_paperclip_contracts.py
@@ -144,6 +144,12 @@ def test_published_evidence_accepts_public_channel_permalink():
     assert nested_state(text, slug="post") == "published"
 
 
+def test_published_evidence_accepts_newline_before_public_channel_permalink():
+    text = "Published:\nhttps://t.me/ffmemes/262"
+    assert has_published_evidence(text) is True
+    assert nested_state(text, slug="post") == "published"
+
+
 def test_published_evidence_accepts_published_archive_path():
     text = "published_archive=docs/comms/published/2026-06-15-text-heavy-memes.md"
     assert has_published_evidence(text) is True


### PR DESCRIPTION
Fixes FFM-1564.

## What changed
- Centralized Daily Channel Post publication evidence in `has_published_evidence()`.
- Treat canonical published outcomes, public `https://t.me/ffmemes/<message>` links, and `docs/comms/published/...` archive paths as terminal publication evidence.
- Accept public `https://t.me/ffmemes/<message>` links when the publication marker and permalink are split across Markdown lines, e.g. `Published:` followed by the URL on the next line.
- Avoid treating static parent routine instructions that mention `decision=approved_to_publish` as live approval evidence.
- When a Daily Channel Post parent references a `[post:...]` child with `nestedState=published`, clear the parent `approved_without_publish_marker` false positive while preserving child non-terminal failures.
- Added regression tests for the FFM-1558/FFM-1559 parent/linked-child shape, Telegram permalink same-line and newline completion shapes, plus published archive completion shapes.

## Verification
- `python3 -m pytest tests/scripts/test_paperclip_routine_audit.py tests/test_paperclip_contracts.py -q` -> 44 passed
- `ruff check --fix src/ tests/ scripts/paperclip_contracts.py scripts/paperclip_routine_audit.py` -> passed
- `ruff format src/ tests/ scripts/paperclip_contracts.py scripts/paperclip_routine_audit.py` -> 1 file reformatted, 274 files left unchanged

Note: I could not run the live `python3 scripts/paperclip_routine_audit.py --focus comms` API audit locally because the script requires `PAPERCLIP_API_KEY` in env, while this runtime only exposes Paperclip auth through the CLI context file. The pure regressions cover the FFM-1558/FFM-1559 API shape and the review-requested Markdown newline permalink shape directly.

Staff Engineer: please review before merge.