### PR TITLE
Fix: harden QA monitoring smoke docs

### DIFF
--- a/agents/qa-engineer/AGENTS.md
+++ b/agents/qa-engineer/AGENTS.md
@@ -25,7 +25,7 @@ You are running without a human operator. NEVER call `AskUserQuestion`. When ski
 
 ## Log Sources
 
-1. **Sentry** — prefer the new CLI: `sentry issue list --query "is:unresolved" --limit 20 --json --fields shortId,title,level,firstSeen`. If only `sentry-cli` exists, use `sentry-cli issues list --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --status unresolved --max-rows 20`. Use `sentry issue view <id>` or Sentry REST API for details.
+1. **Sentry** — prefer the installed CLI: `sentry issues list --query "is:unresolved" --max-rows 20`. If only `sentry-cli` exists, use `sentry-cli issues list --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --status unresolved --max-rows 20`. Use Sentry REST API for details when the CLI list output is insufficient.
 2. **Coolify app logs** — use `mcp__coolify__application_logs` for app
    `v0kkssccwoswgwwscws4kscc`. Use `mcp__coolify__get_application` for app
    lookup/status.
@@ -120,7 +120,7 @@ even when the run is partial or errored.
 
 When reviewing after a deploy, whether from scheduled heartbeat, Sentry trigger, or handoff:
 1. **Run `/canary`** — MANDATORY. Handles console errors, performance regressions, page failures, baseline comparison.
-2. **Sentry scan** — run `sentry issue list --query "is:unresolved" --limit 20 --json --fields shortId,title,level,firstSeen`; if only legacy `sentry-cli` exists, run `sentry-cli issues list --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --status unresolved --max-rows 20`. Cross-reference against the deploy timestamp.
+2. **Sentry scan** — run `sentry issues list --query "is:unresolved" --max-rows 20`; if only legacy `sentry-cli` exists, run `sentry-cli issues list --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --status unresolved --max-rows 20`. Cross-reference against the deploy timestamp.
 3. Run E2E smoke tests if credentials are configured (see below).
 4. Report results to **CTO** — GREEN (all clear) or RED (issues found).
 

--- a/docs/paperclip-ops-runbook.md
+++ b/docs/paperclip-ops-runbook.md
@@ -403,7 +403,11 @@ Agents need `PATH=/paperclip/bin:$PATH` to find them.
 | `codex` | `/paperclip/bin/codex` | `npm install --prefix /paperclip/.npm-global @openai/codex@latest && ln -sf /paperclip/.npm-global/node_modules/.bin/codex /paperclip/bin/codex` |
 | `sentry` / `sentry-cli` | `/paperclip/bin/sentry` or system path | `npm install --prefix /paperclip/.npm-global sentry @sentry/cli && ln -sf /paperclip/.npm-global/node_modules/.bin/sentry /paperclip/bin/sentry && ln -sf /paperclip/.npm-global/node_modules/.bin/sentry-cli /paperclip/bin/sentry-cli` |
 
-`sentry` and legacy `sentry-cli` use different issue-list syntax. Prefer `sentry issue list --query "is:unresolved" --limit 20`; use `sentry-cli issues list --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --status unresolved --max-rows 20` only as a legacy fallback. QA and CTO receive `SENTRY_ORG=ffmemes` and `SENTRY_PROJECT=ff-backend` from the manifest.
+`sentry` and legacy `sentry-cli` can expose different issue-list flags across
+installed versions. Prefer `sentry issues list --query "is:unresolved" --max-rows 20`;
+use `sentry-cli issues list --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --status unresolved --max-rows 20`
+only as a legacy fallback. QA and CTO receive `SENTRY_ORG=ffmemes` and
+`SENTRY_PROJECT=ff-backend` from the manifest.
 
 Post-deployment command (runs after each Coolify deploy) is configured to reinstall these,
 but runs as non-root `node` user — see Coolify Quirks below.

--- a/tests/scripts/test_e2e_smoke.py
+++ b/tests/scripts/test_e2e_smoke.py
@@ -1,51 +1,49 @@
-import importlib.util
-import sys
-from pathlib import Path
-from types import SimpleNamespace
-
-SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
-if str(SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPTS_DIR))
-
-spec = importlib.util.spec_from_file_location("e2e_smoke", SCRIPTS_DIR / "e2e_smoke.py")
-assert spec and spec.loader
-e2e_smoke = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(e2e_smoke)
+from scripts.e2e_smoke import button_data, find_like_button, has_reaction_buttons
 
 
-class UrlButton:
+class _UrlButton:
     url = "https://t.me/share/url?url=https%3A%2F%2Ft.me%2Fffmemesbot"
 
 
-def _message_with_buttons(*buttons):
-    return SimpleNamespace(
-        reply_markup=SimpleNamespace(
-            rows=[SimpleNamespace(buttons=list(buttons))],
-        )
-    )
+class _CallbackButton:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
 
 
-def test_has_reaction_buttons_ignores_url_buttons_without_data():
-    msg = _message_with_buttons(
-        UrlButton(),
-        SimpleNamespace(data=b"r:123:1"),
-    )
-
-    assert e2e_smoke.has_reaction_buttons(msg) is True
+class _Row:
+    def __init__(self, buttons: list[object]) -> None:
+        self.buttons = buttons
 
 
-def test_find_like_button_skips_url_buttons_before_reaction_row():
-    like_button = SimpleNamespace(data=b"r:123:1")
-    msg = _message_with_buttons(
-        UrlButton(),
-        SimpleNamespace(data=b"r:123:2"),
-        like_button,
-    )
-
-    assert e2e_smoke.find_like_button(msg) is like_button
+class _ReplyMarkup:
+    def __init__(self, rows: list[_Row]) -> None:
+        self.rows = rows
 
 
-def test_has_reaction_buttons_returns_false_for_url_only_keyboard():
-    msg = _message_with_buttons(UrlButton())
+class _Message:
+    def __init__(self, buttons: list[object]) -> None:
+        self.reply_markup = _ReplyMarkup([_Row(buttons)])
 
-    assert e2e_smoke.has_reaction_buttons(msg) is False
+
+def test_button_data_ignores_url_buttons_without_data() -> None:
+    assert button_data(_UrlButton()) == b""
+
+
+def test_reaction_button_detection_skips_url_buttons() -> None:
+    msg = _Message([_UrlButton(), _CallbackButton(b"r:123:1")])
+
+    assert has_reaction_buttons(msg) is True
+
+
+def test_find_like_button_skips_url_buttons_before_reaction_row() -> None:
+    like_button = _CallbackButton(b"r:123:1")
+    msg = _Message([_UrlButton(), _CallbackButton(b"r:123:2"), like_button])
+
+    assert find_like_button(msg) is like_button
+
+
+def test_reaction_button_detection_handles_url_only_markup() -> None:
+    msg = _Message([_UrlButton()])
+
+    assert has_reaction_buttons(msg) is False
+    assert find_like_button(msg) is None


### PR DESCRIPTION
Refs FFM-1708.

## What changed
- Correct QA/runbook Sentry scan commands to match the installed `sentry issues list` CLI syntax.
- Keep the existing e2e smoke URL-button guard covered with focused regression tests, including URL-only markup and mixed URL/callback keyboards.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `git diff --check`
- `python3 -m pytest tests/scripts/test_e2e_smoke.py`

## Remaining operational action
- `sentry issues list --query "is:unresolved" --max-rows 3` still reaches Sentry but returns `401 Invalid token` in the CTO runtime too. The Paperclip secret metadata endpoint returns `403 Board access required` for this run, so `SENTRY_AUTH_TOKEN` must be rotated by an owner with Paperclip/Sentry secret access before QA scans are fully restored.