### PR TITLE
Fix: suppress handled chat agent max-turn Sentry events

### DIFF
--- a/src/observability/sentry.py
+++ b/src/observability/sentry.py
@@ -64,6 +64,33 @@ def before_send_log(log: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any
 
 
 @contextmanager
+def chat_agent_scope(
+    *,
+    chat_id: int,
+    user_id: int,
+    reply_to_message_id: int | None = None,
+    trigger_type: str | None = None,
+) -> Iterator[None]:
+    """Attach chat-agent context to Sentry events produced while running the agent."""
+    with sentry_sdk.new_scope() as scope:
+        scope.set_tag("ff.module", "chat_agent")
+        if trigger_type:
+            scope.set_tag("chat_agent.trigger_type", trigger_type)
+        scope.set_context(
+            "chat_agent",
+            _clean_context(
+                {
+                    "chat_id": chat_id,
+                    "user_id": user_id,
+                    "reply_to_message_id": reply_to_message_id,
+                    "trigger_type": trigger_type,
+                }
+            ),
+        )
+        yield
+
+
+@contextmanager
 def telegram_update_scope(update: Any) -> Iterator[None]:
     """Attach Telegram update context to Sentry events produced by one webhook."""
     with sentry_sdk.new_scope() as scope:
@@ -372,8 +399,48 @@ def _is_expected_chat_agent_max_turns_event(event: dict[str, Any]) -> bool:
             return True
         if _exception_has_chat_agent_frame(exception_value):
             return True
+        if _event_has_chat_agent_context(event):
+            return True
+        if _event_has_chat_agent_webhook_context(event, exception_value):
+            return True
 
     return False
+
+
+def _event_has_chat_agent_context(event: dict[str, Any]) -> bool:
+    tags = event.get("tags")
+    if isinstance(tags, dict):
+        if tags.get("ff.module") == "chat_agent":
+            return True
+        if tags.get("chat_agent.trigger_type"):
+            return True
+
+    contexts = event.get("contexts")
+    if isinstance(contexts, dict) and isinstance(contexts.get("chat_agent"), dict):
+        return True
+
+    return False
+
+
+def _event_has_chat_agent_webhook_context(
+    event: dict[str, Any],
+    exception_value: dict[str, Any],
+) -> bool:
+    mechanism = exception_value.get("mechanism")
+    if not isinstance(mechanism, dict) or mechanism.get("type") != "openai_agents":
+        return False
+
+    if event.get("transaction") != "/tgbot/webhook":
+        return False
+
+    tags = event.get("tags")
+    if not isinstance(tags, dict):
+        return False
+
+    return (
+        tags.get("telegram.update_type") == "message"
+        and tags.get("telegram.chat_type") == "supergroup"
+    )
 
 
 def _exception_has_chat_agent_frame(exception_value: dict[str, Any]) -> bool:

--- a/src/tgbot/handlers/chat/agent/runner.py
+++ b/src/tgbot/handlers/chat/agent/runner.py
@@ -10,6 +10,7 @@ from sqlalchemy import text
 
 from src.config import settings
 from src.database import execute
+from src.observability.sentry import chat_agent_scope
 from src.tgbot.handlers.chat.agent.prompts import SYSTEM_PROMPT
 from src.tgbot.handlers.chat.agent.tools import get_tools
 from src.tgbot.handlers.chat.ai import _messages_to_text
@@ -96,12 +97,18 @@ async def run_chat_agent(
     start_time = time.time()
 
     try:
-        result = await Runner.run(
-            starting_agent=agent,
-            input=agent_input,
-            context=ctx,
-            max_turns=MAX_TURNS,
-        )
+        with chat_agent_scope(
+            chat_id=chat_id,
+            user_id=user_id,
+            reply_to_message_id=reply_to_message_id,
+            trigger_type=trigger_type,
+        ):
+            result = await Runner.run(
+                starting_agent=agent,
+                input=agent_input,
+                context=ctx,
+                max_turns=MAX_TURNS,
+            )
     except MaxTurnsExceeded as e:
         logger.warning(
             "Chat agent hit max turns in chat %s after %s turns: %s",

--- a/tests/test_sentry_observability.py
+++ b/tests/test_sentry_observability.py
@@ -143,6 +143,55 @@ def test_before_send_drops_handled_chat_agent_max_turns_event():
     assert before_send(event, {}) is None
 
 
+def test_before_send_drops_scoped_chat_agent_max_turns_event_without_logger():
+    event = {
+        "logger": None,
+        "tags": {
+            "ff.module": "chat_agent",
+        },
+        "contexts": {
+            "chat_agent": {
+                "chat_id": -1002391808824,
+                "user_id": 968203036,
+                "reply_to_message_id": 640447,
+                "trigger_type": "mention",
+            }
+        },
+        "exception": {
+            "values": [
+                {
+                    "type": "MaxTurnsExceeded",
+                    "module": "agents.exceptions",
+                }
+            ]
+        },
+    }
+
+    assert before_send(event, {}) is None
+
+
+def test_before_send_drops_chat_agent_webhook_max_turns_event_without_logger():
+    event = {
+        "logger": None,
+        "transaction": "/tgbot/webhook",
+        "tags": {
+            "telegram.chat_type": "supergroup",
+            "telegram.update_type": "message",
+        },
+        "exception": {
+            "values": [
+                {
+                    "type": "MaxTurnsExceeded",
+                    "module": "agents.exceptions",
+                    "mechanism": {"type": "openai_agents", "handled": False},
+                }
+            ]
+        },
+    }
+
+    assert before_send(event, {}) is None
+
+
 def test_before_send_keeps_unexpected_max_turns_events():
     event = {
         "exception": {


### PR DESCRIPTION
Fixes FFM-1764.

## Summary
- Add chat-agent Sentry scope around the OpenAI Agents runner call so agent events carry explicit chat-agent context.
- Drop expected `agents.exceptions.MaxTurnsExceeded` events from the chat-agent path even when Sentry reports them with `logger=null` / `mechanism=openai_agents`.
- Add regression coverage for both scoped chat-agent events and the production webhook event shape.

## Verification
- `python3 -m pytest tests/test_sentry_observability.py -q`
- `ruff check --fix src/ tests/ && ruff format src/ tests/`

## Notes
- Host Python lacks the app `agents.exceptions` dependency and Docker is unavailable here, so `tests/tgbot/test_chat_agent_runner.py` could not be collected locally. CI should run it in the app dependency environment.