### PR TITLE
fix(goat): filter recently sent memes by sent_at

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -17,7 +17,7 @@
 **Context:** Done 2026-03-27. Rewrote `calculate_meme_stats()` to only update memes with reactions in the last 3 hours, then upsert only those rows. Prevents full-table scan timeout cascade at peak traffic. Commit `84a5119`. See [FFM-5](/FFM/issues/FFM-5).
 
 ### ~~Add per-user recency filter to goat engine~~ — DONE
-**Context:** Done 2026-04-13. Added per-user recency filter using `reacted_at` in SCORES CTE to exclude memes the user reacted to in the last 30 days. PR #162 + #169, deployed Apr 13. Goat LR recovered to 41.9% (7d) vs 39.4% baseline, continuation 97.5%. Experiment running through Apr 27.
+**Context:** Done 2026-04-13, corrected 2026-06-16. The GOAT filter uses `sent_at` in the SCORES CTE to exclude memes sent to the user in the last 30 days, including sent-but-unreacted memes. PR #162 + #169 shipped the original recency filter; the June correction changed the signal from `reacted_at` to `sent_at` while preserving the 30-day window to avoid lifetime pool exhaustion. Goat LR recovered to 41.9% (7d) vs 39.4% baseline, continuation 97.5%.
 
 ### Auto-discover new TG channels from forwarded messages
 **What:** When the TG scraper parses a forwarded post, extract the source channel URL. Store discovered channels in a new `meme_source_candidate` table with status='discovered'. Admin/moderator approval flow to promote to `meme_source`.

--- a/experiments/active/2026-04-12-goat-recency-filter.md
+++ b/experiments/active/2026-04-12-goat-recency-filter.md
@@ -7,11 +7,11 @@
 
 ## Hypothesis
 
-The goat engine has the **best continuation rate (98%)** of all engines but suffered LR decline from 44% to ~16% over 6 days due to pool exhaustion — the same top-ranked GOATs are served repeatedly to users who already reacted to them. Adding a per-user recency filter (exclude memes the user reacted to in the last 30 days) will rotate the GOAT pool per-user, restoring fresh high-quality content delivery.
+The goat engine has the **best continuation rate (98%)** of all engines but suffered LR decline from 44% to ~16% over 6 days due to pool exhaustion — the same top-ranked GOATs are served repeatedly to users who already saw them. Adding a per-user recency filter (exclude memes sent to the user in the last 30 days) will rotate the GOAT pool per-user, restoring fresh high-quality content delivery.
 
 ## Changes Made
 
-- `src/recommendations/candidates.py` (goat function): Added per-user recency filter using `reacted_at` in SCORES CTE to exclude memes the user reacted to in the last 30 days. PR #162, commit 97f188a.
+- `src/recommendations/candidates.py` (goat function): Added per-user recency filter in SCORES CTE. PR #162, commit 97f188a shipped the original filter; 2026-06-16 correction changed the filter signal from `reacted_at` to `sent_at`, so recently sent but unreacted memes are excluded too.
 
 ## Metrics to Track
 

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 GOAT_MIN_REACTIONS = 10  # (nlikes + ndislikes) — enough statistical signal
 GOAT_MIN_LR = 0.20  # lr_smoothed — minimum proven like rate
 GOAT_MIN_AGE_DAYS = 3  # days since created_at — must have aged enough to accumulate reactions
+GOAT_RECENTLY_SENT_WINDOW_DAYS = 30
 TEXT_LIGHT_MAX_OCR_WORDS = 30
 
 _OCR_TEXT_SQL = "trim(coalesce(M.ocr_result->>'text', M.ocr_result->'raw_result'->>'ocr_text', ''))"
@@ -325,7 +326,7 @@ async def goat(
                     SELECT 1 FROM user_meme_reaction umr
                     WHERE umr.user_id = :user_id
                       AND umr.meme_id = M.id
-                      AND umr.reacted_at > NOW() - INTERVAL '30 days'
+                      AND umr.sent_at > NOW() - INTERVAL '{GOAT_RECENTLY_SENT_WINDOW_DAYS} days'
                 )
         )
 

--- a/tests/recommendations/test_engine_contracts.py
+++ b/tests/recommendations/test_engine_contracts.py
@@ -61,7 +61,13 @@ async def base_data():
             conn, user_id=10001, meme_id=10011, reaction_id=1, sent_at=recent, reacted_at=recent
         )
 
-        # meme_stats for all ok memes (10001-10008, 10011)
+        # 1 recently sent but unreacted meme for user 10001.
+        await create_meme(conn, id=10012, meme_source_id=SOURCE_TELEGRAM)
+        await create_reaction(
+            conn, user_id=10001, meme_id=10012, reaction_id=None, sent_at=recent, reacted_at=None
+        )
+
+        # meme_stats for all ok memes (10001-10008, 10011-10012)
         stats_defaults = dict(
             nlikes=15,
             ndislikes=5,
@@ -72,7 +78,7 @@ async def base_data():
             invited_count=3,
             sec_to_react=6.0,
         )
-        for mid in list(range(10001, 10009)) + [10011]:
+        for mid in list(range(10001, 10009)) + [10011, 10012]:
             await create_meme_stats(conn, meme_id=mid, **stats_defaults)
 
         # meme_source_stats
@@ -137,6 +143,14 @@ async def test_excludes_reacted_memes(base_data, engine_name):
     results = await retriever.get_candidates(engine_name, USER_ID, limit=50)
     result_ids = {r["id"] for r in results}
     assert 10011 not in result_ids, f"{engine_name} returned already-reacted meme"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine_name", ALL_TESTABLE_ENGINES)
+async def test_excludes_recently_sent_unreacted_memes(base_data, engine_name):
+    results = await retriever.get_candidates(engine_name, USER_ID, limit=50)
+    result_ids = {r["id"] for r in results}
+    assert 10012 not in result_ids, f"{engine_name} returned recently sent unreacted meme"
 
 
 @pytest.mark.asyncio

--- a/tests/recommendations/test_goat_sql.py
+++ b/tests/recommendations/test_goat_sql.py
@@ -1,0 +1,26 @@
+import pytest
+
+from src.recommendations import candidates
+
+
+@pytest.mark.asyncio
+async def test_goat_recently_seen_filter_uses_sent_at(monkeypatch):
+    captured = {}
+
+    async def fake_fetch_one(query, params):
+        return {"pool_size": 0}
+
+    async def fake_fetch_all(query, params):
+        captured["query"] = str(query)
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(candidates, "fetch_one", fake_fetch_one)
+    monkeypatch.setattr(candidates, "fetch_all", fake_fetch_all)
+
+    await candidates.goat(user_id=10001, limit=5)
+
+    query = captured["query"]
+    assert "umr.sent_at > NOW() - INTERVAL '30 days'" in query
+    assert "umr.reacted_at > NOW() - INTERVAL '30 days'" not in query
+    assert captured["params"] == {"user_id": 10001, "limit": 5}


### PR DESCRIPTION
## Summary
- Fix GOAT per-user recency filtering to use `user_meme_reaction.sent_at` instead of `reacted_at`, preserving the existing 30-day window.
- This excludes recently sent-but-unreacted memes, which are currently eligible to repeat.
- Add a fast SQL guard test and extend the DB-backed engine contract fixture for sent-only rows.
- Update GOAT recency notes so future agents do not reintroduce the `reacted_at` version.

## Tests
- `ENVIRONMENT=TESTING /tmp/ff-backend-ffm1161-venv312/bin/python -m pytest -q tests/recommendations/test_goat_sql.py`
- `/tmp/ff-backend-ffm1161-venv312/bin/python -m py_compile src/recommendations/candidates.py tests/recommendations/test_engine_contracts.py tests/recommendations/test_goat_sql.py`
- `git diff --check`

Note: full `tests/recommendations/test_engine_contracts.py` is DB-backed and did not run in this local environment because Docker/Postgres is unavailable here; the new contract case is included for CI.