### PR TITLE
Fix: freeze recently liked v2 enrollment

### DIFF
--- a/experiments/active/2026-05-09-recently-liked-blender-v2.md
+++ b/experiments/active/2026-05-09-recently-liked-blender-v2.md
@@ -1,6 +1,6 @@
 # Experiment: recently_liked Blender V2
 Created: 2026-05-09
-Status: active - implementation delegated
+Status: frozen - passive watch only
 Owner: ceo
 Measure after: after each variant reaches at least 1,000 assigned mature users
 
@@ -15,6 +15,7 @@ The v1 failure is therefore treated as an experiment-design failure, not proof t
 - 2026-05-09 CEO decision from [FFM-1093](/FFM/issues/FFM-1093): open a redesigned v2 A/B instead of immediately re-enabling the v1 weights.
 - CTO implementation delegated in Paperclip to build LR-stratified assignment, high-volume-skipper handling, and explicit sample gates before the experiment can be read.
 - Analyst measurement delegated in Paperclip and blocked on deployment.
+- 2026-07-23T18:05:54Z freeze applied in code via `RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN = True`: existing assignment rows remain readable, but new/unassigned mature users use control weights without creating new experiment assignments. Rollback path: set the freeze constant to `False` and redeploy.
 
 ## Metrics Before
 

--- a/src/recommendations/blender_experiments.py
+++ b/src/recommendations/blender_experiments.py
@@ -21,6 +21,8 @@ RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID = "recently_liked_blender_v2"
 RECENTLY_LIKED_BLENDER_V2_CONTROL = "control"
 RECENTLY_LIKED_BLENDER_V2_TREATMENT = "treatment"
 RECENTLY_LIKED_BLENDER_V2_EXCLUDED = "excluded_high_volume_skipper"
+RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN = True
+RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN_AT = "2026-07-23T18:05:54Z"
 RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT = 1000
 RECENTLY_LIKED_BLENDER_V2_MATURE_MIN_MEMES_SENT = 100
 RECENTLY_LIKED_BLENDER_V2_SKIPPER_MIN_REACTIONS_7D = 50
@@ -334,6 +336,9 @@ async def get_or_assign_recently_liked_blender_v2_variant(user_id: int) -> str:
     )
     if assignment is not None:
         return assignment["variant"]
+
+    if RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN:
+        return RECENTLY_LIKED_BLENDER_V2_CONTROL
 
     metrics = await get_recent_7d_lr_assignment_metrics(user_id)
     if metrics is None:

--- a/tests/recommendations/test_blender_experiments.py
+++ b/tests/recommendations/test_blender_experiments.py
@@ -6,6 +6,7 @@ from src.recommendations.blender_experiments import (
     MATURE_BLENDER_CONTROL_WEIGHTS,
     MATURE_BLENDER_TREATMENT_WEIGHTS,
     RECENTLY_LIKED_BLENDER_V2_CONTROL,
+    RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN_AT,
     RECENTLY_LIKED_BLENDER_V2_EXCLUDED,
     RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID,
     RECENTLY_LIKED_BLENDER_V2_SAMPLE_GATE_PER_VARIANT,
@@ -177,12 +178,47 @@ async def test_existing_recently_liked_blender_v2_assignment_wins():
 
 
 @pytest.mark.asyncio
+async def test_frozen_recently_liked_blender_v2_does_not_assign_new_user():
+    with (
+        patch(
+            "src.recommendations.blender_experiments.get_experiment_assignment",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as get_assignment,
+        patch(
+            "src.recommendations.blender_experiments.get_recent_7d_lr_assignment_metrics",
+            new_callable=AsyncMock,
+        ) as get_metrics,
+        patch(
+            "src.recommendations.blender_experiments.assign_experiment",
+            new_callable=AsyncMock,
+        ) as assign,
+        patch(
+            "src.recommendations.blender_experiments.get_experiment_variant",
+            new_callable=AsyncMock,
+        ) as get_variant,
+    ):
+        variant = await get_or_assign_recently_liked_blender_v2_variant(202)
+
+    assert variant == RECENTLY_LIKED_BLENDER_V2_CONTROL
+    assert RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN_AT == "2026-07-23T18:05:54Z"
+    get_assignment.assert_awaited_once_with(202, RECENTLY_LIKED_BLENDER_V2_EXPERIMENT_ID)
+    get_metrics.assert_not_awaited()
+    assign.assert_not_awaited()
+    get_variant.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_recently_liked_blender_v2_race_rereads_winning_assignment():
     with (
         patch(
             "src.recommendations.blender_experiments.get_experiment_assignment",
             new_callable=AsyncMock,
             return_value=None,
+        ),
+        patch(
+            "src.recommendations.blender_experiments.RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN",
+            False,
         ),
         patch(
             "src.recommendations.blender_experiments.get_recent_7d_lr_assignment_metrics",
@@ -217,6 +253,10 @@ async def test_recently_liked_blender_v2_defers_assignment_without_real_boundari
             "src.recommendations.blender_experiments.get_experiment_assignment",
             new_callable=AsyncMock,
             return_value=None,
+        ),
+        patch(
+            "src.recommendations.blender_experiments.RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN",
+            False,
         ),
         patch(
             "src.recommendations.blender_experiments.get_recent_7d_lr_assignment_metrics",


### PR DESCRIPTION
Fixes FFM-1917.

## What changed
- Added an explicit freeze gate for `recently_liked_blender_v2` new enrollment after the existing assignment read.
- Existing assignment rows still return their saved variant, so Analyst can keep the passive watch on already-assigned users.
- Unassigned mature users now fall back to control mature-feed weights without inserting control/treatment/excluded experiment rows.
- Updated the active experiment record with the freeze timestamp and rollback path.

## Root cause
The assignment path still inserted new `recently_liked_blender_v2` experiment rows after the July 22 checkpoint showed the 1,000-per-arm gate was no longer reachable in a useful window.

## Freeze record
- Freeze recorded at: `2026-07-23T18:05:54Z`
- Effective freeze point: after this PR is merged and deployed from `production`
- Rollback path: set `RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN = False` and redeploy.

## Validation
- `ruff check --fix src/ tests/`
- `ruff format src/ tests/`
- `env DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:65432/postgres REDIS_URL=redis://localhost:36379/0 CORS_ORIGINS='["*"]' CORS_HEADERS='["*"]' TELEGRAM_BOT_TOKEN=test TELEGRAM_BOT_USERNAME=test_bot TELEGRAM_BOT_WEBHOOK_SECRET=test MEME_STORAGE_TELEGRAM_CHAT_ID=1 UPLOADED_MEMES_REVIEW_CHAT_ID=2 ADMIN_LOGS_CHAT_ID=3 ENVIRONMENT=testing python3 -m pytest tests/recommendations/test_blender_experiments.py -q`

## Reviewer notes
Staff Engineer should verify the gate placement preserves existing assignments and does not touch cold-start routing, `cold_start_candidate_filter`, moderator low-sent quota, or unrelated engines. FFM-1918 remains the Analyst post-deploy passive watch.