### PR TITLE
Fix dormant returner cold-start routing

### DIFF
--- a/src/feed_turn/planner.py
+++ b/src/feed_turn/planner.py
@@ -109,19 +109,26 @@ def plan_candidate_selection(nmemes_sent: int) -> CandidateSelectionPlan:
     )
 
 
+COLD_START_MAX_ACCOUNT_AGE_DAYS = 30
+
+
 def plan_candidate_selection_for_user(
     nmemes_sent: int,
     nsessions: int | None,
     cold_start_nsessions_gate_enabled: bool,
     limit: int | None = None,
+    account_age_days: int | None = None,
 ) -> CandidateSelectionPlan:
     """Plan candidate selection with the production cold-start session gate.
 
     ``limit`` is accepted for batch-pipeline call sites that already carry it;
-    candidate selection currently depends only on maturity and session count.
+    candidate selection depends on maturity, session count, and account age.
     """
     _ = limit
-    if cold_start_nsessions_gate_enabled and (nsessions or 0) > 1 and nmemes_sent < 30:
+    dormant_returner = (nsessions or 0) > 1 or (
+        account_age_days is not None and account_age_days > COLD_START_MAX_ACCOUNT_AGE_DAYS
+    )
+    if cold_start_nsessions_gate_enabled and dormant_returner and nmemes_sent < 30:
         return plan_candidate_selection(30)
 
     return plan_candidate_selection(nmemes_sent)

--- a/src/feed_turn/planner.py
+++ b/src/feed_turn/planner.py
@@ -109,15 +109,12 @@ def plan_candidate_selection(nmemes_sent: int) -> CandidateSelectionPlan:
     )
 
 
-COLD_START_MAX_ACCOUNT_AGE_DAYS = 30
-
-
 def plan_candidate_selection_for_user(
     nmemes_sent: int,
     nsessions: int | None,
     cold_start_nsessions_gate_enabled: bool,
     limit: int | None = None,
-    account_age_days: int | None = None,
+    cold_start_account_too_old: bool = False,
 ) -> CandidateSelectionPlan:
     """Plan candidate selection with the production cold-start session gate.
 
@@ -125,9 +122,7 @@ def plan_candidate_selection_for_user(
     candidate selection depends on maturity, session count, and account age.
     """
     _ = limit
-    dormant_returner = (nsessions or 0) > 1 or (
-        account_age_days is not None and account_age_days > COLD_START_MAX_ACCOUNT_AGE_DAYS
-    )
+    dormant_returner = (nsessions or 0) > 1 or cold_start_account_too_old
     if cold_start_nsessions_gate_enabled and dormant_returner and nmemes_sent < 30:
         return plan_candidate_selection(30)
 

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -145,9 +145,10 @@ async def generate_recommendations(
         nmemes_sent = user_info["nmemes_sent"]
 
     # FFM-1161: nsessions gate. cold_start engines were designed for first-session
-    # users; the cached user_info may predate the gate (1h TTL) — treat missing as 0
-    # so we don't accidentally route dormant returners into cold_start.
+    # users. FFM-1819 also gates old low-sent accounts because nsessions is derived
+    # from send history and can remain <=1 until a dormant returner reacts again.
     nsessions = user_info.get("nsessions") or 0
+    account_age_days = user_info.get("account_age_days")
 
     queue_key = redis.get_meme_queue_key(user_id)
 
@@ -183,6 +184,7 @@ async def generate_recommendations(
             limit=limit,
             nmemes_sent=nmemes_sent,
             nsessions=nsessions,
+            account_age_days=account_age_days,
             user_type=None if user_type is None else user_type.value,
             meme_ids_in_queue=meme_ids_in_queue,
             random_seed=random_seed,

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -149,6 +149,7 @@ async def generate_recommendations(
     # from send history and can remain <=1 until a dormant returner reacts again.
     nsessions = user_info.get("nsessions") or 0
     account_age_days = user_info.get("account_age_days")
+    cold_start_account_too_old = bool(user_info.get("cold_start_account_too_old"))
 
     queue_key = redis.get_meme_queue_key(user_id)
 
@@ -185,6 +186,7 @@ async def generate_recommendations(
             nmemes_sent=nmemes_sent,
             nsessions=nsessions,
             account_age_days=account_age_days,
+            cold_start_account_too_old=cold_start_account_too_old,
             user_type=None if user_type is None else user_type.value,
             meme_ids_in_queue=meme_ids_in_queue,
             random_seed=random_seed,

--- a/src/recommendations/pipeline.py
+++ b/src/recommendations/pipeline.py
@@ -70,6 +70,7 @@ class RecommendationBatchRequest:
     limit: int
     nmemes_sent: int
     nsessions: int = 0
+    account_age_days: int | None = None
     user_type: str | None = None
     meme_ids_in_queue: Sequence[int] = field(default_factory=tuple)
     random_seed: int | None = None
@@ -131,6 +132,7 @@ class RecommendationBatchDiagnostics:
     limit: int
     nmemes_sent: int
     nsessions: int
+    account_age_days: int | None
     user_type: str | None
     queue_len_before: int
     exclude_count: int
@@ -176,6 +178,7 @@ class RecommendationBatchDiagnostics:
             "limit": self.limit,
             "nmemes_sent": self.nmemes_sent,
             "nsessions": self.nsessions,
+            "account_age_days": self.account_age_days,
             "cold_start_nsessions_gate_enabled": self.cold_start_nsessions_gate_enabled,
             "queue_len_before": self.queue_len_before,
             "exclude_count": self.exclude_count,
@@ -283,6 +286,7 @@ class RecommendationBatchPipeline:
             limit=request.limit,
             nmemes_sent=request.nmemes_sent,
             nsessions=request.nsessions,
+            account_age_days=request.account_age_days,
             user_type=request.user_type,
             queue_len_before=len(request.meme_ids_in_queue),
             exclude_count=len(request.meme_ids_in_queue),
@@ -392,6 +396,7 @@ class RecommendationBatchPipeline:
             nsessions=request.nsessions,
             cold_start_nsessions_gate_enabled=request.cold_start_nsessions_gate_enabled,
             limit=limit,
+            account_age_days=request.account_age_days,
         )
         diagnostics.maturity_stage = plan.maturity_stage
 
@@ -592,6 +597,7 @@ class RecommendationBatchPipeline:
                         limit=limit,
                         nmemes_sent=diagnostics.nmemes_sent,
                         nsessions=diagnostics.nsessions,
+                        account_age_days=diagnostics.account_age_days,
                         user_type=diagnostics.user_type,
                         meme_ids_in_queue=exclude_ids,
                     ),

--- a/src/recommendations/pipeline.py
+++ b/src/recommendations/pipeline.py
@@ -71,6 +71,7 @@ class RecommendationBatchRequest:
     nmemes_sent: int
     nsessions: int = 0
     account_age_days: int | None = None
+    cold_start_account_too_old: bool = False
     user_type: str | None = None
     meme_ids_in_queue: Sequence[int] = field(default_factory=tuple)
     random_seed: int | None = None
@@ -133,6 +134,7 @@ class RecommendationBatchDiagnostics:
     nmemes_sent: int
     nsessions: int
     account_age_days: int | None
+    cold_start_account_too_old: bool
     user_type: str | None
     queue_len_before: int
     exclude_count: int
@@ -179,6 +181,7 @@ class RecommendationBatchDiagnostics:
             "nmemes_sent": self.nmemes_sent,
             "nsessions": self.nsessions,
             "account_age_days": self.account_age_days,
+            "cold_start_account_too_old": self.cold_start_account_too_old,
             "cold_start_nsessions_gate_enabled": self.cold_start_nsessions_gate_enabled,
             "queue_len_before": self.queue_len_before,
             "exclude_count": self.exclude_count,
@@ -287,6 +290,7 @@ class RecommendationBatchPipeline:
             nmemes_sent=request.nmemes_sent,
             nsessions=request.nsessions,
             account_age_days=request.account_age_days,
+            cold_start_account_too_old=request.cold_start_account_too_old,
             user_type=request.user_type,
             queue_len_before=len(request.meme_ids_in_queue),
             exclude_count=len(request.meme_ids_in_queue),
@@ -396,7 +400,7 @@ class RecommendationBatchPipeline:
             nsessions=request.nsessions,
             cold_start_nsessions_gate_enabled=request.cold_start_nsessions_gate_enabled,
             limit=limit,
-            account_age_days=request.account_age_days,
+            cold_start_account_too_old=request.cold_start_account_too_old,
         )
         diagnostics.maturity_stage = plan.maturity_stage
 
@@ -598,6 +602,7 @@ class RecommendationBatchPipeline:
                         nmemes_sent=diagnostics.nmemes_sent,
                         nsessions=diagnostics.nsessions,
                         account_age_days=diagnostics.account_age_days,
+                        cold_start_account_too_old=diagnostics.cold_start_account_too_old,
                         user_type=diagnostics.user_type,
                         meme_ids_in_queue=exclude_ids,
                     ),

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -441,6 +441,7 @@ async def get_user_info(
             COALESCE(nmemes_sent, 0) nmemes_sent,
             COALESCE(nsessions, 0) nsessions,
             FLOOR(EXTRACT(EPOCH FROM (NOW() - U.created_at)) / 86400)::INT account_age_days,
+            U.created_at < NOW() - INTERVAL '30 days' cold_start_account_too_old,
             COALESCE(memes_watched_today, 0) memes_watched_today,
             UIL.interface_lang
         FROM "user" AS U

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -440,6 +440,7 @@ async def get_user_info(
             type,
             COALESCE(nmemes_sent, 0) nmemes_sent,
             COALESCE(nsessions, 0) nsessions,
+            FLOOR(EXTRACT(EPOCH FROM (NOW() - U.created_at)) / 86400)::INT account_age_days,
             COALESCE(memes_watched_today, 0) memes_watched_today,
             UIL.interface_lang
         FROM "user" AS U

--- a/src/tgbot/user_info.py
+++ b/src/tgbot/user_info.py
@@ -8,6 +8,8 @@ from src import redis
 from src.tgbot import service
 from src.tgbot.exceptions import UserNotFound
 
+USER_INFO_CACHE_REQUIRED_KEYS = frozenset({"account_age_days"})
+
 
 async def get_cached_user_info(user_id: int) -> dict | None:
     key = redis.get_user_info_key(user_id)
@@ -34,7 +36,7 @@ async def update_user_info_cache(user_id: int) -> defaultdict:
 
 async def get_user_info(user_id: int) -> defaultdict:
     user_info = await get_cached_user_info(user_id)
-    if user_info is None:
+    if user_info is None or not USER_INFO_CACHE_REQUIRED_KEYS.issubset(user_info):
         user_info = await update_user_info_cache(user_id)
 
     user_info["id"] = user_id

--- a/src/tgbot/user_info.py
+++ b/src/tgbot/user_info.py
@@ -8,7 +8,12 @@ from src import redis
 from src.tgbot import service
 from src.tgbot.exceptions import UserNotFound
 
-USER_INFO_CACHE_REQUIRED_KEYS = frozenset({"account_age_days"})
+USER_INFO_CACHE_REQUIRED_KEYS = frozenset(
+    {
+        "account_age_days",
+        "cold_start_account_too_old",
+    }
+)
 
 
 async def get_cached_user_info(user_id: int) -> dict | None:

--- a/tests/feed_turn/test_planner.py
+++ b/tests/feed_turn/test_planner.py
@@ -117,6 +117,7 @@ def test_plan_for_user_gate_enabled_keeps_first_session_low_sent_users_in_cold_s
     plan = plan_candidate_selection_for_user(
         nmemes_sent=8,
         nsessions=nsessions,
+        cold_start_account_too_old=False,
         cold_start_nsessions_gate_enabled=True,
         limit=10,
     )
@@ -142,7 +143,7 @@ def test_plan_for_user_gate_enabled_routes_old_low_sent_users_to_growing_plan():
     plan = plan_candidate_selection_for_user(
         nmemes_sent=8,
         nsessions=1,
-        account_age_days=31,
+        cold_start_account_too_old=True,
         cold_start_nsessions_gate_enabled=True,
         limit=10,
     )

--- a/tests/feed_turn/test_planner.py
+++ b/tests/feed_turn/test_planner.py
@@ -138,6 +138,20 @@ def test_plan_for_user_gate_enabled_routes_returning_low_sent_users_to_growing_p
     assert plan.fallback_engines == ()
 
 
+def test_plan_for_user_gate_enabled_routes_old_low_sent_users_to_growing_plan():
+    plan = plan_candidate_selection_for_user(
+        nmemes_sent=8,
+        nsessions=1,
+        account_age_days=31,
+        cold_start_nsessions_gate_enabled=True,
+        limit=10,
+    )
+
+    assert plan.maturity_stage == GROWING
+    assert "cold_start_adapt" not in plan.blend_weights
+    assert plan.fallback_engines == ()
+
+
 @pytest.mark.parametrize(
     ("limit", "user_type", "quota"),
     [

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -733,7 +733,12 @@ async def test_gate_default_blocks_dormant_returner_from_cold_start():
 async def test_gate_default_blocks_old_low_sent_user_from_cold_start():
     """Old accounts can be dormant returners even before nsessions increments."""
     retriever = _growing_retriever_class()()
-    with _patch_user_info(nsessions=1, nmemes_sent=8, account_age_days=31):
+    with _patch_user_info(
+        nsessions=1,
+        nmemes_sent=8,
+        account_age_days=30,
+        cold_start_account_too_old=True,
+    ):
         candidates = await generate_recommendations(
             TEST_USER_ID, 10, nmemes_sent=8, retriever=retriever, random_seed=42
         )
@@ -742,6 +747,23 @@ async def test_gate_default_blocks_old_low_sent_user_from_cold_start():
     assert "cold_start_explore" not in sources
     assert "cold_start_adapt" not in sources
     assert candidates[0]["recommended_by"] == "lr_smoothed"
+
+
+@pytest.mark.asyncio
+async def test_gate_default_keeps_exact_30_day_low_sent_user_in_cold_start():
+    """The age gate uses the exact timestamp threshold, not floored account_age_days."""
+    retriever = _growing_retriever_class()()
+    with _patch_user_info(
+        nsessions=1,
+        nmemes_sent=8,
+        account_age_days=30,
+        cold_start_account_too_old=False,
+    ):
+        candidates = await generate_recommendations(
+            TEST_USER_ID, 10, nmemes_sent=8, retriever=retriever, random_seed=42
+        )
+
+    assert any(c["recommended_by"] == "cold_start_adapt" for c in candidates)
 
 
 @pytest.mark.asyncio

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -730,6 +730,21 @@ async def test_gate_default_blocks_dormant_returner_from_cold_start():
 
 
 @pytest.mark.asyncio
+async def test_gate_default_blocks_old_low_sent_user_from_cold_start():
+    """Old accounts can be dormant returners even before nsessions increments."""
+    retriever = _growing_retriever_class()()
+    with _patch_user_info(nsessions=1, nmemes_sent=8, account_age_days=31):
+        candidates = await generate_recommendations(
+            TEST_USER_ID, 10, nmemes_sent=8, retriever=retriever, random_seed=42
+        )
+
+    sources = {c["recommended_by"] for c in candidates}
+    assert "cold_start_explore" not in sources
+    assert "cold_start_adapt" not in sources
+    assert candidates[0]["recommended_by"] == "lr_smoothed"
+
+
+@pytest.mark.asyncio
 async def test_gate_on_first_session_routes_to_cold_start_explore():
     """Gate on + nsessions<=1 + nmemes_sent<6 → cold_start_explore (Phase 1)."""
     retriever = _growing_retriever_class()()

--- a/tests/tgbot/test_user_info.py
+++ b/tests/tgbot/test_user_info.py
@@ -1,0 +1,52 @@
+from collections import defaultdict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.tgbot.user_info import get_user_info
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_refreshes_cache_without_account_age_days():
+    cached_user_info = {"nmemes_sent": 8, "nsessions": 1}
+    refreshed_user_info = defaultdict(
+        lambda: None,
+        {"nmemes_sent": 8, "nsessions": 1, "account_age_days": 31},
+    )
+
+    with (
+        patch(
+            "src.tgbot.user_info.get_cached_user_info",
+            new_callable=AsyncMock,
+            return_value=cached_user_info,
+        ),
+        patch(
+            "src.tgbot.user_info.update_user_info_cache",
+            new_callable=AsyncMock,
+            return_value=refreshed_user_info,
+        ) as update_cache,
+    ):
+        user_info = await get_user_info(123)
+
+    update_cache.assert_awaited_once_with(123)
+    assert user_info["id"] == 123
+    assert user_info["account_age_days"] == 31
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_uses_cache_with_required_account_age_days():
+    cached_user_info = {"nmemes_sent": 8, "nsessions": 1, "account_age_days": 12}
+
+    with (
+        patch(
+            "src.tgbot.user_info.get_cached_user_info",
+            new_callable=AsyncMock,
+            return_value=cached_user_info,
+        ),
+        patch("src.tgbot.user_info.update_user_info_cache", new_callable=AsyncMock) as update_cache,
+    ):
+        user_info = await get_user_info(123)
+
+    update_cache.assert_not_awaited()
+    assert user_info["id"] == 123
+    assert user_info["account_age_days"] == 12

--- a/tests/tgbot/test_user_info.py
+++ b/tests/tgbot/test_user_info.py
@@ -7,11 +7,16 @@ from src.tgbot.user_info import get_user_info
 
 
 @pytest.mark.asyncio
-async def test_get_user_info_refreshes_cache_without_account_age_days():
+async def test_get_user_info_refreshes_cache_without_cold_start_age_keys():
     cached_user_info = {"nmemes_sent": 8, "nsessions": 1}
     refreshed_user_info = defaultdict(
         lambda: None,
-        {"nmemes_sent": 8, "nsessions": 1, "account_age_days": 31},
+        {
+            "nmemes_sent": 8,
+            "nsessions": 1,
+            "account_age_days": 30,
+            "cold_start_account_too_old": True,
+        },
     )
 
     with (
@@ -30,12 +35,18 @@ async def test_get_user_info_refreshes_cache_without_account_age_days():
 
     update_cache.assert_awaited_once_with(123)
     assert user_info["id"] == 123
-    assert user_info["account_age_days"] == 31
+    assert user_info["account_age_days"] == 30
+    assert user_info["cold_start_account_too_old"] is True
 
 
 @pytest.mark.asyncio
-async def test_get_user_info_uses_cache_with_required_account_age_days():
-    cached_user_info = {"nmemes_sent": 8, "nsessions": 1, "account_age_days": 12}
+async def test_get_user_info_uses_cache_with_required_cold_start_age_keys():
+    cached_user_info = {
+        "nmemes_sent": 8,
+        "nsessions": 1,
+        "account_age_days": 12,
+        "cold_start_account_too_old": False,
+    }
 
     with (
         patch(
@@ -50,3 +61,4 @@ async def test_get_user_info_uses_cache_with_required_account_age_days():
     update_cache.assert_not_awaited()
     assert user_info["id"] == 123
     assert user_info["account_age_days"] == 12
+    assert user_info["cold_start_account_too_old"] is False


### PR DESCRIPTION
Fixes FFM-1819.

## What changed
- Adds `account_age_days` to the existing user-info payload.
- Extends the cold-start gate so low-sent accounts older than 30 days fall through to the growing-user blender even when `nsessions <= 1`.
- Refreshes stale Redis `user_info` cache entries that do not yet include `account_age_days`, avoiding a one-hour post-deploy leak window.
- Threads the age signal through recommendation diagnostics for validation.

## Why
PR #322 enabled the `nsessions` gate, but `nsessions` is derived from send/reaction history. A user created >30 days ago can return with `nmemes_sent < 30` and `nsessions <= 1` before the next reaction increments stats, which left `cold_start_adapt` eligible.

## Verification
- `ruff check --fix src/ tests/ && ruff format src/ tests/`
- `python3 -m pytest tests/feed_turn/test_planner.py tests/recommendations/test_meme_queue.py tests/recommendations/test_pipeline.py tests/tgbot/test_user_info.py -q` (with CI-style env vars): 69 passed

## Post-deploy check
After deploy and cache refresh, verify no old low-sent users receive cold-start engines:

```sql
SELECT umr.recommended_by, COUNT(*) AS sends, COUNT(DISTINCT umr.user_id) AS users
FROM user_meme_reaction umr
JOIN "user" u ON u.id = umr.user_id
LEFT JOIN user_stats us ON us.user_id = umr.user_id
WHERE umr.recommended_by IN ('cold_start_explore', 'cold_start_adapt')
  AND u.created_at < NOW() - INTERVAL '30 days'
  AND COALESCE(us.nmemes_sent, 0) < 30
  AND umr.reacted_at >= NOW() - INTERVAL '24 hours'
GROUP BY 1;
```

Expected result: zero rows.
