### PR TITLE
Fix: expand Describe Memes free model fallbacks

### DIFF
--- a/specs/describe-memes.md
+++ b/specs/describe-memes.md
@@ -45,6 +45,8 @@ Current production chain:
 ```python
 [
     "google/gemma-4-31b-it:free",
+    "nex-agi/nex-n2-pro:free",
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
     "google/gemma-4-26b-a4b-it:free",
 ]
 ```
@@ -52,6 +54,9 @@ Current production chain:
 Gemma 3 free vision model IDs are intentionally excluded: they are no longer
 listed by OpenRouter and create avoidable failed attempts under the daily free
 quota.
+
+`nvidia/nemotron-3.5-content-safety:free` is intentionally excluded because it
+is a guardrail classifier, not a general OCR/description model.
 
 Do not add paid fallbacks. A paid fallback can spend the account below zero, after which OpenRouter returns 402 for all models, including free models.
 

--- a/src/flows/storage/openrouter_vision.py
+++ b/src/flows/storage/openrouter_vision.py
@@ -23,13 +23,17 @@ OPENROUTER_FORBIDDEN_MODEL_COOLDOWN_SECONDS = 60 * 60 * 6
 # lifetime purchases for 1,000 req/day (vs 50/day without).
 # See specs/describe-memes.md for full OpenRouter constraints.
 #
-# Verified available on OpenRouter API as of 2026-05-17.
+# Verified available on OpenRouter API as of 2026-06-17.
 # Ordered by preference. Falls back to next model on 429/403/timeout/bad response.
 # Transient failures set Redis cooldowns so later memes/runs try other free models.
 VISION_MODELS = [
     "google/gemma-4-31b-it:free",  # 262k context, primary
+    "nex-agi/nex-n2-pro:free",  # 262k context, Qwen3.5 multimodal MoE
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",  # 256k context, multimodal
     "google/gemma-4-26b-a4b-it:free",  # 262k context, MoE variant
     # Gemma 3 free vision fallbacks are no longer listed by OpenRouter.
+    # nvidia/nemotron-3.5-content-safety:free is a guardrail classifier, not
+    # a general OCR/description model.
     # nvidia/nemotron-nano-12b-v2-vl:free removed — returns 504s and invalid
     # JSON/empty content (see specs/describe-memes.md).
 ]

--- a/tests/storage/test_describe_memes_models.py
+++ b/tests/storage/test_describe_memes_models.py
@@ -1,4 +1,4 @@
-from src.flows.storage.describe_memes import VISION_MODELS
+from src.flows.storage.openrouter_vision import VISION_MODELS
 
 
 def test_describe_memes_vision_models_are_free_only():
@@ -8,3 +8,11 @@ def test_describe_memes_vision_models_are_free_only():
 
 def test_describe_memes_does_not_use_removed_gemma_3_free_models():
     assert all("google/gemma-3-" not in model_id for model_id in VISION_MODELS)
+
+
+def test_describe_memes_has_multiple_general_vision_fallbacks():
+    assert "google/gemma-4-31b-it:free" in VISION_MODELS
+    assert "nex-agi/nex-n2-pro:free" in VISION_MODELS
+    assert "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free" in VISION_MODELS
+    assert "nvidia/nemotron-3.5-content-safety:free" not in VISION_MODELS
+    assert "nvidia/nemotron-nano-12b-v2-vl:free" not in VISION_MODELS


### PR DESCRIPTION
Fixes FFM-1614.\n\n## What changed\n- Expands the Describe Memes OpenRouter free vision fallback chain from two Gemma models to four general multimodal free models.\n- Keeps the hard :free model contract intact; no paid fallback and no openrouter/free router ID.\n- Documents why the Nemotron content-safety free model is excluded.\n- Moves the model-list test to import the OpenRouter client directly so it does not initialize the DB engine during collection.\n\n## Why\nRecent production runs completed with 0 described / 0 failed because Gemma 4 31B hit 429 cooldowns and Gemma 4 26B returned invalid JSON, leaving no other usable free model. The extra free multimodal fallbacks give the flow more provider capacity before it stops the batch for cooldown.\n\n## Verification\n- ruff check --fix src/ tests/\n- ruff format src/ tests/\n- pytest tests/storage/test_describe_memes_models.py tests/scripts/test_agent_doctor.py\n\n## Production caveat\nThe diagnostic also reported OpenRouter key auth limit=0 and limit_remaining=0. This PR improves free-model capacity, but production OCR throughput still requires the deployed OpenRouter key/account limit to allow requests. After merge/deploy, verify meme.ocr_result->>'calculated_at' advances and at least one new row has a populated description.