### PR TITLE
Bind GOAT recency window parameter

### DIFF
--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -326,7 +326,7 @@ async def goat(
                     SELECT 1 FROM user_meme_reaction umr
                     WHERE umr.user_id = :user_id
                       AND umr.meme_id = M.id
-                      AND umr.sent_at > NOW() - INTERVAL '{GOAT_RECENTLY_SENT_WINDOW_DAYS} days'
+                      AND umr.sent_at > NOW() - (:goat_recently_sent_window_days * INTERVAL '1 day')
                 )
         )
 
@@ -348,7 +348,15 @@ async def goat(
         ORDER BY SCORES.score DESC NULLS LAST
         LIMIT :limit
     """
-    return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))
+    return await fetch_all(
+        text(query),
+        _build_params(
+            user_id,
+            limit,
+            exclude_meme_ids,
+            goat_recently_sent_window_days=GOAT_RECENTLY_SENT_WINDOW_DAYS,
+        ),
+    )
 
 
 async def get_recently_liked(

--- a/tests/recommendations/test_goat_sql.py
+++ b/tests/recommendations/test_goat_sql.py
@@ -21,6 +21,11 @@ async def test_goat_recently_seen_filter_uses_sent_at(monkeypatch):
     await candidates.goat(user_id=10001, limit=5)
 
     query = captured["query"]
-    assert "umr.sent_at > NOW() - INTERVAL '30 days'" in query
-    assert "umr.reacted_at > NOW() - INTERVAL '30 days'" not in query
-    assert captured["params"] == {"user_id": 10001, "limit": 5}
+    assert "umr.sent_at > NOW() - (:goat_recently_sent_window_days * INTERVAL '1 day')" in query
+    assert "umr.sent_at > NOW() - INTERVAL '30 days'" not in query
+    assert "umr.reacted_at" not in query
+    assert captured["params"] == {
+        "user_id": 10001,
+        "limit": 5,
+        "goat_recently_sent_window_days": candidates.GOAT_RECENTLY_SENT_WINDOW_DAYS,
+    }


### PR DESCRIPTION
## Summary
- bind the GOAT recently-sent window as a SQL parameter instead of interpolating it into the query string
- update the SQL regression test to assert the bound parameter is passed

## Verification
- ENVIRONMENT=TESTING /tmp/ff-backend-ffm1161-venv312/bin/python -m pytest -q tests/recommendations/test_goat_sql.py
- /tmp/ff-backend-ffm1161-venv312/bin/python -m py_compile src/recommendations/candidates.py tests/recommendations/test_goat_sql.py
- git diff --check
- ruff check src/recommendations/candidates.py tests/recommendations/test_goat_sql.py
- ruff format --check src/recommendations/candidates.py tests/recommendations/test_goat_sql.py

Follow-up for Paperclip FFM-1601 / PR #316 review.