### PR TITLE
Fix stale cold-start queue routing leak

### DIFF
--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -25,6 +25,8 @@ from src.storage.schemas import MemeData
 from src.tgbot.constants import UserType
 from src.tgbot.user_info import get_user_info
 
+COLD_START_RECOMMENDED_BY = frozenset({"cold_start_explore", "cold_start_adapt"})
+
 
 async def get_next_meme_for_user(user_id: int) -> MemeData | None:
     queue_key = redis.get_meme_queue_key(user_id)
@@ -52,7 +54,7 @@ async def get_next_meme_for_user(user_id: int) -> MemeData | None:
             discarded_unsendable = True
             continue
 
-        if await _queued_meme_is_sendable(user_id, meme_id):
+        if await _queued_meme_is_sendable(user_id, meme_id, meme_data.get("recommended_by")):
             return MemeData(**meme_data)
 
         discarded_unsendable = True
@@ -63,7 +65,11 @@ async def get_next_meme_for_user(user_id: int) -> MemeData | None:
         )
 
 
-async def _queued_meme_is_sendable(user_id: int, meme_id: int) -> bool:
+async def _queued_meme_is_sendable(
+    user_id: int,
+    meme_id: int,
+    recommended_by: str | None = None,
+) -> bool:
     row = await fetch_one(
         text(
             """
@@ -79,7 +85,89 @@ async def _queued_meme_is_sendable(user_id: int, meme_id: int) -> bool:
         ),
         {"user_id": user_id, "meme_id": meme_id},
     )
-    return row is not None
+    if row is None:
+        return False
+
+    if not _is_cold_start_engine(recommended_by) or not settings.COLD_START_NSESSIONS_GATE_ENABLED:
+        return True
+
+    state = await _get_realtime_cold_start_routing_state(user_id)
+    if _cold_start_allowed_by_realtime_state(state):
+        return True
+
+    logging.info(
+        "discarding cold_start queued meme for ineligible user_id=%s meme_id=%s state=%s",
+        user_id,
+        meme_id,
+        state,
+    )
+    return False
+
+
+def _is_cold_start_engine(recommended_by: str | None) -> bool:
+    return recommended_by in COLD_START_RECOMMENDED_BY
+
+
+def _cold_start_allowed_by_realtime_state(state: dict[str, Any] | None) -> bool:
+    if state is None:
+        return False
+
+    return (
+        int(state.get("prior_sent_count") or 0) < 30
+        and int(state.get("nsessions_after_next_send") or 0) <= 1
+        and not bool(state.get("cold_start_account_too_old"))
+    )
+
+
+async def _get_realtime_cold_start_routing_state(user_id: int) -> dict[str, Any] | None:
+    """Return cold-start routing state from raw send history, including this send.
+
+    user_stats and cached user_info can lag. Counting NOW() as the candidate
+    send catches a dormant returner before the first cold_start meme leaks into
+    the new session.
+    """
+    row = await fetch_one(
+        text(
+            """
+            WITH EVENTS AS (
+                SELECT sent_at, FALSE AS is_candidate_send
+                FROM user_meme_reaction
+                WHERE user_id = :user_id
+
+                UNION ALL
+
+                SELECT NOW() AS sent_at, TRUE AS is_candidate_send
+            ),
+            ORDERED_EVENTS AS (
+                SELECT
+                    sent_at,
+                    is_candidate_send,
+                    LAG(sent_at) OVER (ORDER BY sent_at, is_candidate_send) AS previous_sent_at
+                FROM EVENTS
+            ),
+            METRICS AS (
+                SELECT
+                    COUNT(*) FILTER (WHERE NOT is_candidate_send) AS prior_sent_count,
+                    COUNT(*) FILTER (
+                        WHERE previous_sent_at IS NULL
+                            OR sent_at - previous_sent_at > INTERVAL '30 minutes'
+                    ) AS nsessions_after_next_send
+                FROM ORDERED_EVENTS
+            )
+            SELECT
+                FLOOR(EXTRACT(EPOCH FROM (NOW() - U.created_at)) / 86400)::INT
+                    AS account_age_days,
+                U.created_at < NOW() - INTERVAL '30 days' AS cold_start_account_too_old,
+                COALESCE(M.prior_sent_count, 0) AS prior_sent_count,
+                COALESCE(M.nsessions_after_next_send, 1) AS nsessions_after_next_send
+            FROM "user" U
+            CROSS JOIN METRICS M
+            WHERE U.id = :user_id
+        """
+        ),
+        {"user_id": user_id},
+    )
+    return None if row is None else dict(row)
 
 
 async def has_memes_in_queue(user_id: int) -> bool:
@@ -150,6 +238,15 @@ async def generate_recommendations(
     nsessions = user_info.get("nsessions") or 0
     account_age_days = user_info.get("account_age_days")
     cold_start_account_too_old = bool(user_info.get("cold_start_account_too_old"))
+    if settings.COLD_START_NSESSIONS_GATE_ENABLED and nmemes_sent < 30:
+        realtime_state = await _get_realtime_cold_start_routing_state(user_id)
+        if realtime_state is not None:
+            nmemes_sent = max(nmemes_sent, int(realtime_state.get("prior_sent_count") or 0))
+            nsessions = max(nsessions, int(realtime_state.get("nsessions_after_next_send") or 0))
+            account_age_days = realtime_state.get("account_age_days")
+            cold_start_account_too_old = cold_start_account_too_old or bool(
+                realtime_state.get("cold_start_account_too_old")
+            )
 
     queue_key = redis.get_meme_queue_key(user_id)
 

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -8,7 +8,11 @@ from src.recommendations.blender_experiments import (
     MATURE_BLENDER_TREATMENT_WEIGHTS,
 )
 from src.recommendations.candidates import CandidatesRetriever
-from src.recommendations.meme_queue import generate_recommendations, get_next_meme_for_user
+from src.recommendations.meme_queue import (
+    _cold_start_allowed_by_realtime_state,
+    generate_recommendations,
+    get_next_meme_for_user,
+)
 
 TEST_USER_ID = 99999
 
@@ -46,11 +50,57 @@ def mock_redis():
             new_callable=AsyncMock,
             side_effect=lambda user_id, weights: weights,
         ),
+        patch(
+            "src.recommendations.meme_queue._get_realtime_cold_start_routing_state",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
     ):
         yield
 
 
 # ── Cold start Phase 1 (nmemes_sent < 6): cold_start_explore ──
+
+
+@pytest.mark.parametrize(
+    ("state", "allowed"),
+    [
+        (
+            {
+                "prior_sent_count": 26,
+                "nsessions_after_next_send": 1,
+                "cold_start_account_too_old": False,
+            },
+            True,
+        ),
+        (
+            {
+                "prior_sent_count": 26,
+                "nsessions_after_next_send": 2,
+                "cold_start_account_too_old": False,
+            },
+            False,
+        ),
+        (
+            {
+                "prior_sent_count": 30,
+                "nsessions_after_next_send": 1,
+                "cold_start_account_too_old": False,
+            },
+            False,
+        ),
+        (
+            {
+                "prior_sent_count": 8,
+                "nsessions_after_next_send": 1,
+                "cold_start_account_too_old": True,
+            },
+            False,
+        ),
+    ],
+)
+def test_cold_start_realtime_state_predicate(state, allowed):
+    assert _cold_start_allowed_by_realtime_state(state) is allowed
 
 
 @pytest.mark.asyncio
@@ -73,7 +123,7 @@ async def test_get_next_meme_for_user_skips_stale_queue_payloads():
     async def pop_queue(_queue_key):
         return queued_payloads.pop(0) if queued_payloads else None
 
-    async def is_sendable(_user_id: int, meme_id: int) -> bool:
+    async def is_sendable(_user_id: int, meme_id: int, _recommended_by: str | None = None) -> bool:
         return meme_id == 102
 
     with (
@@ -119,7 +169,7 @@ async def test_get_next_meme_for_user_refills_after_draining_stale_payloads():
         )
         return True
 
-    async def is_sendable(_user_id: int, meme_id: int) -> bool:
+    async def is_sendable(_user_id: int, meme_id: int, _recommended_by: str | None = None) -> bool:
         return meme_id == 102
 
     with (
@@ -144,6 +194,58 @@ async def test_get_next_meme_for_user_refills_after_draining_stale_payloads():
     assert meme is not None
     assert meme.id == 102
     check_queue.assert_awaited_once_with(TEST_USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_get_next_meme_for_user_discards_cold_start_payload_when_realtime_guard_blocks():
+    queued_payloads = [
+        {
+            "id": 101,
+            "type": "image",
+            "telegram_file_id": "stale-cold-start-file-id",
+            "caption": None,
+            "recommended_by": "cold_start_adapt",
+        },
+        {
+            "id": 102,
+            "type": "image",
+            "telegram_file_id": "growing-file-id",
+            "caption": None,
+            "recommended_by": "lr_smoothed",
+        },
+    ]
+    ineligible_state = {
+        "account_age_days": 28,
+        "cold_start_account_too_old": False,
+        "prior_sent_count": 26,
+        "nsessions_after_next_send": 2,
+    }
+
+    async def pop_queue(_queue_key):
+        return queued_payloads.pop(0) if queued_payloads else None
+
+    with (
+        patch(
+            "src.recommendations.meme_queue.redis.pop_meme_from_queue_by_key",
+            new_callable=AsyncMock,
+            side_effect=pop_queue,
+        ),
+        patch(
+            "src.recommendations.meme_queue.fetch_one",
+            new_callable=AsyncMock,
+            side_effect=[{"id": 101}, {"id": 102}],
+        ),
+        patch(
+            "src.recommendations.meme_queue._get_realtime_cold_start_routing_state",
+            new_callable=AsyncMock,
+            return_value=ineligible_state,
+        ) as realtime_state,
+    ):
+        meme = await get_next_meme_for_user(TEST_USER_ID)
+
+    assert meme is not None
+    assert meme.id == 102
+    realtime_state.assert_awaited_once_with(TEST_USER_ID)
 
 
 @pytest.mark.asyncio
@@ -747,6 +849,35 @@ async def test_gate_default_blocks_old_low_sent_user_from_cold_start():
     assert "cold_start_explore" not in sources
     assert "cold_start_adapt" not in sources
     assert candidates[0]["recommended_by"] == "lr_smoothed"
+
+
+@pytest.mark.asyncio
+async def test_gate_default_blocks_realtime_second_session_even_when_cache_is_stale():
+    """Realtime sent history catches dormant returners before user_info/user_stats catches up."""
+    retriever = _growing_retriever_class()()
+    stale_cached_state = {
+        "account_age_days": 28,
+        "cold_start_account_too_old": False,
+        "prior_sent_count": 26,
+        "nsessions_after_next_send": 2,
+    }
+    with (
+        _patch_user_info(nsessions=1, nmemes_sent=26, cold_start_account_too_old=False),
+        patch(
+            "src.recommendations.meme_queue._get_realtime_cold_start_routing_state",
+            new_callable=AsyncMock,
+            return_value=stale_cached_state,
+        ) as realtime_state,
+    ):
+        candidates = await generate_recommendations(
+            TEST_USER_ID, 10, nmemes_sent=26, retriever=retriever, random_seed=42
+        )
+
+    sources = {c["recommended_by"] for c in candidates}
+    assert "cold_start_explore" not in sources
+    assert "cold_start_adapt" not in sources
+    assert candidates[0]["recommended_by"] == "lr_smoothed"
+    realtime_state.assert_awaited_once_with(TEST_USER_ID)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes FFM-1846.

## What changed
- Added a realtime cold-start routing state guard in `src/recommendations/meme_queue.py` based on raw `user_meme_reaction` send history.
- The guard counts the candidate send at `NOW()` so a dormant returner is blocked before the first cold-start meme of a new session leaks.
- Applied the guard both when generating a fresh recommendation batch and when serving existing Redis queue payloads.
- Existing cold-start queue payloads with `recommended_by in {cold_start_explore, cold_start_adapt}` are discarded when the user is no longer eligible.

## Root cause
PR #327 gated planning with cached/user_stats-derived fields, plus account age. `user_info` is cached for up to 1 hour and `user_stats.nsessions` is produced by scheduled stats, so a returning low-sent user could still look like `nsessions <= 1` at queue generation time. Redis could also contain cold-start payloads generated before the user became ineligible. The July 8 leak shape matches that stale-feature/immediate-queue gap.

## Validation
- `env DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/postgres REDIS_URL=redis://localhost:6379/0 CORS_ORIGINS='["*"]' CORS_HEADERS='["*"]' pytest tests/recommendations/test_meme_queue.py -q` -> 31 passed
- `ruff check --fix src/ tests/` -> passed
- `ruff format src/ tests/` -> 279 files left unchanged

## Post-deploy verification
After merge/deploy, Analyst should rerun the sent_at leak checks from FFM-1834/FFM-1846:
- broad old-account dormant-returner cold_start_explore/cold_start_adapt sends since deploy: target 0
- stricter as-of-send prior-session/prior-sent check since deploy: target 0
- continue true-new first-10 measurement until n >= 30 or a stronger stop condition is recorded