### PR TITLE
Fix: diagnose Describe Memes OpenRouter limits

### DIFF
--- a/specs/describe-memes.md
+++ b/specs/describe-memes.md
@@ -38,6 +38,11 @@ The client enforces this twice:
 
 If Redis quota accounting fails, the client fails closed and does not call OpenRouter.
 
+Before each scheduled batch, the flow also checks `GET /api/v1/key`. If
+OpenRouter reports an invalid key or a configured key limit with
+`limit_remaining <= 0`, the batch stops before selecting memes. This does not
+spend model quota and makes account/key exhaustion visible in flow logs.
+
 ## Model Chain
 
 Current production chain:
@@ -45,7 +50,6 @@ Current production chain:
 ```python
 [
     "google/gemma-4-31b-it:free",
-    "nex-agi/nex-n2-pro:free",
     "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
     "google/gemma-4-26b-a4b-it:free",
 ]
@@ -57,6 +61,9 @@ quota.
 
 `nvidia/nemotron-3.5-content-safety:free` is intentionally excluded because it
 is a guardrail classifier, not a general OCR/description model.
+
+`nex-agi/nex-n2-pro:free` was removed after it disappeared from the OpenRouter
+free vision model list, creating avoidable failed attempts.
 
 Do not add paid fallbacks. A paid fallback can spend the account below zero, after which OpenRouter returns 402 for all models, including free models.
 
@@ -73,6 +80,9 @@ Do not add paid fallbacks. A paid fallback can spend the account below zero, aft
 - Healthy batch: up to 9 described, low failures. 429-only batches are acceptable.
 - Daily attempts: inspect Redis key `openrouter:free_requests:YYYY-MM-DD`.
 - Hourly model stats: inspect Redis hashes `openrouter:free_ocr_stats:YYYY-MM-DD:HH` (UTC, 14d TTL). Fields are `{model_id}:{outcome}`, e.g. `...:success`, `...:rate_limited`, `...:timeout`.
+- OpenRouter key health: check flow logs for `OpenRouter key health ok` or
+  `OpenRouter key limit exhausted`. A limit-exhausted key requires raising or
+  resetting the key credit limit, or rotating `OPENROUTER_API_KEY`.
 - Time-window tuning: compare hourly `success / attempt` by UTC hour, then shift the Prefect schedule or batch size if nights are consistently better.
 - Resume paused deployment:
 

--- a/src/flows/storage/describe_memes.py
+++ b/src/flows/storage/describe_memes.py
@@ -45,6 +45,7 @@ from src.flows.storage.openrouter_vision import (
     RATE_LIMITED,
     VISION_MODELS,
     call_openrouter_vision,
+    check_openrouter_key_health,
 )
 from src.storage.deduplication import deduplicate_described_meme
 from src.storage.upload import download_meme_content_from_tg
@@ -133,6 +134,10 @@ async def describe_memes_flow(batch_size: int = 20) -> None:
 
     if not settings.OPENROUTER_API_KEY:
         log.warning("OPENROUTER_API_KEY not set. Skipping.")
+        return
+
+    if not await check_openrouter_key_health(log):
+        log.warning("OpenRouter key is not usable. Skipping Describe Memes batch.")
         return
 
     memes = await get_memes_to_describe(limit=batch_size)

--- a/src/flows/storage/openrouter_vision.py
+++ b/src/flows/storage/openrouter_vision.py
@@ -9,6 +9,7 @@ from src.config import settings
 from src.redis import redis_client
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_KEY_HEALTH_TIMEOUT_SECONDS = 10.0
 OPENROUTER_FREE_DAILY_REQUEST_LIMIT = 1000
 OPENROUTER_FREE_DAILY_REQUEST_BUDGET = 900
 OPENROUTER_FREE_REQUEST_COUNTER_TTL_SECONDS = 60 * 60 * 48
@@ -23,15 +24,15 @@ OPENROUTER_FORBIDDEN_MODEL_COOLDOWN_SECONDS = 60 * 60 * 6
 # lifetime purchases for 1,000 req/day (vs 50/day without).
 # See specs/describe-memes.md for full OpenRouter constraints.
 #
-# Verified available on OpenRouter API as of 2026-06-17.
+# Verified available on OpenRouter API as of 2026-07-09.
 # Ordered by preference. Falls back to next model on 429/403/timeout/bad response.
 # Transient failures set Redis cooldowns so later memes/runs try other free models.
 VISION_MODELS = [
     "google/gemma-4-31b-it:free",  # 262k context, primary
-    "nex-agi/nex-n2-pro:free",  # 262k context, Qwen3.5 multimodal MoE
     "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",  # 256k context, multimodal
     "google/gemma-4-26b-a4b-it:free",  # 262k context, MoE variant
     # Gemma 3 free vision fallbacks are no longer listed by OpenRouter.
+    # nex-agi/nex-n2-pro:free is no longer listed by OpenRouter.
     # nvidia/nemotron-3.5-content-safety:free is a guardrail classifier, not
     # a general OCR/description model.
     # nvidia/nemotron-nano-12b-v2-vl:free removed — returns 504s and invalid
@@ -190,6 +191,77 @@ async def _cool_down_transient_openrouter_model(model_id: str, reason: str) -> f
         reason,
     )
     return float(OPENROUTER_TRANSIENT_MODEL_COOLDOWN_SECONDS)
+
+
+def _is_exhausted_key_limit(limit: object, limit_remaining: object) -> bool:
+    """Return whether OpenRouter reports a configured key limit with no credit left."""
+    if limit is None or limit_remaining is None:
+        return False
+
+    try:
+        return float(limit_remaining) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
+async def check_openrouter_key_health(log) -> bool:
+    """Check whether the configured OpenRouter key can make requests.
+
+    This endpoint does not spend model quota. If the check itself is unavailable,
+    fail open so a transient OpenRouter metadata outage does not stop OCR.
+    """
+    headers = {"Authorization": f"Bearer {settings.OPENROUTER_API_KEY}"}
+
+    try:
+        async with httpx.AsyncClient(timeout=OPENROUTER_KEY_HEALTH_TIMEOUT_SECONDS) as client:
+            response = await client.get(f"{OPENROUTER_BASE_URL}/key", headers=headers)
+    except httpx.RequestError as e:
+        log.warning(
+            "OpenRouter key health check unavailable (%s); continuing with model calls.",
+            type(e).__name__,
+        )
+        return True
+
+    if response.status_code in {401, 403}:
+        log.error(
+            "OpenRouter key health check failed with HTTP %s; "
+            "OPENROUTER_API_KEY is invalid or unauthorized.",
+            response.status_code,
+        )
+        return False
+
+    try:
+        response.raise_for_status()
+        payload = response.json()
+    except (httpx.HTTPStatusError, json.JSONDecodeError) as e:
+        log.warning("OpenRouter key health check returned unusable response: %s", e)
+        return True
+
+    data = payload.get("data", {}) if isinstance(payload, dict) else {}
+    limit = data.get("limit")
+    limit_remaining = data.get("limit_remaining")
+    limit_reset = data.get("limit_reset")
+    is_free_tier = data.get("is_free_tier")
+
+    if _is_exhausted_key_limit(limit, limit_remaining):
+        log.error(
+            "OpenRouter key limit exhausted (limit=%s, limit_remaining=%s, "
+            "limit_reset=%s). Raise/reset the key credit limit or rotate "
+            "OPENROUTER_API_KEY before Describe Memes can recover.",
+            limit,
+            limit_remaining,
+            limit_reset or "never",
+        )
+        return False
+
+    log.info(
+        "OpenRouter key health ok (limit=%s, limit_remaining=%s, limit_reset=%s, is_free_tier=%s).",
+        limit if limit is not None else "unlimited",
+        limit_remaining if limit_remaining is not None else "unlimited",
+        limit_reset or "never",
+        is_free_tier,
+    )
+    return True
 
 
 def _parse_vision_response(raw_content: str) -> dict:

--- a/tests/storage/test_describe_memes_models.py
+++ b/tests/storage/test_describe_memes_models.py
@@ -12,7 +12,7 @@ def test_describe_memes_does_not_use_removed_gemma_3_free_models():
 
 def test_describe_memes_has_multiple_general_vision_fallbacks():
     assert "google/gemma-4-31b-it:free" in VISION_MODELS
-    assert "nex-agi/nex-n2-pro:free" in VISION_MODELS
     assert "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free" in VISION_MODELS
+    assert "nex-agi/nex-n2-pro:free" not in VISION_MODELS
     assert "nvidia/nemotron-3.5-content-safety:free" not in VISION_MODELS
     assert "nvidia/nemotron-nano-12b-v2-vl:free" not in VISION_MODELS

--- a/tests/storage/test_openrouter_vision.py
+++ b/tests/storage/test_openrouter_vision.py
@@ -1,0 +1,97 @@
+import httpx
+import pytest
+
+from src.flows.storage import openrouter_vision
+
+
+class _Log:
+    def __init__(self):
+        self.messages = []
+
+    def error(self, message, *args):
+        self.messages.append(("error", message % args if args else message))
+
+    def info(self, message, *args):
+        self.messages.append(("info", message % args if args else message))
+
+    def warning(self, message, *args):
+        self.messages.append(("warning", message % args if args else message))
+
+
+class _FakeAsyncClient:
+    def __init__(self, response=None, error=None, **_kwargs):
+        self.response = response
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def get(self, *_args, **_kwargs):
+        if self.error:
+            raise self.error
+        return self.response
+
+
+def _response(status_code: int, payload: dict):
+    request = httpx.Request("GET", "https://openrouter.ai/api/v1/key")
+    return httpx.Response(status_code, json=payload, request=request)
+
+
+@pytest.mark.asyncio
+async def test_check_openrouter_key_health_blocks_exhausted_key(monkeypatch):
+    response = _response(
+        200,
+        {"data": {"limit": 1, "limit_remaining": 0, "limit_reset": "monthly"}},
+    )
+    monkeypatch.setattr(
+        openrouter_vision.httpx,
+        "AsyncClient",
+        lambda **kwargs: _FakeAsyncClient(response=response, **kwargs),
+    )
+    monkeypatch.setattr(openrouter_vision.settings, "OPENROUTER_API_KEY", "test-key")
+
+    log = _Log()
+
+    assert await openrouter_vision.check_openrouter_key_health(log) is False
+    assert any("limit exhausted" in message for level, message in log.messages if level == "error")
+
+
+@pytest.mark.asyncio
+async def test_check_openrouter_key_health_allows_unlimited_key(monkeypatch):
+    response = _response(
+        200,
+        {"data": {"limit": None, "limit_remaining": None, "limit_reset": None}},
+    )
+    monkeypatch.setattr(
+        openrouter_vision.httpx,
+        "AsyncClient",
+        lambda **kwargs: _FakeAsyncClient(response=response, **kwargs),
+    )
+    monkeypatch.setattr(openrouter_vision.settings, "OPENROUTER_API_KEY", "test-key")
+
+    assert await openrouter_vision.check_openrouter_key_health(_Log()) is True
+
+
+@pytest.mark.asyncio
+async def test_check_openrouter_key_health_fails_open_when_probe_unavailable(monkeypatch):
+    error = httpx.ConnectError(
+        "unavailable",
+        request=httpx.Request("GET", "https://openrouter.ai/api/v1/key"),
+    )
+    monkeypatch.setattr(
+        openrouter_vision.httpx,
+        "AsyncClient",
+        lambda **kwargs: _FakeAsyncClient(error=error, **kwargs),
+    )
+    monkeypatch.setattr(openrouter_vision.settings, "OPENROUTER_API_KEY", "test-key")
+
+    assert await openrouter_vision.check_openrouter_key_health(_Log()) is True
+
+
+def test_is_exhausted_key_limit_ignores_unlimited_or_unknown_values():
+    assert openrouter_vision._is_exhausted_key_limit(None, None) is False
+    assert openrouter_vision._is_exhausted_key_limit(1, "not-a-number") is False
+    assert openrouter_vision._is_exhausted_key_limit(1, 0) is True


### PR DESCRIPTION
Fixes FFM-1851.

## What changed
- Adds a pre-batch OpenRouter key health check using `GET /api/v1/key`, so exhausted per-key limits or invalid keys are logged explicitly before the flow selects memes.
- Removes `nex-agi/nex-n2-pro:free` from the fallback chain after verifying on 2026-07-09 that it is no longer listed in OpenRouter's free vision model list.
- Keeps the hard `:free` model contract intact; no paid fallback and no `openrouter/free` router ID.
- Documents the key-health gate and current model-chain decisions.
- Adds focused unit tests for the key health gate.

## Investigation
- Production aggregate check via `ANALYST_DATABASE_URL`: `described_24h=7`, `described_7d=970`, `last_described_at=2026-07-08T20:15:12Z`, `backlog_remaining=206324`. This matches the July 9 alert and is not a false positive.
- Local runner has no `OPENROUTER_API_KEY`, so I could not make an authenticated OpenRouter completion/key probe from here.
- Prefect CLI access from this shell returned `401 Unauthorized`, so I could not inspect production flow logs directly.
- Public OpenRouter model list on 2026-07-09 includes Gemma 4 31B, Gemma 4 26B, and NVIDIA Nemotron 3 Nano Omni as free image-capable models; `nex-agi/nex-n2-pro:free` was absent.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `pytest tests/storage/test_describe_memes_models.py tests/storage/test_openrouter_vision.py tests/scripts/test_agent_doctor.py`

## Production follow-up
After deploy, verify `meme.ocr_result->>'calculated_at'` advances after deploy time and at least one new row has `description`. If logs say `OpenRouter key limit exhausted`, the unblock owner is the OpenRouter account/key owner: raise/reset the key credit limit or rotate `OPENROUTER_API_KEY`.