### PR TITLE
Fix E2E smoke URL buttons

### DIFF
--- a/scripts/e2e_smoke.py
+++ b/scripts/e2e_smoke.py
@@ -17,6 +17,7 @@ Usage:
     python scripts/e2e_smoke.py           # returning user flow
     python scripts/e2e_smoke.py --fresh   # reset state + onboarding flow
 """
+
 import argparse
 import asyncio
 import os
@@ -52,13 +53,18 @@ async def wait_for_response(client, entity, since_id, timeout=RESPONSE_TIMEOUT):
     return None
 
 
+def button_data(btn) -> bytes:
+    """Return callback data for callback buttons; URL buttons do not have data."""
+    return getattr(btn, "data", None) or b""
+
+
 def has_reaction_buttons(msg):
     """Check if message has inline keyboard with r: callback buttons."""
     if not msg.reply_markup:
         return False
     for row in msg.reply_markup.rows:
         for btn in row.buttons:
-            data = btn.data.decode() if btn.data else ""
+            data = button_data(btn).decode()
             if data.startswith("r:"):
                 return True
     return False
@@ -70,7 +76,7 @@ def find_like_button(msg):
         return None
     for row in msg.reply_markup.rows:
         for btn in row.buttons:
-            data = btn.data.decode() if btn.data else ""
+            data = button_data(btn).decode()
             if data.startswith("r:") and data.endswith(":1"):
                 return btn
     return None
@@ -113,7 +119,7 @@ async def test_like(client, bot, meme_msg):
         return "WARN", "No like button found on current meme, cannot test reaction flow"
 
     after_id = meme_msg.id
-    await meme_msg.click(data=like_btn.data)
+    await meme_msg.click(data=button_data(like_btn))
     next_msg = await wait_for_response(client, bot, after_id)
 
     if next_msg is None:
@@ -146,8 +152,9 @@ async def test_delete(client, bot):
     if msg.reply_markup:
         for row in msg.reply_markup.rows:
             for btn in row.buttons:
-                if btn.data and b"delete" in btn.data.lower():
-                    await msg.click(data=btn.data)
+                data = button_data(btn)
+                if data and b"delete" in data.lower():
+                    await msg.click(data=data)
                     confirm_msg = await wait_for_response(client, bot, msg.id)
                     confirm_text = (confirm_msg.text or "").lower() if confirm_msg else ""
                     if confirm_msg and ("ciao" in confirm_text or "start" in confirm_text):

--- a/tests/scripts/test_e2e_smoke.py
+++ b/tests/scripts/test_e2e_smoke.py
@@ -1,0 +1,51 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+spec = importlib.util.spec_from_file_location("e2e_smoke", SCRIPTS_DIR / "e2e_smoke.py")
+assert spec and spec.loader
+e2e_smoke = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(e2e_smoke)
+
+
+class UrlButton:
+    url = "https://t.me/share/url?url=https%3A%2F%2Ft.me%2Fffmemesbot"
+
+
+def _message_with_buttons(*buttons):
+    return SimpleNamespace(
+        reply_markup=SimpleNamespace(
+            rows=[SimpleNamespace(buttons=list(buttons))],
+        )
+    )
+
+
+def test_has_reaction_buttons_ignores_url_buttons_without_data():
+    msg = _message_with_buttons(
+        UrlButton(),
+        SimpleNamespace(data=b"r:123:1"),
+    )
+
+    assert e2e_smoke.has_reaction_buttons(msg) is True
+
+
+def test_find_like_button_skips_url_buttons_before_reaction_row():
+    like_button = SimpleNamespace(data=b"r:123:1")
+    msg = _message_with_buttons(
+        UrlButton(),
+        SimpleNamespace(data=b"r:123:2"),
+        like_button,
+    )
+
+    assert e2e_smoke.find_like_button(msg) is like_button
+
+
+def test_has_reaction_buttons_returns_false_for_url_only_keyboard():
+    msg = _message_with_buttons(UrlButton())
+
+    assert e2e_smoke.has_reaction_buttons(msg) is False


### PR DESCRIPTION
Fixes FFM-1629.

## What changed
- Added a safe helper for reading Telethon callback button data so URL inline buttons without `.data` are treated as non-callback buttons.
- Reused the helper in reaction-button detection, like-click selection, and `/delete` confirmation scanning.
- Added regression coverage for URL-only and URL-before-reaction keyboards.

## Root cause
The smoke script scanned every inline keyboard button using `btn.data`. Telethon URL buttons expose `.url` instead of `.data`, so a share URL button could crash the smoke before it reached the reaction buttons.

## Verification
- `pytest tests/scripts/test_e2e_smoke.py`
- `ruff check --fix scripts/e2e_smoke.py tests/scripts/test_e2e_smoke.py`
- `ruff format scripts/e2e_smoke.py tests/scripts/test_e2e_smoke.py`
- `ruff check --fix src/ tests/ && ruff format src/ tests/`