### PR TITLE
Fix FFM-1689: enable cold-start session gate by default

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -51,10 +51,10 @@ class Config(BaseSettings):
     DEEPSEEK_BASE_URL: str = "https://api.deepseek.com"
     CHAT_AGENT_ENABLED: bool = False
 
-    # FFM-1161: gate cold_start engines so they only serve genuinely-new users
-    # (nsessions <= 1). Dormant returners with nmemes_sent < 30 but multiple
-    # sessions fall through to the growing-user blender instead.
-    COLD_START_NSESSIONS_GATE_ENABLED: bool = False
+    # FFM-1161/FFM-1689: gate cold_start engines so they only serve genuinely-new
+    # users (nsessions <= 1). Dormant returners with nmemes_sent < 30 but
+    # multiple sessions fall through to the growing-user blender instead.
+    COLD_START_NSESSIONS_GATE_ENABLED: bool = True
 
     # Recommendation batch diagnostics are realtime operational data, not
     # durable product facts. Keep compact logs/spans always on and sample full

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -702,7 +702,7 @@ def _growing_retriever_class():
 
 @pytest.mark.asyncio
 async def test_gate_off_dormant_returner_still_uses_cold_start():
-    """Default (gate disabled): nsessions is ignored — cold_start still routes by nmemes_sent."""
+    """Emergency override off: nsessions is ignored and cold_start routes by nmemes_sent."""
     retriever = _growing_retriever_class()()
     with (
         _patch_user_info(nsessions=5, nmemes_sent=8),
@@ -712,6 +712,21 @@ async def test_gate_off_dormant_returner_still_uses_cold_start():
             TEST_USER_ID, 10, nmemes_sent=8, retriever=retriever
         )
     assert any(c["recommended_by"] == "cold_start_adapt" for c in candidates)
+
+
+@pytest.mark.asyncio
+async def test_gate_default_blocks_dormant_returner_from_cold_start():
+    """Default config blocks nsessions>=2 low-sent users from cold_start engines."""
+    retriever = _growing_retriever_class()()
+    with _patch_user_info(nsessions=3, nmemes_sent=8):
+        candidates = await generate_recommendations(
+            TEST_USER_ID, 10, nmemes_sent=8, retriever=retriever, random_seed=42
+        )
+
+    sources = {c["recommended_by"] for c in candidates}
+    assert "cold_start_explore" not in sources
+    assert "cold_start_adapt" not in sources
+    assert candidates[0]["recommended_by"] == "lr_smoothed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Enables `COLD_START_NSESSIONS_GATE_ENABLED` by default so low-sent dormant returners (`nsessions >= 2`) fall through to the growing-user blender instead of `cold_start_adapt` / `cold_start_explore`.
- Keeps the explicit off-switch behavior covered as an emergency override.
- Adds a default-config regression test proving dormant returners no longer reach cold-start engines.

## Root cause
FFM-1161 implemented the `nsessions <= 1` cold-start gate behind `COLD_START_NSESSIONS_GATE_ENABLED`, but the config default stayed `False`. If production does not explicitly set the env var, the gate is present but inert, matching the observed 7-day dormant-returner leak in FFM-1689.

## Guardrail decision
I did not add a new positions 6-10 `cold_start_adapt` quality guardrail in this PR. The current report says adapt weakness is spread across 21 sources and direct/meme-link cohorts, while existing code already applies a text-light content guard. A source/content quality rule needs a follow-up experiment or Analyst isolation; this PR fixes the obvious routing/config bug first.

## Verification
- `DATABASE_URL=postgresql+asyncpg://app:app@localhost:65432/app REDIS_URL=redis://localhost:36379/0 CORS_ORIGINS='["http://localhost"]' CORS_HEADERS='["*"]' TELEGRAM_BOT_TOKEN=test TELEGRAM_BOT_USERNAME=test_bot TELEGRAM_BOT_WEBHOOK_SECRET=test MEME_STORAGE_TELEGRAM_CHAT_ID=-1 UPLOADED_MEMES_REVIEW_CHAT_ID=-2 ADMIN_LOGS_CHAT_ID=-3 ENVIRONMENT=TESTING python3 -m pytest tests/recommendations/test_meme_queue.py tests/feed_turn/test_planner.py -q` → 57 passed
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`

Fixes FFM-1689.