### PR TITLE
Disable inline share canary by default

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -33,7 +33,7 @@ class Config(BaseSettings):
     TELEGRAM_BOT_USERNAME: str | None = None
     TELEGRAM_BOT_WEBHOOK_SECRET: str | None = None
     TELEGRAM_INLINE_SHARE_ENABLED: bool = True
-    TELEGRAM_INLINE_SHARE_CANARY_PERCENT: int = 20
+    TELEGRAM_INLINE_SHARE_CANARY_PERCENT: int = 0
     MEME_STORAGE_TELEGRAM_CHAT_ID: str | None = None
     UPLOADED_MEMES_REVIEW_CHAT_ID: str | None = None
     ADMIN_LOGS_CHAT_ID: str | None = None


### PR DESCRIPTION
## Summary

- Set `TELEGRAM_INLINE_SHARE_CANARY_PERCENT` default to `0` so future deployments do not expose new exact-meme inline share assignments unless explicitly re-enabled.
- Kept existing assignment/history logic intact; the runtime guard already returns `url_share` when the canary percent is zero.

## Production action

- Added `TELEGRAM_INLINE_SHARE_CANARY_PERCENT=0` to the Coolify `ffmemes-backend` application env.
- Queued and completed a production redeploy for commit `3c3ce301` so the running app reloads the env setting.

## Verification

- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `DATABASE_URL='postgresql+asyncpg://postgres:postgres@localhost/postgres' REDIS_URL='redis://localhost:6379/0' CORS_ORIGINS='[]' CORS_HEADERS='[]' TELEGRAM_BOT_USERNAME='ffmemesbot' python3 -m pytest tests/tgbot/test_sharing.py -q`

Fixes FFM-1745.