### PR TITLE
Launch inline meme share canary

### DIFF
--- a/docs/analyst/inline-share-canary-readout.sql
+++ b/docs/analyst/inline-share-canary-readout.sql
@@ -1,0 +1,120 @@
+-- Exact-meme inline share canary readout.
+--
+-- Replace the timestamps below with the trial window. Always exclude the
+-- current partial UTC day from final day-7 reads.
+--
+-- Primary:
+--   non-self m_/s_ deep-link opens per 1k meme sends
+-- Send proxy:
+--   inline_search_chosen_result_logs rows with exact #meme_id queries
+-- Guardrails:
+--   like rate and continued feed consumption by assigned variant
+--
+-- Do not call this native Telegram forward tracking. Telegram does not expose
+-- whether a user forwarded or sent the URL; we only observe later recipient
+-- starts and inline chosen-result callbacks.
+
+WITH params AS (
+    SELECT
+        TIMESTAMP '2026-06-16 00:00:00' AS started_at,
+        TIMESTAMP '2026-06-23 00:00:00' AS ended_at
+),
+assignments AS (
+    SELECT
+        ea.user_id,
+        ea.variant,
+        ea.assigned_at,
+        (ea.assignment_metadata->>'bucket')::int AS bucket,
+        (ea.assignment_metadata->>'inline_canary_percent')::int AS inline_canary_percent
+    FROM experiment_assignment ea, params p
+    WHERE ea.experiment_id = 'meme_share_button'
+      AND ea.assigned_at >= p.started_at
+      AND ea.assigned_at < p.ended_at
+),
+assigned_sends AS (
+    SELECT
+        a.user_id,
+        a.variant,
+        count(*) AS meme_sends,
+        count(*) FILTER (WHERE umr.reaction_id IS NOT NULL) AS reactions,
+        count(*) FILTER (WHERE umr.reaction_id = 1) AS likes
+    FROM assignments a
+    JOIN user_meme_reaction umr
+      ON umr.user_id = a.user_id
+     AND umr.sent_at >= a.assigned_at
+    JOIN params p ON true
+    WHERE umr.sent_at >= p.started_at
+      AND umr.sent_at < p.ended_at
+    GROUP BY a.user_id, a.variant
+),
+inline_chosen AS (
+    SELECT
+        a.variant,
+        count(*) AS exact_inline_sends,
+        count(DISTINCT ic.user_id) AS exact_inline_senders
+    FROM assignments a
+    JOIN inline_search_chosen_result_logs ic
+      ON ic.user_id = a.user_id
+     AND ic.chosen_at >= a.assigned_at
+    JOIN params p ON true
+    WHERE ic.chosen_at >= p.started_at
+      AND ic.chosen_at < p.ended_at
+      AND ic.query ~ '^#[0-9]+$'
+    GROUP BY a.variant
+),
+parsed_share_clicks AS (
+    SELECT
+        udll.created_at,
+        udll.user_id AS clicked_user_id,
+        split_part(udll.deep_link, '_', 2)::bigint AS sharer_user_id,
+        split_part(udll.deep_link, '_', 3)::int AS meme_id
+    FROM user_deep_link_log udll, params p
+    WHERE udll.created_at >= p.started_at
+      AND udll.created_at < p.ended_at
+      AND udll.deep_link ~ '^[ms]_[0-9]+_[0-9]+$'
+),
+nonself_share_starts AS (
+    SELECT
+        a.variant,
+        count(*) AS nonself_share_starts,
+        count(DISTINCT psc.clicked_user_id) AS nonself_share_users,
+        count(DISTINCT psc.sharer_user_id) AS sharers_with_nonself_starts
+    FROM assignments a
+    JOIN parsed_share_clicks psc
+      ON psc.sharer_user_id = a.user_id
+     AND psc.clicked_user_id <> psc.sharer_user_id
+     AND psc.created_at >= a.assigned_at
+    GROUP BY a.variant
+)
+SELECT
+    a.variant,
+    count(DISTINCT a.user_id) AS assigned_users,
+    max(a.inline_canary_percent) AS inline_canary_percent,
+    count(DISTINCT a.user_id) FILTER (WHERE s.meme_sends >= 1) AS users_sent_after_assignment,
+    coalesce(sum(s.meme_sends), 0) AS meme_sends,
+    round(100.0 * sum(s.likes) / nullif(sum(s.reactions), 0), 2) AS like_rate_pct,
+    round(
+        100.0 * count(DISTINCT a.user_id) FILTER (WHERE s.meme_sends >= 2)
+        / nullif(count(DISTINCT a.user_id) FILTER (WHERE s.meme_sends >= 1), 0),
+        2
+    ) AS continued_after_first_sent_pct,
+    coalesce(max(ic.exact_inline_sends), 0) AS exact_inline_sends,
+    coalesce(max(ic.exact_inline_senders), 0) AS exact_inline_senders,
+    coalesce(max(ns.nonself_share_starts), 0) AS nonself_share_starts,
+    coalesce(max(ns.nonself_share_users), 0) AS nonself_share_users,
+    coalesce(max(ns.sharers_with_nonself_starts), 0) AS sharers_with_nonself_starts,
+    round(
+        1000.0 * coalesce(max(ns.nonself_share_starts), 0)
+        / nullif(coalesce(sum(s.meme_sends), 0), 0),
+        3
+    ) AS nonself_share_starts_per_1k_sends
+FROM assignments a
+LEFT JOIN assigned_sends s
+  ON s.user_id = a.user_id
+ AND s.variant = a.variant
+LEFT JOIN inline_chosen ic
+  ON ic.variant = a.variant
+LEFT JOIN nonself_share_starts ns
+  ON ns.variant = a.variant
+GROUP BY a.variant
+ORDER BY a.variant;

--- a/src/config.py
+++ b/src/config.py
@@ -32,7 +32,8 @@ class Config(BaseSettings):
     TELEGRAM_BOT_TOKEN: str | None = None
     TELEGRAM_BOT_USERNAME: str | None = None
     TELEGRAM_BOT_WEBHOOK_SECRET: str | None = None
-    TELEGRAM_INLINE_SHARE_ENABLED: bool = False
+    TELEGRAM_INLINE_SHARE_ENABLED: bool = True
+    TELEGRAM_INLINE_SHARE_CANARY_PERCENT: int = 20
     MEME_STORAGE_TELEGRAM_CHAT_ID: str | None = None
     UPLOADED_MEMES_REVIEW_CHAT_ID: str | None = None
     ADMIN_LOGS_CHAT_ID: str | None = None

--- a/src/tgbot/sharing.py
+++ b/src/tgbot/sharing.py
@@ -75,12 +75,26 @@ def get_meme_inline_query(meme_id: int) -> str:
     return f"#{meme_id}"
 
 
-def build_meme_share_assignment(user_id: int) -> tuple[str, dict[str, Any]]:
+def _bounded_percent(value: int) -> int:
+    return max(0, min(100, value))
+
+
+def build_meme_share_assignment(
+    user_id: int,
+    inline_percent: int | None = None,
+) -> tuple[str, dict[str, Any]]:
+    rollout_percent = _bounded_percent(
+        settings.TELEGRAM_INLINE_SHARE_CANARY_PERCENT
+        if inline_percent is None
+        else inline_percent
+    )
     key = f"{MEME_SHARE_BUTTON_EXPERIMENT_ID}:{user_id}"
-    bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 2
-    variant = MEME_SHARE_BUTTON_URL if bucket == 0 else MEME_SHARE_BUTTON_INLINE
+    bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 100
+    variant = MEME_SHARE_BUTTON_INLINE if bucket < rollout_percent else MEME_SHARE_BUTTON_URL
     return variant, {
-        "assignment_strategy": "sha256(experiment_id:user_id)%2",
+        "assignment_strategy": "sha256(experiment_id:user_id)%100",
+        "inline_canary_percent": rollout_percent,
+        "bucket": bucket,
         "url_share": "t.me/share/url with m_{sharer_user_id}_{meme_id}",
         "inline_query": "switch_inline_query_chosen_chat with #meme_id",
     }
@@ -88,6 +102,9 @@ def build_meme_share_assignment(user_id: int) -> tuple[str, dict[str, Any]]:
 
 async def get_or_assign_meme_share_button_variant(user_id: int) -> str:
     if not settings.TELEGRAM_INLINE_SHARE_ENABLED:
+        return MEME_SHARE_BUTTON_URL
+
+    if _bounded_percent(settings.TELEGRAM_INLINE_SHARE_CANARY_PERCENT) <= 0:
         return MEME_SHARE_BUTTON_URL
 
     try:

--- a/tests/tgbot/test_sharing.py
+++ b/tests/tgbot/test_sharing.py
@@ -6,6 +6,7 @@ import pytest
 from src.tgbot.sharing import (
     MEME_SHARE_BUTTON_INLINE,
     MEME_SHARE_BUTTON_URL,
+    build_meme_share_assignment,
     build_meme_share_button,
     get_meme_inline_query,
     get_meme_share_link,
@@ -74,9 +75,26 @@ def test_build_inline_share_button_prefills_exact_meme_query():
     assert button.switch_inline_query_chosen_chat.allow_channel_chats is True
 
 
+def test_build_meme_share_assignment_respects_canary_bounds():
+    variant, metadata = build_meme_share_assignment(10001, inline_percent=0)
+
+    assert variant == MEME_SHARE_BUTTON_URL
+    assert metadata["inline_canary_percent"] == 0
+
+    variant, metadata = build_meme_share_assignment(10001, inline_percent=100)
+
+    assert variant == MEME_SHARE_BUTTON_INLINE
+    assert metadata["inline_canary_percent"] == 100
+
+    variant, metadata = build_meme_share_assignment(10001, inline_percent=150)
+
+    assert variant == MEME_SHARE_BUTTON_INLINE
+    assert metadata["inline_canary_percent"] == 100
+
+
 @pytest.mark.asyncio
-async def test_inline_share_variant_is_disabled_by_default():
-    with patch(
+async def test_inline_share_variant_can_be_disabled_by_flag():
+    with patch("src.tgbot.sharing.settings.TELEGRAM_INLINE_SHARE_ENABLED", False), patch(
         "src.tgbot.sharing.get_experiment_variant",
         new_callable=AsyncMock,
     ) as get_variant:
@@ -84,3 +102,39 @@ async def test_inline_share_variant_is_disabled_by_default():
 
     assert variant == MEME_SHARE_BUTTON_URL
     get_variant.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inline_share_zero_canary_does_not_assign_experiment():
+    with (
+        patch("src.tgbot.sharing.settings.TELEGRAM_INLINE_SHARE_ENABLED", True),
+        patch("src.tgbot.sharing.settings.TELEGRAM_INLINE_SHARE_CANARY_PERCENT", 0),
+        patch("src.tgbot.sharing.get_experiment_variant", new_callable=AsyncMock) as get_variant,
+    ):
+        variant = await get_or_assign_meme_share_button_variant(10001)
+
+    assert variant == MEME_SHARE_BUTTON_URL
+    get_variant.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inline_share_canary_assigns_inline_variant_when_bucketed_in():
+    with (
+        patch("src.tgbot.sharing.settings.TELEGRAM_INLINE_SHARE_ENABLED", True),
+        patch("src.tgbot.sharing.settings.TELEGRAM_INLINE_SHARE_CANARY_PERCENT", 100),
+        patch(
+            "src.tgbot.sharing.get_experiment_variant",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as get_variant,
+        patch(
+            "src.tgbot.sharing.assign_experiment",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as assign,
+    ):
+        variant = await get_or_assign_meme_share_button_variant(10001)
+
+    assert variant == MEME_SHARE_BUTTON_INLINE
+    get_variant.assert_awaited_once_with(10001, "meme_share_button")
+    assign.assert_awaited_once()


### PR DESCRIPTION
## Summary
- enable the exact-meme inline share experiment as a bounded canary by default
- add `TELEGRAM_INLINE_SHARE_CANARY_PERCENT` with a safe 0% kill-switch path
- keep `TELEGRAM_INLINE_SHARE_ENABLED=false` as a full rollback to URL sharing
- add an Analyst SQL readout for assignments, exact inline sends, non-self starts, and guardrails

## Trial context
This is the concrete product-growth bet for the one-week Paperclip trial: FFM-1577 / FFM-1576. It avoids recommender A/B churn and uses the strongest existing signal from the share-button readout.

## Verification
- `python3 -m py_compile src/config.py src/tgbot/sharing.py tests/tgbot/test_sharing.py`
- `git diff --check`
- line-length scan over touched files

Full integration tests were not run here because this local machine has no Docker/pytest environment; README says tests run via `docker compose exec app pytest`.