### PR TITLE
fix: shorten referral reward alert

### DIFF
--- a/src/tgbot/handlers/deep_link.py
+++ b/src/tgbot/handlers/deep_link.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from telegram import Bot
 
 from src.tgbot.constants import UserType
-from src.tgbot.handlers.treasury.constants import TrxType
-from src.tgbot.handlers.treasury.payments import pay_if_not_paid_with_alert
+from src.tgbot.handlers.treasury.constants import PAYOUTS, TrxType
+from src.tgbot.handlers.treasury.payments import pay_if_not_paid, pay_if_not_paid_with_alert
 from src.tgbot.logs import log
 from src.tgbot.senders.invite import send_successfull_invitation_alert
 from src.tgbot.service import (
@@ -64,16 +64,21 @@ but his bot access is blocked (type={invitor_user["type"]})
         else TrxType.USER_INVITER
     )
 
-    paid = await pay_if_not_paid_with_alert(
-        bot,
+    balance = await pay_if_not_paid(
         invitor_user_id,
         trx_type,
         external_id=str(invited_user["id"]),
     )
 
-    if paid:
-        await send_successfull_invitation_alert(invitor_user_id, invited_user_name)
-        await log(f"🤝 #{invitor_user_id} invited {invited_user_name}")
+    if balance is not None:
+        reward_amount = PAYOUTS[trx_type]
+        await send_successfull_invitation_alert(
+            invitor_user_id,
+            invited_user_name,
+            balance=balance,
+            reward_amount=reward_amount,
+        )
+        await log(f"🤝 #{invitor_user_id} invited {invited_user_name}: +{reward_amount} 🍔")
 
 
 async def handle_shared_meme_reward(

--- a/src/tgbot/senders/invite.py
+++ b/src/tgbot/senders/invite.py
@@ -1,15 +1,35 @@
+import logging
+
+from telegram.error import Forbidden
+
 from src import localizer
 from src.tgbot.bot import bot
 from src.tgbot.user_info import get_user_info
 
 
-async def send_successfull_invitation_alert(invitor_user_id: int, invited_user_name: str) -> None:
+def _format_burgers(amount: int | None) -> str:
+    return f"{int(amount or 0):,}".replace(",", " ")
+
+
+async def send_successfull_invitation_alert(
+    invitor_user_id: int,
+    invited_user_name: str,
+    balance: int,
+    reward_amount: int,
+) -> None:
     user_info = await get_user_info(invitor_user_id)
 
-    await bot.send_message(
-        chat_id=invitor_user_id,
-        text=localizer.t(
-            "onboarding.invitation_successful_alert",
-            user_info["interface_lang"],
-        ).format(invited_user_name=invited_user_name),
-    )
+    try:
+        await bot.send_message(
+            chat_id=invitor_user_id,
+            text=localizer.t(
+                "onboarding.invitation_successful_alert",
+                user_info["interface_lang"],
+            ).format(
+                invited_user_name=invited_user_name,
+                balance=_format_burgers(balance),
+                reward_amount=reward_amount,
+            ),
+        )
+    except Forbidden:
+        logging.info("Invitation alert skipped: user %s blocked the bot", invitor_user_id)

--- a/src/tgbot/sharing.py
+++ b/src/tgbot/sharing.py
@@ -84,9 +84,7 @@ def build_meme_share_assignment(
     inline_percent: int | None = None,
 ) -> tuple[str, dict[str, Any]]:
     rollout_percent = _bounded_percent(
-        settings.TELEGRAM_INLINE_SHARE_CANARY_PERCENT
-        if inline_percent is None
-        else inline_percent
+        settings.TELEGRAM_INLINE_SHARE_CANARY_PERCENT if inline_percent is None else inline_percent
     )
     key = f"{MEME_SHARE_BUTTON_EXPERIMENT_ID}:{user_id}"
     bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 100

--- a/static/localization/onboarding.yml
+++ b/static/localization/onboarding.yml
@@ -68,44 +68,45 @@ onboarding.welcome_message:
 
 onboarding.invitation_successful_alert:
   en: |-
-    👏 Your friend {invited_user_name} just joined the bot!
-    Keep sharing memes from the bot and earn tokens 🍔 /b
+    👏 {invited_user_name} joined the bot. +{reward_amount} 🍔
+    Balance: {balance} 🍔
   ru: |-
-    🎉 Твой друг {invited_user_name} теперь тоже с нами.
-    Продолжай делиться мемами из бота и зарабатывай токены 🍔 /b
+    🎉 кореш {invited_user_name} в боте
+    тебе капнуло +{reward_amount} 🍔
+    баланс: {balance} 🍔
   uk: |-
-    🎉 Твій друг {invited_user_name} тепер теж з нами.
-    Продовжуй ділитися мемами з бота і заробляй токени 🍔 /b
+    🎉 {invited_user_name} у боті. +{reward_amount} 🍔
+    Баланс: {balance} 🍔
   es: |-
-    🎉 ¡Tu amigo {invited_user_name} acaba de unirse al bot!
-    Sigue compartiendo memes del bot y gana tokens 🍔 /b
+    🎉 {invited_user_name} se unió al bot. +{reward_amount} 🍔
+    Saldo: {balance} 🍔
   pt-br: |-
-    🎉 Seu amigo {invited_user_name} acabou de se juntar ao bot!
-    Continue compartilhando memes do bot e ganhe tokens 🍔 /b
+    🎉 {invited_user_name} entrou no bot. +{reward_amount} 🍔
+    Saldo: {balance} 🍔
   fr: |-
-    🎉 Votre ami {invited_user_name} vient de rejoindre le bot !
-    Continuez à partager des memes du bot et gagnez des jetons 🍔 /b
+    🎉 {invited_user_name} a rejoint le bot. +{reward_amount} 🍔
+    Solde: {balance} 🍔
   it: |-
-    🎉 Il tuo amico {invited_user_name} si è appena unito al bot!
-    Continua a condividere meme dal bot e guadagna token 🍔 /b
+    🎉 {invited_user_name} si è unito al bot. +{reward_amount} 🍔
+    Saldo: {balance} 🍔
   de: |-
-    👏 Dein Freund {invited_user_name} ist gerade dem Bot beigetreten!
-    Teile weiterhin Memes aus dem Bot und verdiene Token 🍔 /b
+    👏 {invited_user_name} ist im Bot. +{reward_amount} 🍔
+    Kontostand: {balance} 🍔
   uz: |-
-    🎉 Sizning do'stingiz {invited_user_name} hozir ham botda!
-    Botdan mamlakatlar ulashing va tokenlar olishingiz mumkin 🍔 /b
+    🎉 {invited_user_name} botga qo'shildi. +{reward_amount} 🍔
+    Balans: {balance} 🍔
   fa: |-
-    👏 دوست شما {invited_user_name} به تازگی به ربات پیوست!
-    ادامه دادن به اشتراک گذاری میمز از ربات و کسب توکن‌ها 🍔 /b
+    👏 {invited_user_name} به ربات پیوست! +{reward_amount} 🍔
+    موجودی: {balance} 🍔
   ar: |-
-    👏 صديقك {invited_user_name} انضم للتو إلى البوت!
-    استمر في مشاركة الميمز من البوت واكسب الرموز 🍔 /b
+    👏 {invited_user_name} انضم إلى البوت. +{reward_amount} 🍔
+    الرصيد: {balance} 🍔
   tr: |-
-    👏 Arkadaşın {invited_user_name} botumuza katıldı!
-    Botun memelerini paylaşmaya devam edin ve token kazanın 🍔 /b
+    👏 {invited_user_name} bota katıldı. +{reward_amount} 🍔
+    Bakiye: {balance} 🍔
   hi: |-
-    👏 आपका दोस्त {invited_user_name} अभी बॉट में शामिल हुआ है!
-    बॉट से मीम साझा करना जारी रखें और टोकन कमाएं 🍔 /b
+    👏 {invited_user_name} बॉट में शामिल हुआ. +{reward_amount} 🍔
+    बैलेंस: {balance} 🍔
 
 
 onboarding.invited_by_admin:

--- a/tests/tgbot/test_deep_link.py
+++ b/tests/tgbot/test_deep_link.py
@@ -1,0 +1,62 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+fake_bot_module = ModuleType("src.tgbot.bot")
+fake_bot_module.bot = SimpleNamespace()
+sys.modules["src.tgbot.bot"] = fake_bot_module
+
+
+@pytest.mark.asyncio
+async def test_invited_user_reward_uses_single_balance_alert(monkeypatch):
+    from src.tgbot.constants import UserType
+    from src.tgbot.handlers import deep_link
+    from src.tgbot.handlers.treasury.constants import TrxType
+
+    get_user_by_id = AsyncMock(
+        return_value={
+            "id": 111,
+            "blocked_bot_at": None,
+            "type": UserType.USER,
+        }
+    )
+    update_user = AsyncMock()
+    get_tg_user_by_id = AsyncMock(return_value={"is_premium": False})
+    pay_if_not_paid = AsyncMock(return_value=1200)
+    pay_if_not_paid_with_alert = AsyncMock()
+    send_successfull_invitation_alert = AsyncMock()
+    log = AsyncMock()
+
+    monkeypatch.setattr(deep_link, "get_user_by_id", get_user_by_id)
+    monkeypatch.setattr(deep_link, "update_user", update_user)
+    monkeypatch.setattr(deep_link, "get_tg_user_by_id", get_tg_user_by_id)
+    monkeypatch.setattr(deep_link, "pay_if_not_paid", pay_if_not_paid)
+    monkeypatch.setattr(deep_link, "pay_if_not_paid_with_alert", pay_if_not_paid_with_alert)
+    monkeypatch.setattr(
+        deep_link,
+        "send_successfull_invitation_alert",
+        send_successfull_invitation_alert,
+    )
+    monkeypatch.setattr(deep_link, "log", log)
+
+    await deep_link.handle_invited_user(
+        bot=SimpleNamespace(),
+        invited_user={"id": 222},
+        invited_user_name="@ZXCeresha",
+        deep_link="m_111_333",
+    )
+
+    pay_if_not_paid.assert_awaited_once_with(
+        111,
+        TrxType.USER_INVITER,
+        external_id="222",
+    )
+    pay_if_not_paid_with_alert.assert_not_awaited()
+    send_successfull_invitation_alert.assert_awaited_once_with(
+        111,
+        "@ZXCeresha",
+        balance=1200,
+        reward_amount=100,
+    )

--- a/tests/tgbot/test_invite_sender.py
+++ b/tests/tgbot/test_invite_sender.py
@@ -1,0 +1,48 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+fake_bot_module = ModuleType("src.tgbot.bot")
+fake_bot_module.bot = SimpleNamespace()
+sys.modules["src.tgbot.bot"] = fake_bot_module
+
+
+@pytest.mark.asyncio
+async def test_successful_invitation_alert_shows_reward_and_balance(monkeypatch):
+    from src.tgbot.senders import invite
+
+    fake_bot = SimpleNamespace(send_message=AsyncMock())
+    monkeypatch.setattr(invite, "bot", fake_bot)
+    monkeypatch.setattr(
+        invite,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "ru"}),
+    )
+
+    await invite.send_successfull_invitation_alert(
+        invitor_user_id=123,
+        invited_user_name="@ZXCeresha",
+        balance=1200,
+        reward_amount=100,
+    )
+
+    fake_bot.send_message.assert_awaited_once_with(
+        chat_id=123,
+        text="🎉 кореш @ZXCeresha в боте\nтебе капнуло +100 🍔\nбаланс: 1 200 🍔",
+    )
+
+
+def test_invitation_successful_alert_localizations_do_not_show_balance_command():
+    from src import localizer
+
+    for text in localizer.localizations["onboarding.invitation_successful_alert"].values():
+        formatted = text.format(
+            invited_user_name="@ZXCeresha",
+            balance="1 200",
+            reward_amount=100,
+        )
+
+        assert "/b" not in formatted
+        assert "1 200" in formatted

--- a/tests/tgbot/test_sharing.py
+++ b/tests/tgbot/test_sharing.py
@@ -94,10 +94,13 @@ def test_build_meme_share_assignment_respects_canary_bounds():
 
 @pytest.mark.asyncio
 async def test_inline_share_variant_can_be_disabled_by_flag():
-    with patch("src.tgbot.sharing.settings.TELEGRAM_INLINE_SHARE_ENABLED", False), patch(
-        "src.tgbot.sharing.get_experiment_variant",
-        new_callable=AsyncMock,
-    ) as get_variant:
+    with (
+        patch("src.tgbot.sharing.settings.TELEGRAM_INLINE_SHARE_ENABLED", False),
+        patch(
+            "src.tgbot.sharing.get_experiment_variant",
+            new_callable=AsyncMock,
+        ) as get_variant,
+    ):
         variant = await get_or_assign_meme_share_button_variant(10001)
 
     assert variant == MEME_SHARE_BUTTON_URL


### PR DESCRIPTION
## Summary
- replace referral reward follow-up with one short balance-aware alert
- remove the stray `/b` command from invitation success localization
- avoid sending the generic treasury payment alert for referral rewards so users get one clear message
- include format-only cleanup required by the current CI format gate

## Tests
- `/tmp/ff-backend-referral-alert-venv/bin/python -m pytest tests/tgbot/test_invite_sender.py tests/tgbot/test_deep_link.py`
- `/tmp/ff-backend-referral-alert-venv/bin/python -m pytest tests/tgbot/test_invite_sender.py tests/tgbot/test_deep_link.py tests/tgbot/test_sharing.py`
- `/tmp/ff-backend-referral-alert-venv/bin/python -m ruff check src/tgbot/senders/invite.py src/tgbot/handlers/deep_link.py src/tgbot/sharing.py tests/tgbot/test_invite_sender.py tests/tgbot/test_deep_link.py tests/tgbot/test_sharing.py`
- `/tmp/ff-backend-referral-alert-venv/bin/python -m ruff format --check src/ tests/`