### PR TITLE
fix: reduce stats workload

### DIFF
--- a/alembic/versions/2026-06-26_reaction_stats_perf_indexes.py
+++ b/alembic/versions/2026-06-26_reaction_stats_perf_indexes.py
@@ -1,0 +1,55 @@
+"""Add reaction stats performance indexes
+
+Revision ID: f2a5c8e1b4d7
+Revises: c1e2f3a4b5d6
+Create Date: 2026-06-26 16:10:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f2a5c8e1b4d7"
+down_revision = "c1e2f3a4b5d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_user_meme_reaction_liked_sent_at_meme_id "
+            "ON user_meme_reaction (sent_at DESC, meme_id) "
+            "WHERE reaction_id = 1"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_user_meme_reaction_sent_at_meme_id_user_id "
+            "ON user_meme_reaction (sent_at, meme_id, user_id) "
+            "INCLUDE (reaction_id, reacted_at)"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_user_meme_reaction_meme_id_sent_at_user_id "
+            "ON user_meme_reaction (meme_id, sent_at, user_id) "
+            "INCLUDE (reaction_id, reacted_at)"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_user_meme_reaction_user_id_reacted_at "
+            "ON user_meme_reaction (user_id, reacted_at) "
+            "INCLUDE (reaction_id, meme_id, sent_at)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_user_meme_reaction_user_id_reacted_at")
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_user_meme_reaction_meme_id_sent_at_user_id"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_user_meme_reaction_sent_at_meme_id_user_id"
+        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_user_meme_reaction_liked_sent_at_meme_id")

--- a/gunicorn/gunicorn_conf.py
+++ b/gunicorn/gunicorn_conf.py
@@ -10,7 +10,7 @@ bind_env = os.getenv("BIND", None)
 use_bind = bind_env if bind_env else f"{host}:{port}"
 
 workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
-max_workers_str = os.getenv("MAX_WORKERS")
+max_workers_str = os.getenv("MAX_WORKERS", "4")
 web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
 
 cores = multiprocessing.cpu_count()

--- a/logging_production.ini
+++ b/logging_production.ini
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,gunicorn.access,gunicorn.error,uvicorn
+keys=root,gunicorn.access,gunicorn.error,uvicorn,httpx,httpcore,telegram
 
 [handlers]
 keys=console
@@ -31,6 +31,27 @@ propagate=0
 handlers=console
 formatter=json
 qualname=uvicorn
+
+[logger_httpx]
+level=WARNING
+handlers=console
+formatter=json
+qualname=httpx
+propagate=0
+
+[logger_httpcore]
+level=WARNING
+handlers=console
+formatter=json
+qualname=httpcore
+propagate=0
+
+[logger_telegram]
+level=WARNING
+handlers=console
+formatter=json
+qualname=telegram
+propagate=0
 
 [handler_console]
 class=logging.StreamHandler

--- a/scripts/serve_flows.py
+++ b/scripts/serve_flows.py
@@ -69,10 +69,10 @@ MSK = "Europe/Moscow"
 
 if __name__ == "__main__":
     serve(
-        # ── Stats (every 15 min, staggered) ──
+        # ── Stats ──
         calculate_user_stats.to_deployment(
             name="Calculate user_stats",
-            schedules=[CronSchedule(cron="0,15,30,45 * * * *", timezone=LON)],
+            schedules=[CronSchedule(cron="0,30 * * * *", timezone=LON)],
         ),
         calculate_meme_stats.to_deployment(
             name="Calculate meme_stats",
@@ -84,13 +84,13 @@ if __name__ == "__main__":
         ),
         calculate_meme_source_stats.to_deployment(
             name="Calculate meme_source_stats",
-            schedules=[CronSchedule(cron="5,20,35,50 * * * *", timezone=LON)],
+            schedules=[CronSchedule(cron="10 * * * *", timezone=LON)],
         ),
         calculate_user_meme_source_stats.to_deployment(
             name="Calculate user_meme_source_stats",
             schedules=[
                 CronSchedule(
-                    cron="12,27,42,57 * * * *",
+                    cron="40 * * * *",
                     timezone=LON,
                 )
             ],

--- a/src/flows/events.py
+++ b/src/flows/events.py
@@ -6,11 +6,17 @@ never crashes the flow itself (critical gap from eng review).
 
 import logging
 
+from src.config import settings
+
 logger = logging.getLogger(__name__)
 
 
 def safe_emit(event: str, resource_id: str, payload: dict | None = None) -> None:
     """Emit a Prefect event, silently catching errors."""
+    if not settings.PREFECT_API_URL:
+        logger.debug("Skipping Prefect event %s: PREFECT_API_URL is not configured", event)
+        return
+
     try:
         from prefect.events import emit_event
 

--- a/src/stats/meme.py
+++ b/src/stats/meme.py
@@ -83,7 +83,48 @@ async def _execute_meme_reactions_and_engagement(
     Both metrics are computed from one pass over user_meme_reaction.
     """
 
-    query = """
+    if meme_ids:
+        recent_meme_ids_cte = "SELECT NULL::integer AS meme_id WHERE FALSE"
+    else:
+        recent_meme_ids_cte = """
+            SELECT meme_id
+            FROM user_meme_reaction
+            WHERE sent_at > NOW() - :lookback_hours * INTERVAL '1 hour'
+
+            UNION
+
+            SELECT meme_id
+            FROM user_meme_reaction
+            WHERE reacted_at > NOW() - :lookback_hours * INTERVAL '1 hour'
+        """
+
+    if include_user_history:
+        affected_users_cte = """
+        AFFECTED_USERS AS (
+            SELECT DISTINCT R.user_id
+            FROM user_meme_reaction R
+            INNER JOIN TARGET_MEME_IDS T
+                ON T.meme_id = R.meme_id
+        ),
+        """
+        base_reactions_from = """
+            FROM user_meme_reaction R
+            INNER JOIN AFFECTED_USERS AU
+                ON AU.user_id = R.user_id
+            INNER JOIN meme
+                ON R.meme_id = meme.id
+        """
+    else:
+        affected_users_cte = ""
+        base_reactions_from = """
+            FROM user_meme_reaction R
+            INNER JOIN TARGET_MEME_IDS T
+                ON T.meme_id = R.meme_id
+            INNER JOIN meme
+                ON R.meme_id = meme.id
+        """
+
+    query = f"""
         INSERT INTO meme_stats (
             meme_id, nlikes, ndislikes, nmemes_sent,
             age_days, sec_to_react, updated_at,
@@ -91,9 +132,7 @@ async def _execute_meme_reactions_and_engagement(
         )
 
         WITH RECENT_MEME_IDS AS (
-            SELECT DISTINCT meme_id
-            FROM user_meme_reaction
-            WHERE COALESCE(reacted_at, sent_at) > NOW() - :lookback_hours * INTERVAL '1 hour'
+            {recent_meme_ids_cte}
         ),
 
         FORCED_MEME_IDS AS (
@@ -108,12 +147,7 @@ async def _execute_meme_reactions_and_engagement(
             UNION
             SELECT meme_id FROM FORCED_MEME_IDS
         ),
-
-        AFFECTED_USERS AS (
-            SELECT DISTINCT user_id
-            FROM user_meme_reaction
-            WHERE meme_id IN (SELECT meme_id FROM TARGET_MEME_IDS)
-        ),
+        {affected_users_cte}
 
         BASE_REACTIONS AS (
             SELECT
@@ -125,15 +159,7 @@ async def _execute_meme_reactions_and_engagement(
                 EXTRACT(EPOCH FROM R.reacted_at - R.sent_at) AS sec_to_react,
                 MAX(CASE WHEN R.reaction_id IS NOT NULL THEN R.sent_at END)
                     OVER (PARTITION BY R.user_id) AS user_last_reaction_sent_at
-            FROM user_meme_reaction R
-            JOIN meme ON R.meme_id = meme.id
-            WHERE (
-                (:include_user_history AND R.user_id IN (SELECT user_id FROM AFFECTED_USERS))
-                OR (
-                    NOT :include_user_history
-                    AND R.meme_id IN (SELECT meme_id FROM TARGET_MEME_IDS)
-                )
-            )
+            {base_reactions_from}
         ),
 
         WITH_USER_AVGS AS (
@@ -212,8 +238,9 @@ async def _execute_meme_reactions_and_engagement(
                 ), 99999) AS sec_to_react
                 , NOW() AS updated_at
             FROM meme M
+            INNER JOIN TARGET_MEME_IDS T
+                ON T.meme_id = M.id
             LEFT JOIN user_meme_reaction E ON E.meme_id = M.id
-            WHERE M.id IN (SELECT meme_id FROM TARGET_MEME_IDS)
             GROUP BY 1
         )
 

--- a/src/storage/parsers/vk.py
+++ b/src/storage/parsers/vk.py
@@ -25,13 +25,14 @@ class VkGroupScraper(Scraper):
         self.source_link = source_link
         self.vk_source_link = None
         self.VK_TOKEN = settings.VK_TOKEN
-        self.base_url = "https://api.vk.com/method/wall.get?access_token={vk_token}&v={v}&domain={domain}&count=100&offset={offset}"  # noqa: E501
+        self.base_url = "https://api.vk.com/method/wall.get?access_token={vk_token}&v={v}&domain={domain}&count={count}&offset={offset}"  # noqa: E501
 
     async def get_items(self, num_of_posts: Optional[int] = None) -> list[VkGroupPostParsingResult]:
         logger.info(f"Going to parse VK: {self.source_link}")
         vk_source = _extract_username_from_url(self.source_link)
         self.vk_source_link = "https://vk.com/%s" % vk_source
-        r = await self._get_vk_wall(vk_source)
+        page_size = min(num_of_posts or 100, 100)
+        r = await self._get_vk_wall(vk_source, count=page_size)
         if r is None or "response" not in r:
             logger.error(f"Can't parse vk, got response: {r}")
             return []
@@ -41,29 +42,42 @@ class VkGroupScraper(Scraper):
         if num_of_posts:
             posts_count = num_of_posts
 
-        offset = 100
+        offset = len(posts)
         while posts_count > len(posts):
-            r = await self._get_vk_wall(vk_source, offset)
+            r = await self._get_vk_wall(vk_source, offset, count=min(posts_count - len(posts), 100))
             if r is None:
                 break
             posts.extend(r["response"]["items"])
-            offset += 100
+            offset += len(r["response"]["items"])
             await asyncio.sleep(5)  # to not to DDOS VK
+            if not r["response"]["items"]:
+                break
 
         results = []
-        for post in posts:
+        for post in posts[:posts_count]:
             post_details = await self.get_post_details(post)
             if post_details:
                 results.append(post_details)
 
         return results
 
-    async def _get_vk_wall(self, vk_source: str, offset: int = 0) -> Optional[dict]:
+    async def _get_vk_wall(
+        self,
+        vk_source: str,
+        offset: int = 0,
+        count: int = 100,
+    ) -> Optional[dict]:
         if self.VK_TOKEN is None:
             logger.error("Can't parse vk without VK_TOKEN")
             return None
         req = await self._request(
-            self.base_url.format(vk_token=self.VK_TOKEN, v="5.92", domain=vk_source, offset=offset)
+            self.base_url.format(
+                vk_token=self.VK_TOKEN,
+                v="5.92",
+                domain=vk_source,
+                count=count,
+                offset=offset,
+            )
         )
         if req.status_code != 200:
             raise ScraperException(f"Got status code {req.status_code}")

--- a/src/tgbot/handlers/upload/moderation.py
+++ b/src/tgbot/handlers/upload/moderation.py
@@ -25,7 +25,6 @@ from src.observability.sentry import (
 )
 from src.recommendations.service import create_user_meme_reaction
 from src.stats.meme import calculate_meme_reactions_and_engagement
-from src.stats.meme_source import calculate_meme_source_stats
 from src.storage.constants import MemeStatus, MemeType
 from src.storage.deduplication import (
     find_duplicate_by_ocr_text,
@@ -506,8 +505,7 @@ async def handle_uploaded_meme_review_button(
             reacted_at=datetime.utcnow(),
         )
 
-        asyncio.create_task(calculate_meme_source_stats())
-        asyncio.create_task(calculate_meme_reactions_and_engagement())
+        asyncio.create_task(calculate_meme_reactions_and_engagement(meme_ids=[meme["id"]]))
 
         await pay_if_not_paid_with_alert(
             context.bot,


### PR DESCRIPTION
## Summary
- add targeted indexes for the high-cost user_meme_reaction stats paths
- make meme stats use indexable recent-reaction predicates and avoid recent scans for targeted meme recalculation
- reduce scheduled stats pressure and stop upload approvals from launching full source/stats recomputes
- cap default Gunicorn workers and skip Prefect event emission when app workers have no PREFECT_API_URL
- limit VK pagination to the requested post count

## Validation
- ruff check touched files
- ruff format --check touched files
- py_compile touched files
- pytest tests/stats/test_meme.py tests/stats/test_engagement_score.py tests/stats/test_batch_stats.py -q
- pytest tests/tgbot/test_upload_moderation.py tests/tgbot/test_upload_observability.py -q