### PR TITLE
Fix Analyst/Comms feedback loops for Paperclip trial

### DIFF
--- a/agents/analyst/AGENTS.md
+++ b/agents/analyst/AGENTS.md
@@ -34,15 +34,27 @@ delegated subtasks instead of comment-only handoffs.
 ## Issue Hygiene
 
 Every issue you create must start with a stable bracket slug. Use
-`[report:YYYY-MM-DD]` for scheduled reports and update/comment on an existing
-open issue with that slug instead of creating duplicates. Use native Paperclip
+`[report:YYYY-MM-DD]` for scheduled daily reports and search open, blocked,
+in-review, and done issues with that slug before creating anything. If today's
+daily report issue already exists in any non-cancelled state, add a short
+comment/no-op instead of creating a duplicate CEO review. Use native Paperclip
 company search / issue search before creating a recurrent slug.
+
+For unscheduled diagnostics, never reuse `[report:YYYY-MM-DD]`. Use a distinct
+slug such as `[diagnostic:YYYY-MM-DD-HHmm-topic]` and create it only when a
+severity threshold is crossed or the CEO explicitly asked for the slice.
 
 Only the CEO may open strategic issues. As Analyst, create only execution
 tickets from your explicit workflow; put strategic findings in your report for
 CEO to route.
 
 ## Every Heartbeat (every 6 hours)
+
+Heartbeat runs are health checks and anomaly scans. They must not create a
+scheduled daily report or CEO review by default. Run the Daily Report workflow
+only when the current Paperclip task/routine is explicitly "Daily Analyst
+Report" or the CEO asked for a report. If a heartbeat finds a severe incident,
+create a `[diagnostic:...]` issue or comment on the owning incident instead.
 
 ### 1. Review Historical Context
 Before running any queries, read:
@@ -114,9 +126,16 @@ Flag if pct_reacted drops below 55% or pct_delivered drops below 90%.
 
 IMPORTANT: The old dashboard metric (user_stats.nmemes_sent > 0) measures "reacted", not "received". Always use user_meme_reaction directly for delivery measurement. See comments in metrics.sql for details.
 
-### 8. Write Daily Report (FIXED SHAPE — do not deviate)
+### 8. Write Daily Report (scheduled routine only — fixed shape)
 
-Create the report at `experiments/reports/YYYY-MM-DD-HHmm.md`. The report has **four sections** in this order. Do not add other sections, do not omit any. Brevity is mandatory.
+Create the scheduled daily report at `experiments/reports/YYYY-MM-DD.md`. Before
+writing, check whether that file already exists and whether `experiments/log.jsonl`
+already contains `agent=analyst`, `action=daily_report` for the same UTC date.
+If either exists, do not write a second daily report; comment/no-op on the
+Paperclip run and point to the existing report. Use timestamped
+`YYYY-MM-DD-HHmm.md` files only for explicit `[diagnostic:...]` tasks.
+
+The report has **four sections** in this order. Do not add other sections, do not omit any. Brevity is mandatory.
 
 ```markdown
 # Daily report YYYY-MM-DD
@@ -233,8 +252,13 @@ Append an entry to `experiments/log.jsonl`:
 }
 ```
 
-### 10. Create Task for CEO
-Create a Paperclip issue assigned to @ceo with the report summary, key metrics, anomalies, and recommended actions. Set priority "high" if anomalies >30%.
+### 10. Upsert Task for CEO
+Create or update exactly one Paperclip issue assigned to @ceo with slug
+`[report:YYYY-MM-DD]`. Search open, blocked, in-review, and done issues first.
+If today's report task already exists and is not cancelled, add a concise
+comment pointing at the newest report/anomaly files and do not create another
+CEO issue. Set priority "high" only if a severity-gated anomaly crossed the
+threshold.
 
 ### 11. Close Your Execution Issue
 

--- a/agents/comms-manager/AGENTS.md
+++ b/agents/comms-manager/AGENTS.md
@@ -56,8 +56,16 @@ into the moderator chat.
 **Daily routine** (cron: `0 7 * * *` / 10:00 MSK):
 
 ### Step 0 — Read yesterday's channel performance
-Read `experiments/reports/channel-stats-YYYY-MM-DD.md` (regenerated at 06:55
-UTC by the `Write Channel Stats Report` Prefect deployment). It contains:
+Pick the target channel first. Default to `channel="ffmemes"` for product,
+process, and build-in-public posts. Read the matching channel-specific stats
+file:
+
+- `experiments/reports/channel-stats-ffmemes-YYYY-MM-DD.md` for @ffmemes
+- `experiments/reports/channel-stats-ru-YYYY-MM-DD.md` for @fastfoodmemes
+- `experiments/reports/channel-stats-en-YYYY-MM-DD.md` for @fast_food_memes
+
+The @ffmemes file is regenerated at 06:55 UTC by the
+`Write Channel Stats Report` Prefect deployment. It contains:
 
 - Median views across the last 30 days of editorial posts
 - Top 5 and weakest 3 posts with category/entity
@@ -70,14 +78,43 @@ canonical topic families from the last 14 posts are enforced by code as a hard
 rotation check (see "Posting" below), but you should also aim for variety
 beyond that.
 
-If the file is missing (first run, or cron failed), proceed without it —
-the rotation check still runs against the database.
+If the file is missing or older than today's date, run the DB fallback directly:
+call `src.comms.performance.write_channel_stats_report(channel="ffmemes")`
+for @ffmemes, or the matching channel slug for the target channel, then read the
+fresh file it returns. If both the file and DB fallback fail, do not publish a
+C/Data or anomaly post. Use a non-data fallback (A-Feature, B-Historical,
+F-Behind-the-scenes) only if it does not depend on performance stats; otherwise
+block the draft with a clear Paperclip comment.
+
+Also read the `Stats freshness:` line. If it is `stale`, block C/Data and raw
+anomaly posts. A stale stats file may still inform non-data fallback rotation,
+but the draft must record `fallback_reason=stale_channel_stats`.
 
 ### Step 1 — Build today's editorial slate
 Read `experiments/reports/anomalies-YYYY-MM-DD.md` written by the Analyst agent
 earlier this morning. This file ranks the day's most surprising findings and
 may include an editorial fallback slate. Do not mechanically publish Finding 1.
 Build a short candidate slate and pick the best public story.
+
+Always write down a slate of 3 candidates before drafting:
+- candidate topic and target channel;
+- source: anomaly finding, shipped feature, lore, DB fallback, or weekly digest;
+- why a stranger would care;
+- why it is not a repeat of the last 14 post families;
+- visual plan.
+
+Candidate filter:
+- `Post eligibility: post-ready`;
+- `HARD BAN risk: no`;
+- `Novelty vs last 14 posts: new`;
+- `Public story score >= 4` OR the candidate is a shipped user-facing feature
+  people can try today;
+- explicit `Reader payoff`.
+
+Reject candidates that are raw/internal metric cards, infra-only, or "chart says
+X vs baseline" without a reader payoff. `Chart-worthy: yes` never rescues a weak
+story. If fewer than 2 candidates survive, use Step 1b fallback instead of
+forcing a weak anomaly.
 
 Priority order:
 1. **User-facing product change people can try today** — share button, inline
@@ -126,7 +163,7 @@ Pick ONE from:
 Read the last 14 posts from the channel:
 ```python
 from src.comms.channel_history import get_last_n_posts
-recent = await get_last_n_posts(n=14)
+recent = await get_last_n_posts(n=14, channel="ffmemes")
 ```
 Extract the topic/entity of each. Your next post MUST differ from recent posts
 on the actual topic family, not just on a new slug. For example,
@@ -136,8 +173,9 @@ anomaly if the reader would experience it as "another post about the same
 metric/source/feature".
 
 If `get_last_n_posts` returns `[]` (Telethon misconfigured / session expired),
-log a warning to `$ADMIN_LOGS_CHAT_ID` and proceed without rotation — failing
-closed would block the channel.
+log a warning to `$ADMIN_LOGS_CHAT_ID`, then use the channel stats report and
+`docs/comms/published/` as the rotation source. Do not silently proceed with no
+rotation evidence.
 
 ### Step 2b — Draft backlog check
 Before creating a new `[post:...]` issue, search Paperclip for open or blocked
@@ -199,7 +237,9 @@ Do not repeat the botty template:
 Vary the opening, verb, and payoff. If the post still reads like a daily
 analyst card, choose a different format or fallback topic.
 
-**Length cap: ~400 characters of text** (excluding image). Strict.
+**Length cap: 250-400 visible characters, max 6 short lines** (excluding image).
+Strict. If a detail needs more room, the topic is probably not a Telegram post
+or belongs in one short `<blockquote>`.
 
 ### Step 5 — Stranger test
 Before posting, ask yourself: "Would a random person who doesn't know anything
@@ -215,9 +255,16 @@ For exact data, use `src/comms/visuals.py` primitives ONLY. Do not write raw mat
 - Pie charts, 3D, dual-axis → banned
 
 These primitives return PNG bytes. Pass them directly as `photo_bytes=png` to
-`publish_editorial_post`. Under Codex subscription-only runtime, do not use
-`OPENAI_API_KEY` or GPT image generation inside this agent. If editorial art is
-required, create a CEO/ops task for a separate non-Codex image pipeline.
+`publish_editorial_post`.
+
+For non-data editorial art, prefer a generated visual only when the runtime has
+a first-class Codex/image-generation tool that returns an attachable PNG without
+`OPENAI_API_KEY`. Do not bind or use `OPENAI_API_KEY` in a `codex_local` agent.
+If the Paperclip runtime does not expose image generation, create a short
+`[visual:YYYY-MM-DD-slug]` Paperclip task for an interactive Codex operator to
+generate the image and attach the PNG to the draft. After the PNG exists,
+inspect it and publish via `photo_bytes=image_bytes`. Never stage generated
+art in the moderator chat.
 
 See `docs/comms/brand-guide.md` for the full decision tree and constraints.
 
@@ -282,7 +329,8 @@ Style reference: https://github.com/ohld/dania-zip (read the USAGE RULES section
 - Hook first — first 1-2 lines grab attention
 - Emoji bullets only (structural, not decorative). Max 1-3 per post
 - One thought per line. Short sentences
-- Max 15-25 lines. Cut aggressively — 4 strong points beats 6 diluted
+- Max 6 short lines for channel posts. Cut aggressively — one strong idea beats
+  a diluted mini-report
 - Shows process, not just result: "Стали рисерчить", "Собрали данные"
 - Casual, like talking to a friend who codes
 - Never corporate, never dry
@@ -631,5 +679,5 @@ curl -s -X POST "https://api.telegram.org/bot${FFMEMES_PROD_TELEGRAM_BOT_TOKEN}/
 - Do NOT commit secrets to git
 - Do NOT post text-only — always include a visual
 - Do NOT use corporate language or greetings
-- Do NOT exceed ~400 visible characters of post text — cut aggressively, put
-  long detail in `<blockquote>`
+- Do NOT exceed 250-400 visible characters or 6 short lines — cut aggressively,
+  put only genuinely useful detail in one short `<blockquote>`

--- a/agents/comms-manager/routines/daily-channel-post.description.md
+++ b/agents/comms-manager/routines/daily-channel-post.description.md
@@ -8,12 +8,23 @@ Things that trip people up:
 
 - Post via `src.comms.publishing.publish_editorial_post()`. Single sanctioned path. Raw curl, sendPhoto, or sendMessage to the channel splits the post into photo-without-caption + text — we shipped that once.
 - For generated/local visuals, pass `photo_bytes=png` directly. Do not post the image to the moderator chat for staging or `file_id` extraction.
-- Step 0 — read `experiments/reports/channel-stats-YYYY-MM-DD.md` for yesterday's performance.
-- Step 1 — pick the strongest `Chart-worthy: yes` finding from `experiments/reports/anomalies-YYYY-MM-DD.md`.
+- Step 0 — pick the target channel, then read the fresh channel-specific stats
+  file (`channel-stats-ffmemes-YYYY-MM-DD.md` for @ffmemes). If it is missing,
+  run the DB fallback from `src.comms.performance.write_channel_stats_report`.
+  Do not publish data/anomaly posts without fresh stats or fallback evidence.
+- Step 1 — build a slate of 3 candidate public stories from anomalies, shipped
+  features, lore, DB findings, or weekly digest material. Do not mechanically
+  pick the strongest `Chart-worthy: yes` finding; raw anomaly cards are a
+  fallback of last resort.
 - Step 2 — avoid the last 14 topic families, not just exact slugs. A new
   session-length/North-Star slug is still a repeated session-length post.
 - Step 2b — search open/blocked `[post:...]` issues before drafting; blocked or
   approved-unpublished drafts count as already used topics.
+- Step 6 — use `src/comms/visuals.py` for exact numbers. For generated editorial
+  art, use only a first-class Codex/image-generation artifact when available;
+  do not bind `OPENAI_API_KEY` to `codex_local`. If no image tool is available,
+  create a `[visual:...]` task and publish only after a PNG is attached and
+  visually inspected.
 - Step 7 — archive to `docs/comms/published/YYYY-MM-DD-slug.md` and close this issue with a one-liner pointing at the archive.
 - Outcome comments must include the actual public channel and Telegram URL.
   `telegram_message_id` alone is ambiguous because @ffmemes and @fastfoodmemes

--- a/docs/comms/brand-guide.md
+++ b/docs/comms/brand-guide.md
@@ -140,10 +140,13 @@ await publish_editorial_post(..., photo_bytes=png)
 
 If an idea needs exact numbers beyond these primitives, flag it to CTO — don't improvise raw matplotlib.
 
-For non-data editorial art, use `src.comms.image_generation.build_editorial_image_prompt(...)`
-and `generate_editorial_image(...)` with a precise visual brief, then publish via
-`photo_bytes=image.image_bytes`. Do not stage generated visuals in the moderator
-chat to obtain Telegram `file_id`.
+For non-data editorial art, use a first-class Codex/image-generation artifact
+only when the runtime exposes one without `OPENAI_API_KEY`. Codex-local
+Paperclip agents must not bind or use `OPENAI_API_KEY` for image generation.
+If no image-generation tool is available in the agent runtime, create a
+`[visual:YYYY-MM-DD-slug]` Paperclip task for an interactive Codex operator to
+generate and attach a PNG. Publish the reviewed PNG via `photo_bytes=...`. Do
+not stage generated visuals in the moderator chat to obtain Telegram `file_id`.
 
 ### 4. Diagrams
 For engineering/architecture posts.

--- a/scripts/serve_flows.py
+++ b/scripts/serve_flows.py
@@ -181,12 +181,13 @@ if __name__ == "__main__":
             name="Weekly Burger Report",
             schedules=[CronSchedule(cron="0 14 * * 0", timezone=MSK)],
         ),
-        # Materialize channel-stats-YYYY-MM-DD.md 5 minutes before Comms Agent
-        # fires at 07:00 UTC (10:00 MSK) so agent reads a fresh digest.
+        # Materialize channel-stats-ffmemes-YYYY-MM-DD.md 5 minutes before
+        # Comms Agent fires at 07:00 UTC (10:00 MSK) so agent reads a fresh
+        # @ffmemes digest.
         write_channel_stats_report.to_deployment(
             name="Write Channel Stats Report",
             schedules=[CronSchedule(cron="55 6 * * *", timezone=LON)],
-            parameters={"channel": "ru", "days": 30},
+            parameters={"channel": "ffmemes", "days": 30},
         ),
         # ── Rewards (weekly) ──
         reward_ru_users_for_weekly_top_uploaded_memes.to_deployment(

--- a/src/comms/channel_history.py
+++ b/src/comms/channel_history.py
@@ -19,7 +19,7 @@ from src.config import settings
 
 logger = logging.getLogger(__name__)
 
-FFMEMES_USERNAME = "fastfoodmemes"  # @ffmemes (Russian channel)
+FFMEMES_USERNAME = "ffmemes"  # @ffmemes build-in-public channel
 
 
 @dataclass

--- a/src/comms/image_generation.py
+++ b/src/comms/image_generation.py
@@ -4,6 +4,11 @@ This module is intentionally small: Comms builds an explicit prompt, receives
 image bytes, visually reviews them, and passes the bytes directly to
 `publish_editorial_post(photo_bytes=...)`. No Telegram moderator-chat staging
 is needed to obtain a file_id.
+
+This helper is API-key backed and is not the approved path for Paperclip
+`codex_local` agents. Those agents should use first-class Codex subscription
+image-generation artifacts when the runtime exposes them, or create a visual
+handoff task for an interactive Codex operator.
 """
 
 from __future__ import annotations

--- a/src/comms/performance.py
+++ b/src/comms/performance.py
@@ -5,8 +5,8 @@ Two layers:
   1. `get_recent_editorial_performance(channel, days)` — DB query returning
      rows with category, entity_id, text preview, views, forwards, reactions.
   2. `write_channel_stats_report(channel, days, output_dir)` — materializes
-     `experiments/reports/channel-stats-YYYY-MM-DD.md`. The Comms Agent reads
-     this file as its first input of the day (Step 0 of its routine).
+     `experiments/reports/channel-stats-{channel}-YYYY-MM-DD.md`. The Comms
+     Agent reads this file as its first input of the day (Step 0 of its routine).
 
 The report is deliberately short (LLM-friendly): top/bottom by views,
 reaction-mix summary, category/entity frequency. Numbers are the source of
@@ -43,6 +43,7 @@ class EditorialRow:
     reactions: int
     reactions_detail: dict[str, int] | None
     telegram_message_id: int
+    stats_updated_at: datetime | None
 
 
 async def get_recent_editorial_performance(
@@ -65,6 +66,7 @@ async def get_recent_editorial_performance(
             editorial_posts.c.reactions,
             editorial_posts.c.reactions_detail,
             editorial_posts.c.telegram_message_id,
+            editorial_posts.c.stats_updated_at,
         )
         .where(editorial_posts.c.channel == channel)
         .where(editorial_posts.c.created_at >= cutoff)
@@ -85,6 +87,7 @@ async def get_recent_editorial_performance(
             reactions=r["reactions"] or 0,
             reactions_detail=r["reactions_detail"],
             telegram_message_id=r["telegram_message_id"],
+            stats_updated_at=r["stats_updated_at"],
         )
         for r in (rows or [])
     ]
@@ -130,6 +133,13 @@ def format_channel_stats_report(
 
     views = [r.views for r in rows]
     median_views = _median(views)
+    newest_stats = max((r.stats_updated_at for r in rows if r.stats_updated_at), default=None)
+    stats_age_hours = (
+        (as_of - newest_stats.replace(tzinfo=None)).total_seconds() / 3600
+        if newest_stats
+        else None
+    )
+    freshness = "ok" if stats_age_hours is not None and stats_age_hours <= 12 else "stale"
     top_views = sorted(rows, key=lambda r: r.views, reverse=True)[:5]
     # Only include posts that had at least 24h to accumulate views.
     cutoff_24h = as_of - timedelta(hours=24)
@@ -151,6 +161,12 @@ def format_channel_stats_report(
         f"# Channel stats — @{channel} — {as_of.date().isoformat()}",
         "",
         f"Window: last {days} days. Posts: {len(rows)}. Median views: {median_views}.",
+        (
+            f"Stats freshness: {freshness} "
+            f"(last collector update {stats_age_hours:.1f}h ago)."
+            if stats_age_hours is not None
+            else "Stats freshness: stale (no collector update recorded)."
+        ),
         "",
         "## Top 5 by views",
         "",
@@ -197,6 +213,12 @@ def format_channel_stats_report(
     return "\n".join(lines)
 
 
+def channel_stats_report_path(out_dir: Path, channel: str, as_of: datetime) -> Path:
+    """Return the channel-specific stats report path for a run date."""
+    safe_channel = channel.replace("/", "-")
+    return out_dir / f"channel-stats-{safe_channel}-{as_of.date().isoformat()}.md"
+
+
 @flow(
     retries=1,
     retry_delay_seconds=30,
@@ -216,8 +238,16 @@ async def write_channel_stats_report(
 
     out_dir = Path(output_dir) if output_dir else REPORTS_DIR
     out_dir.mkdir(parents=True, exist_ok=True)
-    path = out_dir / f"channel-stats-{as_of.date().isoformat()}.md"
+    path = channel_stats_report_path(out_dir, channel, as_of)
     path.write_text(report, encoding="utf-8")
+
+    # Backward-compatible alias for older Comms instructions during rollout.
+    # The daily deployment targets @ffmemes, so the legacy name should point to
+    # @ffmemes stats rather than the main meme channel.
+    if channel == "ffmemes":
+        legacy_path = out_dir / f"channel-stats-{as_of.date().isoformat()}.md"
+        legacy_path.write_text(report, encoding="utf-8")
+
     log.info(f"Wrote {path} with {len(rows)} posts")
     return str(path)
 
@@ -225,6 +255,7 @@ async def write_channel_stats_report(
 __all__ = [
     "EditorialRow",
     "REPORTS_DIR",
+    "channel_stats_report_path",
     "format_channel_stats_report",
     "get_recent_editorial_performance",
     "write_channel_stats_report",

--- a/src/flows/crossposting/stats_collector.py
+++ b/src/flows/crossposting/stats_collector.py
@@ -1,8 +1,8 @@
 """
 Channel post stats collector via Telethon.
 
-Reads views, forwards, reactions from @fastfoodmemes and @fast_food_memes
-channel posts. Stores time-series snapshots for analysis.
+Reads views, forwards, reactions from @ffmemes, @fastfoodmemes, and
+@fast_food_memes channel posts. Stores time-series snapshots for analysis.
 
 Runs every 6 hours via Prefect cron (registered in serve_flows.py).
 
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 # Channel usernames (without @)
 CHANNELS = {
+    "ffmemes": "ffmemes",
     "tgchannelru": "fastfoodmemes",
     "tgchannelen": "fast_food_memes",
 }

--- a/tests/comms/test_performance.py
+++ b/tests/comms/test_performance.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 
 from src.comms.performance import (
     EditorialRow,
+    channel_stats_report_path,
     format_channel_stats_report,
 )
 
@@ -22,6 +23,7 @@ def _row(
     reactions_detail: dict[str, int] | None = None,
     forwards: int = 0,
     text: str = "sample",
+    stats_updated_at: datetime | None = None,
 ) -> EditorialRow:
     now = datetime(2026, 4, 24, 6, 0, 0)
     return EditorialRow(
@@ -37,6 +39,7 @@ def _row(
         reactions=reactions,
         reactions_detail=reactions_detail,
         telegram_message_id=1000 + rid,
+        stats_updated_at=stats_updated_at or now,
     )
 
 
@@ -51,6 +54,7 @@ def test_format_reports_median_and_counts():
     out = format_channel_stats_report(rows, channel="ru", days=30, as_of=datetime(2026, 4, 24, 10))
     assert "Posts: 5" in out
     assert "Median views: 120" in out
+    assert "Stats freshness: ok" in out
 
 
 def test_format_top_views_sorted_desc():
@@ -109,3 +113,21 @@ def test_format_strips_html_from_preview():
     out = format_channel_stats_report(rows, channel="ru", days=30, as_of=datetime(2026, 4, 24, 10))
     assert "<b>" not in out
     assert "жир и курсив" in out
+
+
+def test_channel_stats_report_path_is_channel_specific(tmp_path):
+    path = channel_stats_report_path(tmp_path, "ffmemes", datetime(2026, 4, 24, 10))
+    assert path.name == "channel-stats-ffmemes-2026-04-24.md"
+
+
+def test_format_marks_stale_stats_when_collector_update_is_old():
+    rows = [
+        _row(
+            1,
+            1,
+            100,
+            stats_updated_at=datetime(2026, 4, 23, 0, 0),
+        )
+    ]
+    out = format_channel_stats_report(rows, channel="ffmemes", days=30, as_of=datetime(2026, 4, 24, 14))
+    assert "Stats freshness: stale" in out

--- a/tests/comms/test_performance.py
+++ b/tests/comms/test_performance.py
@@ -129,5 +129,10 @@ def test_format_marks_stale_stats_when_collector_update_is_old():
             stats_updated_at=datetime(2026, 4, 23, 0, 0),
         )
     ]
-    out = format_channel_stats_report(rows, channel="ffmemes", days=30, as_of=datetime(2026, 4, 24, 14))
+    out = format_channel_stats_report(
+        rows,
+        channel="ffmemes",
+        days=30,
+        as_of=datetime(2026, 4, 24, 14),
+    )
     assert "Stats freshness: stale" in out


### PR DESCRIPTION
## Summary
- make Analyst daily reports idempotent by date and stop heartbeat-created duplicate CEO report issues
- make Comms require fresh channel-specific stats, use a 3-candidate editorial slate, and avoid dry raw anomaly cards
- switch daily channel stats to @ffmemes, add ffmemes to the Telethon stats collector, and expose stats freshness in the report
- clarify Codex subscription image-generation workflow without binding OPENAI_API_KEY to codex_local agents

## Verification
- `python3 -m py_compile src/comms/performance.py src/comms/channel_history.py src/flows/crossposting/stats_collector.py src/comms/image_generation.py scripts/serve_flows.py tests/comms/test_performance.py`

Full pytest was not run locally because this shell has no uv/poetry/pytest installed.

## Paperclip trial context
Related Paperclip tasks: FFM-1575, FFM-1576, FFM-1578.
