### PR TITLE
Add cold-start first-10 quality readout

### DIFF
--- a/docs/analyst/README.md
+++ b/docs/analyst/README.md
@@ -11,6 +11,7 @@ The Analyst agent monitors product health, tracks experiments, and produces dail
 ## Key Files
 - `docs/analyst/metrics.sql` — SQL queries organized by section (health, north star, engines, retention, etc.)
 - `docs/analyst/crossposting.sql` — reusable read-only queries for Telegram channel views/forwards, 24h labels, and pre-posting share signals.
+- `scripts/cold_start_first10_quality_readout.py` — repeatable true-new cold-start first-10 readout. It uses each user's first-ever `user_meme_reaction.sent_at`, requires that first send to be `cold_start_explore` or `cold_start_adapt`, and then reports first-meme/first-10 quality, depth gates, per-position, engine, source/type/language, and top/bottom meme slices.
 - `specs/crossposting-share-optimization-2026-05-18.md` — current compact crossposting readout and next experiment gate.
 - `experiments/active/` — Currently running experiments to monitor
 - `experiments/completed/` — Historical experiments for context

--- a/scripts/cold_start_first10_quality_readout.py
+++ b/scripts/cold_start_first10_quality_readout.py
@@ -1,0 +1,76 @@
+"""Run the true-new cold-start first-10 quality readout.
+
+Usage:
+    source .env
+    python scripts/cold_start_first10_quality_readout.py --lookback-days 14
+
+The query is shadow-only analytics: it reads user_meme_reaction/meme stats and
+does not change recommendation ranking, thresholds, weights, or assignments.
+"""
+
+import argparse
+import asyncio
+import os
+from collections.abc import Sequence
+from decimal import Decimal
+from typing import Any
+
+
+def _to_asyncpg_url(url: str) -> str:
+    if url.startswith("postgres://"):
+        return url.replace("postgres://", "postgresql+asyncpg://", 1)
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return url
+
+
+def _configure_database_url() -> None:
+    analyst_url = os.environ.get("ANALYST_DATABASE_URL")
+    if analyst_url and not os.environ.get("DATABASE_URL"):
+        os.environ["DATABASE_URL"] = _to_asyncpg_url(analyst_url)
+    elif os.environ.get("DATABASE_URL"):
+        os.environ["DATABASE_URL"] = _to_asyncpg_url(os.environ["DATABASE_URL"])
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, Decimal):
+        return str(value.normalize())
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _print_rows(title: str, rows: Sequence[dict[str, Any]]) -> None:
+    print(f"\n## {title}")
+    if not rows:
+        print("(no rows)")
+        return
+
+    columns = list(rows[0].keys())
+    print("\t".join(columns))
+    for row in rows:
+        print("\t".join(_format_value(row[column]) for column in columns))
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lookback-days", type=int, default=14)
+    parser.add_argument("--min-candidate-sends", type=int, default=3)
+    parser.add_argument("--candidate-limit", type=int, default=20)
+    args = parser.parse_args()
+
+    _configure_database_url()
+
+    from src.stats.cold_start_quality import fetch_cold_start_first10_quality_readout
+
+    readout = await fetch_cold_start_first10_quality_readout(
+        lookback_days=args.lookback_days,
+        min_candidate_sends=args.min_candidate_sends,
+        candidate_limit=args.candidate_limit,
+    )
+    for section, rows in readout.items():
+        _print_rows(section, rows)
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/scripts/cold_start_first10_quality_readout.py
+++ b/scripts/cold_start_first10_quality_readout.py
@@ -11,9 +11,15 @@ does not change recommendation ranking, thresholds, weights, or assignments.
 import argparse
 import asyncio
 import os
+import sys
 from collections.abc import Sequence
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 
 def _to_asyncpg_url(url: str) -> str:
@@ -26,7 +32,7 @@ def _to_asyncpg_url(url: str) -> str:
 
 def _configure_database_url() -> None:
     analyst_url = os.environ.get("ANALYST_DATABASE_URL")
-    if analyst_url and not os.environ.get("DATABASE_URL"):
+    if analyst_url:
         os.environ["DATABASE_URL"] = _to_asyncpg_url(analyst_url)
     elif os.environ.get("DATABASE_URL"):
         os.environ["DATABASE_URL"] = _to_asyncpg_url(os.environ["DATABASE_URL"])

--- a/src/stats/cold_start_quality.py
+++ b/src/stats/cold_start_quality.py
@@ -1,0 +1,488 @@
+from typing import Any, Literal
+
+from sqlalchemy import text
+from sqlalchemy.sql.elements import TextClause
+
+ReadoutSection = Literal[
+    "summary",
+    "per_position",
+    "per_engine",
+    "segments",
+    "candidate_memes",
+]
+
+READOUT_SECTIONS: tuple[ReadoutSection, ...] = (
+    "summary",
+    "per_position",
+    "per_engine",
+    "segments",
+    "candidate_memes",
+)
+
+DEFAULT_LOOKBACK_DAYS = 14
+DEFAULT_MIN_CANDIDATE_SENDS = 3
+DEFAULT_CANDIDATE_LIMIT = 20
+
+_BASE_CTE = """
+WITH first_sends AS (
+    SELECT DISTINCT ON (user_id)
+        user_id,
+        meme_id,
+        recommended_by,
+        sent_at
+    FROM user_meme_reaction
+    ORDER BY user_id, sent_at, meme_id
+),
+
+true_new_users AS (
+    SELECT
+        user_id,
+        sent_at AS first_send_at
+    FROM first_sends
+    WHERE sent_at >= NOW() - (:lookback_days * INTERVAL '1 day')
+      AND recommended_by IN ('cold_start_explore', 'cold_start_adapt')
+),
+
+candidate_sends AS (
+    SELECT
+        R.user_id,
+        R.meme_id,
+        R.recommended_by,
+        R.sent_at,
+        R.reaction_id,
+        R.reacted_at
+    FROM user_meme_reaction R
+    JOIN true_new_users TNU ON TNU.user_id = R.user_id
+    WHERE R.sent_at >= TNU.first_send_at
+),
+
+ordered_sends AS (
+    SELECT
+        CS.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY CS.user_id
+            ORDER BY CS.sent_at, CS.meme_id
+        ) AS send_position,
+        LAG(CS.sent_at) OVER (
+            PARTITION BY CS.user_id
+            ORDER BY CS.sent_at, CS.meme_id
+        ) AS previous_sent_at,
+        LEAD(CS.sent_at) OVER (
+            PARTITION BY CS.user_id
+            ORDER BY CS.sent_at, CS.meme_id
+        ) AS next_sent_at,
+        MAX(CASE WHEN CS.reaction_id IS NOT NULL THEN CS.sent_at END) OVER (
+            PARTITION BY CS.user_id
+        ) AS user_last_reaction_sent_at
+    FROM candidate_sends CS
+),
+
+sessionized_sends AS (
+    SELECT
+        OS.*,
+        CASE
+            WHEN OS.previous_sent_at IS NULL THEN 1
+            WHEN OS.sent_at - OS.previous_sent_at > INTERVAL '30 minutes' THEN 1
+            ELSE 0
+        END AS new_session_flag
+    FROM ordered_sends OS
+),
+
+ranked_sends AS (
+    SELECT
+        SS.*,
+        SUM(SS.new_session_flag) OVER (
+            PARTITION BY SS.user_id
+            ORDER BY SS.sent_at, SS.meme_id
+        ) AS session_number
+    FROM sessionized_sends SS
+),
+
+first10_sends AS (
+    SELECT
+        RS.user_id,
+        RS.meme_id,
+        RS.recommended_by,
+        RS.sent_at,
+        RS.reaction_id,
+        RS.reacted_at,
+        RS.send_position AS first10_position,
+        RS.session_number,
+        RS.next_sent_at,
+        RS.next_sent_at IS NOT NULL
+            AND RS.next_sent_at - RS.sent_at < INTERVAL '30 minutes'
+            AS continued_within_30m,
+        CASE
+            WHEN RS.reaction_id = 1 THEN 1.0
+            WHEN RS.reaction_id = 2
+                AND EXTRACT(EPOCH FROM RS.reacted_at - RS.sent_at) BETWEEN 0.5 AND 60
+                AND EXTRACT(EPOCH FROM RS.reacted_at - RS.sent_at) > 3
+                THEN -1.0
+            WHEN RS.reaction_id = 2
+                AND EXTRACT(EPOCH FROM RS.reacted_at - RS.sent_at) BETWEEN 0.5 AND 60
+                AND EXTRACT(EPOCH FROM RS.reacted_at - RS.sent_at) <= 3
+                THEN -0.5
+            WHEN RS.reaction_id = 2 THEN -1.0
+            WHEN RS.reaction_id IS NULL
+                AND RS.sent_at < RS.user_last_reaction_sent_at THEN -0.3
+            ELSE NULL
+        END AS first10_engagement_value,
+        M.type AS meme_type,
+        M.language_code AS meme_language_code,
+        M.meme_source_id,
+        SRC.url AS source_url,
+        SRC.type AS source_type,
+        SRC.language_code AS source_language_code,
+        MS.lr_smoothed,
+        MS.engagement_score AS meme_engagement_score,
+        MS.nlikes AS historical_likes,
+        MS.ndislikes AS historical_dislikes,
+        MS.nmemes_sent AS historical_sends
+    FROM ranked_sends RS
+    JOIN meme M ON M.id = RS.meme_id
+    LEFT JOIN meme_source SRC ON SRC.id = M.meme_source_id
+    LEFT JOIN meme_stats MS ON MS.meme_id = RS.meme_id
+    WHERE RS.send_position <= 10
+),
+
+cohort_depth AS (
+    SELECT
+        user_id,
+        COUNT(*) AS first10_sends
+    FROM first10_sends
+    GROUP BY user_id
+),
+
+cohort_sessions AS (
+    SELECT
+        user_id,
+        BOOL_OR(session_number >= 2) AS has_second_session
+    FROM ranked_sends
+    GROUP BY user_id
+),
+
+cohort_users AS (
+    SELECT
+        TNU.user_id,
+        TNU.first_send_at,
+        COALESCE(CD.first10_sends, 0) AS first10_sends,
+        COALESCE(CS.has_second_session, FALSE) AS has_second_session
+    FROM true_new_users TNU
+    LEFT JOIN cohort_depth CD ON CD.user_id = TNU.user_id
+    LEFT JOIN cohort_sessions CS ON CS.user_id = TNU.user_id
+)
+"""
+
+_SECTION_SQL: dict[ReadoutSection, str] = {
+    "summary": """
+, summary_counts AS (
+    SELECT
+        (SELECT COUNT(*) FROM cohort_users) AS cohort_users,
+        (SELECT COUNT(*) FROM cohort_users WHERE first10_sends >= 5) AS reached5_users,
+        (SELECT COUNT(*) FROM cohort_users WHERE first10_sends >= 10) AS reached10_users,
+        (SELECT COUNT(*) FROM cohort_users WHERE has_second_session) AS second_session_users,
+        COUNT(*) FILTER (WHERE first10_position = 1) AS first_meme_sends,
+        COUNT(*) FILTER (
+            WHERE first10_position = 1 AND reaction_id = 1
+        ) AS first_meme_likes,
+        COUNT(*) FILTER (
+            WHERE first10_position = 1 AND reaction_id IS NOT NULL
+        ) AS first_meme_reacted,
+        COUNT(*) FILTER (
+            WHERE first10_position = 1 AND continued_within_30m
+        ) AS first_meme_continued,
+        COUNT(*) AS first10_sends,
+        COUNT(*) FILTER (WHERE reaction_id = 1) AS first10_likes,
+        COUNT(*) FILTER (WHERE reaction_id IS NOT NULL) AS first10_reacted,
+        COUNT(*) FILTER (WHERE continued_within_30m) AS first10_continued,
+        AVG(first10_engagement_value) AS first10_quality_score,
+        AVG(meme_engagement_score) AS avg_meme_engagement_score
+    FROM first10_sends
+)
+SELECT
+    cohort_users,
+    first_meme_sends,
+    first_meme_likes,
+    first_meme_reacted,
+    ROUND((100.0 * first_meme_likes / NULLIF(first_meme_reacted, 0))::numeric, 1)
+        AS first_meme_lr_pct,
+    ROUND((100.0 * first_meme_continued / NULLIF(first_meme_sends, 0))::numeric, 1)
+        AS first_meme_continuation_pct,
+    first10_sends,
+    first10_likes,
+    first10_reacted,
+    ROUND((100.0 * first10_likes / NULLIF(first10_reacted, 0))::numeric, 1)
+        AS first10_lr_pct,
+    ROUND((100.0 * first10_continued / NULLIF(first10_sends, 0))::numeric, 1)
+        AS first10_continuation_pct,
+    reached5_users,
+    ROUND((100.0 * reached5_users / NULLIF(cohort_users, 0))::numeric, 1)
+        AS reached5_pct,
+    reached10_users,
+    ROUND((100.0 * reached10_users / NULLIF(cohort_users, 0))::numeric, 1)
+        AS reached10_pct,
+    second_session_users,
+    ROUND((100.0 * second_session_users / NULLIF(cohort_users, 0))::numeric, 1)
+        AS second_session_pct,
+    ROUND(first10_quality_score::numeric, 3) AS first10_quality_score,
+    ROUND(avg_meme_engagement_score::numeric, 3) AS avg_meme_engagement_score
+FROM summary_counts
+""",
+    "per_position": """
+SELECT
+    first10_position,
+    COUNT(DISTINCT user_id) AS users,
+    COUNT(*) AS sends,
+    COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+    COUNT(*) FILTER (WHERE reaction_id = 2) AS dislikes,
+    COUNT(*) FILTER (WHERE reaction_id IS NULL) AS unreacted,
+    ROUND(
+        (100.0 * COUNT(*) FILTER (WHERE reaction_id = 1)
+            / NULLIF(COUNT(*) FILTER (WHERE reaction_id IS NOT NULL), 0))::numeric,
+        1
+    ) AS like_rate_pct,
+    ROUND(
+        (100.0 * COUNT(*) FILTER (WHERE continued_within_30m) / NULLIF(COUNT(*), 0))::numeric,
+        1
+    ) AS continuation_pct,
+    ROUND(AVG(first10_engagement_value)::numeric, 3) AS first10_quality_score,
+    ROUND(AVG(meme_engagement_score)::numeric, 3) AS avg_meme_engagement_score
+FROM first10_sends
+GROUP BY first10_position
+ORDER BY first10_position
+""",
+    "per_engine": """
+SELECT
+    recommended_by AS engine,
+    COUNT(DISTINCT user_id) AS users,
+    COUNT(*) AS sends,
+    COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+    COUNT(*) FILTER (WHERE reaction_id = 2) AS dislikes,
+    COUNT(*) FILTER (WHERE reaction_id IS NULL) AS unreacted,
+    ROUND(
+        (100.0 * COUNT(*) FILTER (WHERE reaction_id = 1)
+            / NULLIF(COUNT(*) FILTER (WHERE reaction_id IS NOT NULL), 0))::numeric,
+        1
+    ) AS like_rate_pct,
+    ROUND(
+        (100.0 * COUNT(*) FILTER (WHERE continued_within_30m) / NULLIF(COUNT(*), 0))::numeric,
+        1
+    ) AS continuation_pct,
+    ROUND(AVG(first10_engagement_value)::numeric, 3) AS first10_quality_score,
+    ROUND(AVG(meme_engagement_score)::numeric, 3) AS avg_meme_engagement_score
+FROM first10_sends
+GROUP BY recommended_by
+ORDER BY sends DESC, engine
+""",
+    "segments": """
+, segment_rollups AS (
+    SELECT
+        'source' AS segment_type,
+        COALESCE(source_url, 'unknown') AS segment_value,
+        COUNT(DISTINCT user_id) AS users,
+        COUNT(*) AS sends,
+        COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+        COUNT(*) FILTER (WHERE reaction_id = 2) AS dislikes,
+        COUNT(*) FILTER (WHERE reaction_id IS NULL) AS unreacted,
+        COUNT(*) FILTER (WHERE continued_within_30m) AS continued,
+        AVG(first10_engagement_value) AS first10_quality_score,
+        AVG(meme_engagement_score) AS avg_meme_engagement_score
+    FROM first10_sends
+    GROUP BY source_url
+
+    UNION ALL
+
+    SELECT
+        'meme_type' AS segment_type,
+        COALESCE(meme_type, 'unknown') AS segment_value,
+        COUNT(DISTINCT user_id) AS users,
+        COUNT(*) AS sends,
+        COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+        COUNT(*) FILTER (WHERE reaction_id = 2) AS dislikes,
+        COUNT(*) FILTER (WHERE reaction_id IS NULL) AS unreacted,
+        COUNT(*) FILTER (WHERE continued_within_30m) AS continued,
+        AVG(first10_engagement_value) AS first10_quality_score,
+        AVG(meme_engagement_score) AS avg_meme_engagement_score
+    FROM first10_sends
+    GROUP BY meme_type
+
+    UNION ALL
+
+    SELECT
+        'meme_language' AS segment_type,
+        COALESCE(meme_language_code, 'unknown') AS segment_value,
+        COUNT(DISTINCT user_id) AS users,
+        COUNT(*) AS sends,
+        COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+        COUNT(*) FILTER (WHERE reaction_id = 2) AS dislikes,
+        COUNT(*) FILTER (WHERE reaction_id IS NULL) AS unreacted,
+        COUNT(*) FILTER (WHERE continued_within_30m) AS continued,
+        AVG(first10_engagement_value) AS first10_quality_score,
+        AVG(meme_engagement_score) AS avg_meme_engagement_score
+    FROM first10_sends
+    GROUP BY meme_language_code
+
+    UNION ALL
+
+    SELECT
+        'source_language' AS segment_type,
+        COALESCE(source_language_code, 'unknown') AS segment_value,
+        COUNT(DISTINCT user_id) AS users,
+        COUNT(*) AS sends,
+        COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+        COUNT(*) FILTER (WHERE reaction_id = 2) AS dislikes,
+        COUNT(*) FILTER (WHERE reaction_id IS NULL) AS unreacted,
+        COUNT(*) FILTER (WHERE continued_within_30m) AS continued,
+        AVG(first10_engagement_value) AS first10_quality_score,
+        AVG(meme_engagement_score) AS avg_meme_engagement_score
+    FROM first10_sends
+    GROUP BY source_language_code
+)
+SELECT
+    segment_type,
+    segment_value,
+    users,
+    sends,
+    likes,
+    dislikes,
+    unreacted,
+    ROUND((100.0 * likes / NULLIF(likes + dislikes, 0))::numeric, 1) AS like_rate_pct,
+    ROUND((100.0 * continued / NULLIF(sends, 0))::numeric, 1) AS continuation_pct,
+    ROUND(first10_quality_score::numeric, 3) AS first10_quality_score,
+    ROUND(avg_meme_engagement_score::numeric, 3) AS avg_meme_engagement_score
+FROM segment_rollups
+ORDER BY segment_type, sends DESC, segment_value
+""",
+    "candidate_memes": """
+, meme_rollups AS (
+    SELECT
+        meme_id,
+        MAX(source_url) AS source_url,
+        MAX(meme_type) AS meme_type,
+        MAX(meme_language_code) AS meme_language_code,
+        MIN(first10_position) AS min_first10_position,
+        MAX(first10_position) AS max_first10_position,
+        ROUND(AVG(first10_position)::numeric, 2) AS avg_first10_position,
+        COUNT(DISTINCT user_id) AS users,
+        COUNT(*) AS sends,
+        COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+        COUNT(*) FILTER (WHERE reaction_id = 2) AS dislikes,
+        COUNT(*) FILTER (WHERE reaction_id IS NULL) AS unreacted,
+        COUNT(*) FILTER (WHERE continued_within_30m) AS continued,
+        AVG(first10_engagement_value) AS first10_quality_score,
+        AVG(meme_engagement_score) AS avg_meme_engagement_score,
+        MAX(lr_smoothed) AS lr_smoothed,
+        MAX(historical_likes) AS historical_likes,
+        MAX(historical_dislikes) AS historical_dislikes,
+        MAX(historical_sends) AS historical_sends
+    FROM first10_sends
+    GROUP BY meme_id
+    HAVING COUNT(*) >= :min_candidate_sends
+),
+
+ranked_meme_rollups AS (
+    SELECT
+        MR.*,
+        ROW_NUMBER() OVER (
+            ORDER BY first10_quality_score DESC NULLS LAST, sends DESC, meme_id
+        ) AS top_rank,
+        ROW_NUMBER() OVER (
+            ORDER BY first10_quality_score ASC NULLS LAST, sends DESC, meme_id
+        ) AS bottom_rank
+    FROM meme_rollups MR
+)
+SELECT
+    'top' AS quality_bucket,
+    top_rank AS bucket_rank,
+    meme_id,
+    source_url,
+    meme_type,
+    meme_language_code,
+    min_first10_position,
+    max_first10_position,
+    avg_first10_position,
+    users,
+    sends,
+    likes,
+    dislikes,
+    unreacted,
+    ROUND((100.0 * likes / NULLIF(likes + dislikes, 0))::numeric, 1) AS like_rate_pct,
+    ROUND((100.0 * continued / NULLIF(sends, 0))::numeric, 1) AS continuation_pct,
+    ROUND(first10_quality_score::numeric, 3) AS first10_quality_score,
+    ROUND(avg_meme_engagement_score::numeric, 3) AS avg_meme_engagement_score,
+    lr_smoothed,
+    historical_likes,
+    historical_dislikes,
+    historical_sends
+FROM ranked_meme_rollups
+WHERE top_rank <= :candidate_limit
+
+UNION ALL
+
+SELECT
+    'bottom' AS quality_bucket,
+    bottom_rank AS bucket_rank,
+    meme_id,
+    source_url,
+    meme_type,
+    meme_language_code,
+    min_first10_position,
+    max_first10_position,
+    avg_first10_position,
+    users,
+    sends,
+    likes,
+    dislikes,
+    unreacted,
+    ROUND((100.0 * likes / NULLIF(likes + dislikes, 0))::numeric, 1) AS like_rate_pct,
+    ROUND((100.0 * continued / NULLIF(sends, 0))::numeric, 1) AS continuation_pct,
+    ROUND(first10_quality_score::numeric, 3) AS first10_quality_score,
+    ROUND(avg_meme_engagement_score::numeric, 3) AS avg_meme_engagement_score,
+    lr_smoothed,
+    historical_likes,
+    historical_dislikes,
+    historical_sends
+FROM ranked_meme_rollups
+WHERE bottom_rank <= :candidate_limit
+ORDER BY quality_bucket DESC, bucket_rank
+""",
+}
+
+
+def cold_start_first10_quality_params(
+    *,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    min_candidate_sends: int = DEFAULT_MIN_CANDIDATE_SENDS,
+    candidate_limit: int = DEFAULT_CANDIDATE_LIMIT,
+) -> dict[str, int]:
+    return {
+        "lookback_days": lookback_days,
+        "min_candidate_sends": min_candidate_sends,
+        "candidate_limit": candidate_limit,
+    }
+
+
+def build_cold_start_first10_quality_query(section: ReadoutSection) -> TextClause:
+    return text(f"{_BASE_CTE}\n{_SECTION_SQL[section]}")
+
+
+async def fetch_cold_start_first10_quality_readout(
+    *,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    min_candidate_sends: int = DEFAULT_MIN_CANDIDATE_SENDS,
+    candidate_limit: int = DEFAULT_CANDIDATE_LIMIT,
+) -> dict[ReadoutSection, list[dict[str, Any]]]:
+    from src.database import fetch_all
+
+    params = cold_start_first10_quality_params(
+        lookback_days=lookback_days,
+        min_candidate_sends=min_candidate_sends,
+        candidate_limit=candidate_limit,
+    )
+    readout: dict[ReadoutSection, list[dict[str, Any]]] = {}
+    for section in READOUT_SECTIONS:
+        readout[section] = await fetch_all(
+            build_cold_start_first10_quality_query(section),
+            params,
+        )
+    return readout

--- a/tests/stats/test_cold_start_quality.py
+++ b/tests/stats/test_cold_start_quality.py
@@ -1,7 +1,9 @@
+import os
 from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
+from scripts.cold_start_first10_quality_readout import _configure_database_url
 from tests.factories import (
     cleanup_test_data,
     create_meme,
@@ -134,6 +136,18 @@ async def _fetch_section(section: ReadoutSection, **params):
         candidate_limit=params.get("candidate_limit", 5),
     )
     return await fetch_all(build_cold_start_first10_quality_query(section), readout_params)
+
+
+def test_readout_script_prefers_analyst_database_url(monkeypatch):
+    primary_url = "postgresql" + "://primary.example/db"
+    analyst_url = "postgres" + "://analyst.example/db"
+    expected_url = "postgresql+asyncpg" + "://analyst.example/db"
+    monkeypatch.setenv("DATABASE_URL", primary_url)
+    monkeypatch.setenv("ANALYST_DATABASE_URL", analyst_url)
+
+    _configure_database_url()
+
+    assert os.environ["DATABASE_URL"] == expected_url
 
 
 @pytest.mark.asyncio

--- a/tests/stats/test_cold_start_quality.py
+++ b/tests/stats/test_cold_start_quality.py
@@ -1,0 +1,191 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from tests.factories import (
+    cleanup_test_data,
+    create_meme,
+    create_meme_source,
+    create_meme_stats,
+    create_reaction,
+    create_user,
+)
+
+from src.database import engine, fetch_all
+from src.stats.cold_start_quality import (
+    ReadoutSection,
+    build_cold_start_first10_quality_query,
+    cold_start_first10_quality_params,
+)
+
+T0 = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1)
+
+
+@pytest_asyncio.fixture()
+async def cold_start_readout_data():
+    async with engine.connect() as conn:
+        await create_meme_source(conn, id=10001, url="https://t.me/source_ru", language_code="ru")
+        await create_meme_source(conn, id=10002, url="https://t.me/source_en", language_code="en")
+
+        for meme_id in range(10001, 10021):
+            source_id = 10001 if meme_id % 2 else 10002
+            language_code = "ru" if source_id == 10001 else "en"
+            meme_type = "image" if meme_id % 3 else "animation"
+            await create_meme(
+                conn,
+                id=meme_id,
+                meme_source_id=source_id,
+                type=meme_type,
+                language_code=language_code,
+            )
+            await create_meme_stats(
+                conn,
+                meme_id=meme_id,
+                lr_smoothed=0.1 * (meme_id - 10000),
+                engagement_score=0.05 * (meme_id - 10000),
+            )
+
+        for user_id in range(10001, 10005):
+            await create_user(conn, id=user_id)
+
+        user_10001_reactions = [1, 2, None, 1, 2, 1, 2, 1, 2, 1]
+        for index, reaction_id in enumerate(user_10001_reactions, start=1):
+            sent_at = T0 + timedelta(minutes=index - 1)
+            if index >= 6:
+                sent_at = T0 + timedelta(minutes=39 + index)
+            reacted_at = None
+            if reaction_id is not None:
+                seconds_to_react = 2 if index == 5 else 5
+                reacted_at = sent_at + timedelta(seconds=seconds_to_react)
+            await create_reaction(
+                conn,
+                user_id=10001,
+                meme_id=10000 + index,
+                reaction_id=reaction_id,
+                recommended_by="cold_start_explore" if index <= 5 else "cold_start_adapt",
+                sent_at=sent_at,
+                reacted_at=reacted_at,
+            )
+
+        for index, reaction_id in enumerate([2, 1], start=1):
+            sent_at = T0 + timedelta(hours=2, minutes=index)
+            await create_reaction(
+                conn,
+                user_id=10002,
+                meme_id=10000 + index,
+                reaction_id=reaction_id,
+                recommended_by="cold_start_explore",
+                sent_at=sent_at,
+                reacted_at=sent_at + timedelta(seconds=5),
+            )
+
+        old_sent_at = T0 - timedelta(days=40)
+        await create_reaction(
+            conn,
+            user_id=10003,
+            meme_id=10020,
+            reaction_id=1,
+            recommended_by="goat",
+            sent_at=old_sent_at,
+            reacted_at=old_sent_at + timedelta(seconds=5),
+        )
+        await create_reaction(
+            conn,
+            user_id=10003,
+            meme_id=10001,
+            reaction_id=1,
+            recommended_by="cold_start_explore",
+            sent_at=T0 + timedelta(hours=3),
+            reacted_at=T0 + timedelta(hours=3, seconds=5),
+        )
+
+        await create_reaction(
+            conn,
+            user_id=10004,
+            meme_id=10020,
+            reaction_id=1,
+            recommended_by="share_link",
+            sent_at=T0 + timedelta(hours=4),
+            reacted_at=T0 + timedelta(hours=4, seconds=5),
+        )
+        await create_reaction(
+            conn,
+            user_id=10004,
+            meme_id=10002,
+            reaction_id=1,
+            recommended_by="cold_start_explore",
+            sent_at=T0 + timedelta(hours=4, minutes=1),
+            reacted_at=T0 + timedelta(hours=4, minutes=1, seconds=5),
+        )
+
+        await conn.commit()
+
+    yield
+
+    async with engine.connect() as conn:
+        await cleanup_test_data(conn)
+        await conn.commit()
+
+
+async def _fetch_section(section: ReadoutSection, **params):
+    readout_params = cold_start_first10_quality_params(
+        lookback_days=14,
+        min_candidate_sends=params.get("min_candidate_sends", 1),
+        candidate_limit=params.get("candidate_limit", 5),
+    )
+    return await fetch_all(build_cold_start_first10_quality_query(section), readout_params)
+
+
+@pytest.mark.asyncio
+async def test_summary_uses_true_new_cold_start_cohort(cold_start_readout_data):
+    rows = await _fetch_section("summary")
+
+    assert len(rows) == 1
+    summary = rows[0]
+    assert summary["cohort_users"] == 2
+    assert summary["first_meme_sends"] == 2
+    assert float(summary["first_meme_lr_pct"]) == 50.0
+    assert float(summary["first_meme_continuation_pct"]) == 100.0
+    assert summary["first10_sends"] == 12
+    assert float(summary["first10_lr_pct"]) == pytest.approx(54.5)
+    assert float(summary["first10_continuation_pct"]) == 75.0
+    assert summary["reached5_users"] == 1
+    assert summary["reached10_users"] == 1
+    assert float(summary["second_session_pct"]) == 50.0
+
+
+@pytest.mark.asyncio
+async def test_per_position_uses_sent_at_order_and_skip_semantics(cold_start_readout_data):
+    rows = await _fetch_section("per_position")
+    by_position = {row["first10_position"]: row for row in rows}
+
+    assert sorted(by_position) == list(range(1, 11))
+    position_3 = by_position[3]
+    assert position_3["users"] == 1
+    assert position_3["unreacted"] == 1
+    assert float(position_3["first10_quality_score"]) == pytest.approx(-0.3)
+    assert float(position_3["continuation_pct"]) == 100.0
+
+    position_5 = by_position[5]
+    assert position_5["dislikes"] == 1
+    assert float(position_5["first10_quality_score"]) == pytest.approx(-0.5)
+    assert float(position_5["continuation_pct"]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_engine_segments_and_candidate_memes_are_exposed(cold_start_readout_data):
+    engine_rows = await _fetch_section("per_engine")
+    assert {row["engine"] for row in engine_rows} == {
+        "cold_start_adapt",
+        "cold_start_explore",
+    }
+
+    segment_rows = await _fetch_section("segments")
+    segment_keys = {(row["segment_type"], row["segment_value"]) for row in segment_rows}
+    assert ("meme_type", "image") in segment_keys
+    assert ("meme_language", "ru") in segment_keys
+    assert ("source", "https://t.me/source_ru") in segment_keys
+
+    candidate_rows = await _fetch_section("candidate_memes", candidate_limit=2)
+    assert {row["quality_bucket"] for row in candidate_rows} == {"top", "bottom"}
+    assert all(row["meme_id"] >= 10001 for row in candidate_rows)


### PR DESCRIPTION
Fixes FFM-1869.

## What changed
- Added a repeatable true-new cold-start first-10 readout in `src/stats/cold_start_quality.py`.
- Added `scripts/cold_start_first10_quality_readout.py` for Analyst/ops execution with `ANALYST_DATABASE_URL` support.
- Documented the readout entrypoint in `docs/analyst/README.md`.
- Added focused integration coverage for true-new cohort selection, dormant/non-cold first-send exclusion, `sent_at` ordering, skip scoring, continuation, engine/segment splits, and top/bottom candidate meme output.

## Readout coverage
The readout reports first-meme LR/continuation, first-10 LR/continuation, reached-5, reached-10, second-session, per-position quality, per-engine split, source/type/language segments, and top/bottom first-10 candidate memes.

## Guardrails
- Measurement-only; no ranking, threshold, weight, queue, or experiment-assignment changes.
- Does not touch `recently_liked_blender_v2` logic or readout rules.
- True-new cohort requires each user's first-ever `user_meme_reaction.sent_at` to be a cold-start engine send.

## Verification
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `ruff check --fix scripts/cold_start_first10_quality_readout.py && ruff format scripts/cold_start_first10_quality_readout.py`
- `python3 -m compileall -q src/stats/cold_start_quality.py scripts/cold_start_first10_quality_readout.py tests/stats/test_cold_start_quality.py`

Focused pytest was attempted locally with normalized `DATABASE_URL`, but this workspace DB is not in a clean migrated test state: Alembic hit an existing `user` table and the fixture then failed because `meme_source` was absent. CI should run this against its clean test DB.

## Post-merge handoff
After merge/deploy, Analyst should run:

```bash
source .env
python scripts/cold_start_first10_quality_readout.py --lookback-days 14
```

Then recommend whether the next step should be a cold-start candidate/filter experiment, continued measurement, or rejecting the quality-score hypothesis.
