### PR TITLE
feat: viral_shares blender v1 + delivery prep

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -8,19 +8,18 @@
 
 ## P1 — Growth & feed measurement
 
-### Virality score for ranking
-**What:** First-class meme-level virality signal from share clicks (`user_deep_link_log`) + invites (`invited_count` / `user.inviter_id`), used either as an engine or as a re-ranker on the mature blend.
-**Why:** Organic user growth is the growth north star; LR alone underweights shareable memes.
-**Depends on:** clean attribution defs in `CONTEXT.md` (done).
+### ~~Virality score for ranking~~ — SHIPPED as viral_shares_blender_v1
+**What:** Engine `viral_shares` + mature blend A/B (`viral_shares_blender_v1`). See `experiments/active/2026-08-09-viral-shares-blender-v1.md`.
+**Next:** day-7 readout via `docs/analyst/viral-shares-blender-v1.sql`; decide keep/scale/kill.
 
 ### Per-engine session continuation rate (dashboard)
 **What:** SQL/readout for % of times a user continues scrolling after a meme from each `recommended_by` engine.
 **Why:** Better engine evaluation than LR; aligns with session-length north star.
 **Context:** Measurement patterns exist in archived cold-start / es-ranked experiment notes under `specs/archive/`.
 
-### Share CTA experiment harness
-**What:** All share-button / caption CTA variants go through one delivery-prep module + `experiment_assignment`.
-**Why:** Avoid copy-paste across `senders/meme.py` and `senders/next_message.py`.
+### ~~Share CTA experiment harness~~ — seam landed
+**What:** `src/tgbot/senders/delivery.py` unifies prep for `next_message` + `send_meme_to_user`.
+**Next:** CTA copy/placement experiments only need to touch delivery + `sharing.py`.
 
 ## P2 — Supply side (ETL)
 

--- a/docs/analyst/README.md
+++ b/docs/analyst/README.md
@@ -10,6 +10,8 @@ The Analyst agent monitors product health, tracks experiments, and produces dail
 
 ## Key Files
 - `docs/analyst/metrics.sql` — SQL queries organized by section (health, north star, engines, retention, etc.)
+- `docs/analyst/viral-shares-blender-v1.sql` — readout for `viral_shares_blender_v1` (share clickers + invites vs control).
+- `docs/growth/2026-08-09-viral-shares-blender-v1.md` — experiment design note (also under `experiments/active/` when tracked).
 - `docs/analyst/crossposting.sql` — reusable read-only queries for Telegram channel views/forwards, 24h labels, and pre-posting share signals.
 - `specs/crossposting-share-optimization-2026-05-18.md` — current compact crossposting readout and next experiment gate.
 - `docs/archive/2026-q2/meme-share-button-readout-2026-06-04.md` — share button canary readout; use non-self `m_`/`s_` deep-link clicks, not raw share clicks.

--- a/docs/analyst/viral-shares-blender-v1.sql
+++ b/docs/analyst/viral-shares-blender-v1.sql
@@ -1,0 +1,130 @@
+-- Viral shares blender v1 readout
+-- Experiment: viral_shares_blender_v1
+-- Primary: unique share clickers + new-user invites per 1k memes sent
+-- Guardrails: session depth proxy, like rate
+
+-- 1) Cohort sizes by variant
+SELECT
+  variant,
+  count(*) AS n_users,
+  min(assigned_at) AS first_assigned,
+  max(assigned_at) AS last_assigned
+FROM experiment_assignment
+WHERE experiment_id = 'viral_shares_blender_v1'
+GROUP BY 1
+ORDER BY 1;
+
+-- 2) Exposure + reactions after assignment
+WITH assigned AS (
+  SELECT user_id, variant, assigned_at
+  FROM experiment_assignment
+  WHERE experiment_id = 'viral_shares_blender_v1'
+),
+sent AS (
+  SELECT
+    a.variant,
+    r.user_id,
+    r.meme_id,
+    r.recommended_by,
+    r.sent_at,
+    r.reacted_at,
+    r.reaction_id
+  FROM assigned a
+  JOIN user_meme_reaction r
+    ON r.user_id = a.user_id
+   AND r.sent_at >= a.assigned_at
+)
+SELECT
+  variant,
+  count(*) AS memes_sent,
+  count(*) FILTER (WHERE reaction_id IS NOT NULL) AS reactions,
+  round(
+    100.0 * count(*) FILTER (WHERE reaction_id = 1)
+    / nullif(count(*) FILTER (WHERE reaction_id IS NOT NULL), 0),
+    2
+  ) AS like_rate_pct,
+  count(*) FILTER (WHERE recommended_by = 'viral_shares') AS viral_engine_sends
+FROM sent
+GROUP BY 1
+ORDER BY 1;
+
+-- 3) Share clicks (m_ and s_) on memes sent post-assignment, non-self
+WITH assigned AS (
+  SELECT user_id, variant, assigned_at
+  FROM experiment_assignment
+  WHERE experiment_id = 'viral_shares_blender_v1'
+),
+sent AS (
+  SELECT a.variant, a.user_id AS sharer_user_id, r.meme_id, r.sent_at
+  FROM assigned a
+  JOIN user_meme_reaction r
+    ON r.user_id = a.user_id
+   AND r.sent_at >= a.assigned_at
+),
+clicks AS (
+  SELECT
+    s.variant,
+    udll.user_id AS clicker_id,
+    s.meme_id,
+    s.sharer_user_id
+  FROM user_deep_link_log udll
+  JOIN sent s
+    ON udll.deep_link IN (
+      'm_' || s.sharer_user_id || '_' || s.meme_id,
+      's_' || s.sharer_user_id || '_' || s.meme_id
+    )
+   AND udll.created_at >= s.sent_at
+  WHERE udll.user_id <> s.sharer_user_id
+)
+SELECT
+  s.variant,
+  count(DISTINCT s.sharer_user_id || ':' || s.meme_id) AS meme_sends_proxy,
+  count(*) AS share_clicks,
+  count(DISTINCT c.clicker_id) AS unique_clickers,
+  round(
+    1000.0 * count(DISTINCT c.clicker_id)
+    / nullif(count(*), 0),
+    3
+  ) AS unique_clickers_per_1k_sent_rows
+FROM sent s
+LEFT JOIN clicks c
+  ON c.variant = s.variant
+ AND c.meme_id = s.meme_id
+ AND c.sharer_user_id = s.sharer_user_id
+GROUP BY 1
+ORDER BY 1;
+
+-- 4) New-user invites attributed after assignment (user.inviter_id)
+WITH assigned AS (
+  SELECT user_id, variant, assigned_at
+  FROM experiment_assignment
+  WHERE experiment_id = 'viral_shares_blender_v1'
+),
+invites AS (
+  SELECT a.variant, u.id AS invitee_id, u.created_at
+  FROM assigned a
+  JOIN "user" u
+    ON u.inviter_id = a.user_id
+   AND u.created_at >= a.assigned_at
+)
+SELECT
+  a.variant,
+  count(DISTINCT a.user_id) AS cohort_users,
+  count(i.invitee_id) AS new_invites,
+  round(
+    1000.0 * count(i.invitee_id)
+    / nullif(
+      (
+        SELECT count(*)
+        FROM user_meme_reaction r
+        JOIN assigned ax ON ax.user_id = r.user_id AND r.sent_at >= ax.assigned_at
+        WHERE ax.variant = a.variant
+      ),
+      0
+    ),
+    3
+  ) AS invites_per_1k_sends
+FROM assigned a
+LEFT JOIN invites i ON i.variant = a.variant
+GROUP BY a.variant
+ORDER BY 1;

--- a/docs/growth/2026-08-09-viral-shares-blender-v1.md
+++ b/docs/growth/2026-08-09-viral-shares-blender-v1.md
@@ -1,0 +1,48 @@
+# Experiment: Viral shares blender v1
+
+Created: 2026-08-09  
+Status: active  
+Owner: engineer / analyst  
+Deployed: pending merge  
+Measure after: +7 days and sample_gate_per_variant ≥ 1000
+
+## Hypothesis
+
+Injecting a dedicated `viral_shares` engine (memes ranked by share-click conversion)
+into the mature blend at weight 0.2 (stolen from `lr_smoothed`) increases unique
+share clickers and new-user invites per 1k memes sent without reducing session depth.
+
+## Changes Made
+
+- Engine: `src/recommendations/candidates.py::viral_shares`
+- Experiment: `viral_shares_blender_v1` in `src/recommendations/blender_experiments.py`
+- Wiring: mature path uses `get_mature_blend_weights_with_experiments` (recently_liked v2 base + viral overlay)
+- Delivery prep seam: `src/tgbot/senders/delivery.py` (shared by `next_message` + `send_meme_to_user`)
+- Crosspost fix: share-click CTEs accept both `m_` and `s_` deep links
+
+## Assignment
+
+- Eligible: mature users via existing mature blend path (`nmemes_sent ≥ 100`)
+- Strategy: `sha256(experiment_id:user_id) % 2`
+- Control: base mature weights (after recently_liked v2 assignment)
+- Treatment: base + `viral_shares: 0.2`, `lr_smoothed` reduced by 0.2
+- Sample gate: 1000 users/variant before day-7 read
+
+## Primary metrics
+
+1. Unique non-self share clickers (`user_deep_link_log` m_/s_) per 1k memes sent
+2. New-user invites (`user.inviter_id` attributed in window) per 1k memes sent
+
+## Guardrails
+
+- Median / p50 session length (memes with reaction gap < 30 min)
+- Like rate (7d)
+- Block rate
+
+## Engine slice
+
+Where `recommended_by = 'viral_shares'`: continuation rate vs `lr_smoothed`.
+
+## Readout SQL
+
+See `docs/analyst/viral-shares-blender-v1.sql`.

--- a/docs/growth/virality-loop.md
+++ b/docs/growth/virality-loop.md
@@ -55,15 +55,23 @@ A shippable ranking/growth experiment should have:
 4. **Readout SQL** committed under `docs/analyst/` or `experiments/active/…`
 5. **Control weights** imported from `src/feed_turn/planner.py` (`MATURE_BLEND_WEIGHTS` / `GROWING_BLEND_WEIGHTS`), never copy-pasted.
 
-## Architecture we want next (not done in Wave A)
+## Shipped: viral_shares blender v1 (2026-08-09)
 
-To make product tests cheaper:
+| Piece | Location |
+|-------|----------|
+| Engine | `candidates.viral_shares` — rank by `invited_count / ln(nmemes_sent+e)` |
+| Experiment | `viral_shares_blender_v1` — 0.2 weight from `lr_smoothed` for treatment |
+| Mature wiring | `get_mature_blend_weights_with_experiments` |
+| Delivery prep | `src/tgbot/senders/delivery.py` |
+| Readout | `docs/analyst/viral-shares-blender-v1.sql` |
+| Experiment note | `experiments/active/2026-08-09-viral-shares-blender-v1.md` |
 
-1. **Deepen meme delivery prep** — one module for caption + share button + keyboard so CTA experiments touch one seam.
-2. **Engine template / viral score module** — explicit “virality score” from share clicks + invites + (optional) channel forwards, as a first-class engine or re-ranker, not buried in inline search SQL only.
-3. **Experiment harness** — flags in `config.py` + assignment helpers only; hard-disabled experiments either deleted or gated by settings (no silent `enabled=False` with full code paths).
-4. **VK ETL parity** — same `parsing_enabled` / quality gates as TG so the supply side is comparable.
-5. **Analyst dashboard queries** for weekly: top memes by share-click conversion, engines by continuation, invite funnel by language.
+## Architecture still wanted
+
+1. **VK ETL parity** — same `parsing_enabled` / quality gates as TG.
+2. **Stronger experiment harness** — flags in `config.py`; hard-disabled experiments quarantined.
+3. **Weekly analyst dashboard** — engines by continuation, invite funnel by language.
+4. Optional: meme-level **new-user invite** rate (not only unique clickers via `invited_count`).
 
 ## Related living docs
 

--- a/experiments/active/2026-08-09-viral-shares-blender-v1.md
+++ b/experiments/active/2026-08-09-viral-shares-blender-v1.md
@@ -1,0 +1,48 @@
+# Experiment: Viral shares blender v1
+
+Created: 2026-08-09  
+Status: active  
+Owner: engineer / analyst  
+Deployed: pending merge  
+Measure after: +7 days and sample_gate_per_variant ≥ 1000
+
+## Hypothesis
+
+Injecting a dedicated `viral_shares` engine (memes ranked by share-click conversion)
+into the mature blend at weight 0.2 (stolen from `lr_smoothed`) increases unique
+share clickers and new-user invites per 1k memes sent without reducing session depth.
+
+## Changes Made
+
+- Engine: `src/recommendations/candidates.py::viral_shares`
+- Experiment: `viral_shares_blender_v1` in `src/recommendations/blender_experiments.py`
+- Wiring: mature path uses `get_mature_blend_weights_with_experiments` (recently_liked v2 base + viral overlay)
+- Delivery prep seam: `src/tgbot/senders/delivery.py` (shared by `next_message` + `send_meme_to_user`)
+- Crosspost fix: share-click CTEs accept both `m_` and `s_` deep links
+
+## Assignment
+
+- Eligible: mature users via existing mature blend path (`nmemes_sent ≥ 100`)
+- Strategy: `sha256(experiment_id:user_id) % 2`
+- Control: base mature weights (after recently_liked v2 assignment)
+- Treatment: base + `viral_shares: 0.2`, `lr_smoothed` reduced by 0.2
+- Sample gate: 1000 users/variant before day-7 read
+
+## Primary metrics
+
+1. Unique non-self share clickers (`user_deep_link_log` m_/s_) per 1k memes sent
+2. New-user invites (`user.inviter_id` attributed in window) per 1k memes sent
+
+## Guardrails
+
+- Median / p50 session length (memes with reaction gap < 30 min)
+- Like rate (7d)
+- Block rate
+
+## Engine slice
+
+Where `recommended_by = 'viral_shares'`: continuation rate vs `lr_smoothed`.
+
+## Readout SQL
+
+See `docs/analyst/viral-shares-blender-v1.sql`.

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -288,7 +288,7 @@ _STANDARD_RANKER_QUERY = """
         FROM user_deep_link_log udll
         CROSS JOIN LATERAL (
             SELECT substring(
-                udll.deep_link FROM ('^s_([1-9][0-9]{0,18})_' || ranked.id || '$')
+                udll.deep_link FROM ('^[ms]_([1-9][0-9]{0,18})_' || ranked.id || '$')
             ) AS sharer_id
         ) share_link
         WHERE udll.created_at < selected_at.decided_at
@@ -413,7 +413,7 @@ _SHARE_MAX_QUERY = """
         CROSS JOIN selected_at
         CROSS JOIN LATERAL regexp_matches(
             udll.deep_link,
-            '^s_([1-9][0-9]{0,18})_([1-9][0-9]{0,18})$'
+            '^[ms]_([1-9][0-9]{0,18})_([1-9][0-9]{0,18})$'
         ) AS share_match(parts)
         WHERE udll.created_at < selected_at.decided_at
           AND CASE

--- a/src/recommendations/blender_experiments.py
+++ b/src/recommendations/blender_experiments.py
@@ -440,3 +440,130 @@ async def get_text_light_blender_v1_weights(
     if variant == TEXT_LIGHT_BLENDER_V1_TREATMENT:
         return _text_light_weights(base_weights)
     return dict(base_weights)
+
+
+# --- Viral shares blender v1: inject share-conversion engine into mature blend ---
+
+VIRAL_SHARES_BLENDER_V1_EXPERIMENT_ID = "viral_shares_blender_v1"
+VIRAL_SHARES_BLENDER_V1_CONTROL = "control"
+VIRAL_SHARES_BLENDER_V1_TREATMENT = "treatment_viral_shares"
+VIRAL_SHARES_BLENDER_V1_SAMPLE_GATE_PER_VARIANT = 1000
+VIRAL_SHARES_BLENDER_V1_WEIGHT = 0.2
+VIRAL_SHARES_BLENDER_V1_SOURCE_ENGINE = "lr_smoothed"
+
+
+def _viral_shares_variant_for_user(user_id: int) -> str:
+    key = f"{VIRAL_SHARES_BLENDER_V1_EXPERIMENT_ID}:{user_id}"
+    bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 2
+    if bucket == 0:
+        return VIRAL_SHARES_BLENDER_V1_CONTROL
+    return VIRAL_SHARES_BLENDER_V1_TREATMENT
+
+
+def apply_viral_shares_treatment_weights(base_weights: dict[str, float]) -> dict[str, float]:
+    """Steal weight from lr_smoothed (or next available) into viral_shares."""
+    weights = dict(base_weights)
+    amount = VIRAL_SHARES_BLENDER_V1_WEIGHT
+    source = VIRAL_SHARES_BLENDER_V1_SOURCE_ENGINE
+    available = float(weights.get(source, 0.0))
+    if available >= amount:
+        weights[source] = available - amount
+    else:
+        # Fall back: take from the largest non-viral engine so total mass stays ~constant.
+        weights[source] = 0.0
+        remaining = amount - available
+        donors = sorted(
+            ((k, float(v)) for k, v in weights.items() if k != "viral_shares" and v > 0),
+            key=lambda item: item[1],
+            reverse=True,
+        )
+        for key, value in donors:
+            if remaining <= 0:
+                break
+            take = min(value, remaining)
+            weights[key] = value - take
+            remaining -= take
+    weights["viral_shares"] = float(weights.get("viral_shares", 0.0)) + amount
+    # Drop zero-weight engines so the retriever does not fetch them for nothing.
+    return {k: v for k, v in weights.items() if v > 0}
+
+
+def build_viral_shares_blender_v1_assignment(
+    user_id: int,
+    base_weights: dict[str, float],
+) -> tuple[str, dict[str, Any]]:
+    variant = _viral_shares_variant_for_user(user_id)
+    treatment_weights = apply_viral_shares_treatment_weights(base_weights)
+    assignment_metadata = {
+        "assignment_strategy": "sha256(experiment_id:user_id)%2",
+        "engine": "viral_shares",
+        "weight": VIRAL_SHARES_BLENDER_V1_WEIGHT,
+        "source_engine": VIRAL_SHARES_BLENDER_V1_SOURCE_ENGINE,
+        "sample_gate_per_variant": VIRAL_SHARES_BLENDER_V1_SAMPLE_GATE_PER_VARIANT,
+        "primary_read": (
+            "unique share clickers + new-user invites per 1k memes sent; "
+            "guardrails: session depth, LR, block rate"
+        ),
+        "base_weights": dict(base_weights),
+        "assigned_weights": (
+            treatment_weights
+            if variant == VIRAL_SHARES_BLENDER_V1_TREATMENT
+            else dict(base_weights)
+        ),
+    }
+    return variant, assignment_metadata
+
+
+async def get_or_assign_viral_shares_blender_v1_variant(
+    user_id: int,
+    base_weights: dict[str, float],
+) -> str:
+    assignment = await get_experiment_assignment(
+        user_id,
+        VIRAL_SHARES_BLENDER_V1_EXPERIMENT_ID,
+    )
+    if assignment is not None:
+        return assignment["variant"]
+
+    proposed_variant, assignment_metadata = build_viral_shares_blender_v1_assignment(
+        user_id,
+        base_weights,
+    )
+    inserted = await assign_experiment(
+        user_id,
+        VIRAL_SHARES_BLENDER_V1_EXPERIMENT_ID,
+        proposed_variant,
+        assignment_metadata,
+    )
+    if inserted:
+        return proposed_variant
+
+    return (
+        await get_experiment_variant(user_id, VIRAL_SHARES_BLENDER_V1_EXPERIMENT_ID)
+        or VIRAL_SHARES_BLENDER_V1_CONTROL
+    )
+
+
+async def get_viral_shares_blender_v1_weights(
+    user_id: int,
+    base_weights: dict[str, float],
+) -> dict[str, float]:
+    try:
+        variant = await get_or_assign_viral_shares_blender_v1_variant(user_id, base_weights)
+    except Exception:
+        logger.warning(
+            "viral_shares blender v1 assignment failed for user %d",
+            user_id,
+            exc_info=True,
+        )
+        return dict(base_weights)
+
+    if variant == VIRAL_SHARES_BLENDER_V1_TREATMENT:
+        return apply_viral_shares_treatment_weights(base_weights)
+    return dict(base_weights)
+
+
+async def get_mature_blend_weights_with_experiments(user_id: int) -> dict[str, float]:
+    """Mature blend weights: recently_liked v2 base, then viral_shares overlay."""
+    base = await get_recently_liked_blender_v2_weights(user_id)
+    return await get_viral_shares_blender_v1_weights(user_id, base)

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -603,6 +603,63 @@ async def cold_start_adapt(
     )
 
 
+async def viral_shares(
+    user_id: int,
+    limit: int = 10,
+    exclude_meme_ids: list[int] = [],
+):
+    """Memes with proven share-click conversion (unique non-self deep-link clickers).
+
+    Ranks by invited_count / ln(nmemes_sent + e) so high-volume memes do not
+    dominate purely by raw share-click counts. Quality floor keeps junk out of
+    the growth-oriented blend slot.
+    """
+    query = f"""
+        SELECT
+            M.id
+            , M.type, M.telegram_file_id, M.caption
+            , 'viral_shares' AS recommended_by
+            , COALESCE(MS.nlikes, 0) AS nlikes
+            , COALESCE(MS.invited_count, 0) AS invited_count
+            , COALESCE(MS.nmemes_sent, 0) AS nmemes_sent
+            , COALESCE(MS.lr_smoothed, 0) AS lr_smoothed
+            , (
+                COALESCE(MS.invited_count, 0)::float
+                / LN(COALESCE(MS.nmemes_sent, 0) + 2.718281828)
+              ) AS virality_score
+
+        FROM meme M
+        INNER JOIN meme_stats MS
+            ON MS.meme_id = M.id
+
+        INNER JOIN user_language L
+            ON L.language_code = M.language_code
+            AND L.user_id = :user_id
+
+        LEFT JOIN user_meme_reaction R
+            ON R.meme_id = M.id
+            AND R.user_id = :user_id
+
+        WHERE 1=1
+            AND M.status = 'ok'
+            AND R.meme_id IS NULL
+            AND COALESCE(MS.invited_count, 0) > 0
+            AND COALESCE(MS.nmemes_sent, 0) >= 20
+            AND COALESCE(MS.lr_smoothed, 0) >= 0.05
+            {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+
+        ORDER BY
+            (
+                COALESCE(MS.invited_count, 0)::float
+                / LN(COALESCE(MS.nmemes_sent, 0) + 2.718281828)
+            ) DESC
+            , MS.lr_smoothed DESC NULLS LAST
+            , MS.nlikes DESC NULLS LAST
+        LIMIT :limit
+    """
+    return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))
+
+
 class CandidatesRetriever:
     """CandidatesRetriever class is used for unit testing"""
 
@@ -616,6 +673,7 @@ class CandidatesRetriever:
         "es_ranked": get_es_ranked,
         "cold_start_explore": cold_start_explore,
         "cold_start_adapt": cold_start_adapt,
+        "viral_shares": viral_shares,
     }
 
     async def get_candidates(

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -10,7 +10,7 @@ from src.database import fetch_all, fetch_one
 from src.recommendations.blender import blend
 from src.recommendations.blender_experiments import (
     MATURE_BLENDER_CONTROL_WEIGHTS,
-    get_recently_liked_blender_v2_weights,
+    get_mature_blend_weights_with_experiments,
     get_text_light_blender_v1_weights,
 )
 from src.recommendations.candidates import (
@@ -300,7 +300,7 @@ async def generate_recommendations(
         retriever=retriever,
         blend_func=blend,
         fetch_all_func=fetch_all,
-        mature_weights_func=get_recently_liked_blender_v2_weights,
+        mature_weights_func=get_mature_blend_weights_with_experiments,
         text_light_weights_func=get_text_light_blender_v1_weights,
         mature_control_weights=MATURE_BLENDER_CONTROL_WEIGHTS,
     )

--- a/src/recommendations/pipeline.py
+++ b/src/recommendations/pipeline.py
@@ -25,7 +25,7 @@ from src.observability.sentry import sentry_log_extra
 from src.recommendations.blender import blend as default_blend
 from src.recommendations.blender_experiments import (
     MATURE_BLENDER_CONTROL_WEIGHTS,
-    get_recently_liked_blender_v2_weights,
+    get_mature_blend_weights_with_experiments,
     get_text_light_blender_v1_weights,
 )
 from src.recommendations.candidates import CandidatesRetriever
@@ -280,7 +280,7 @@ class RecommendationBatchPipeline:
         fetch_all_func: FetchAllFunc | None = None,
         low_sent_fetcher: LowSentFetcher | None = None,
         shadow_scorer: ShadowScorer | None = None,
-        mature_weights_func: MatureWeightsFunc = get_recently_liked_blender_v2_weights,
+        mature_weights_func: MatureWeightsFunc = get_mature_blend_weights_with_experiments,
         text_light_weights_func: TextLightWeightsFunc = get_text_light_blender_v1_weights,
         mature_control_weights: Mapping[str, float] = MATURE_BLENDER_CONTROL_WEIGHTS,
     ) -> None:

--- a/src/tgbot/senders/delivery.py
+++ b/src/tgbot/senders/delivery.py
@@ -1,0 +1,70 @@
+"""Single seam for preparing a meme for Telegram delivery.
+
+Both the reaction hot path (`next_message`) and direct send (`send_meme_to_user`)
+must build the same share button + caption + keyboard. CTA / share experiments
+should touch this module only.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from telegram import InlineKeyboardMarkup
+
+from src.storage.schemas import MemeData
+from src.tgbot.senders.keyboards import meme_reaction_keyboard
+from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
+from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
+from src.tgbot.senders.utils import collect_user_languages
+from src.tgbot.sharing import (
+    get_meme_share_button_text,
+    get_or_assign_meme_share_button_variant,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PreparedMemeDelivery:
+    caption: str
+    reply_markup: InlineKeyboardMarkup
+    share_button_variant: str
+    languages: frozenset[str]
+
+
+async def prepare_meme_delivery(
+    *,
+    user_id: int,
+    meme: MemeData,
+    user_info: dict,
+    reaction_context: str | None = None,
+) -> PreparedMemeDelivery:
+    languages = await collect_user_languages(user_id, user_info.get("interface_lang"))
+    referral_button_text = get_meme_share_button_text(user_info.get("interface_lang"))
+    share_button_variant = await get_or_assign_meme_share_button_variant(user_id)
+    logger.debug(
+        "Prepared meme %s for user %s share_button='%s' variant=%s languages=%s",
+        meme.id,
+        user_id,
+        referral_button_text,
+        share_button_variant,
+        sorted(languages),
+    )
+    reply_markup = meme_reaction_keyboard(
+        meme.id,
+        user_id,
+        referral_button_text,
+        visible_like_count=await get_visible_meme_like_count(user_id, meme.nlikes),
+        share_button_variant=share_button_variant,
+        interface_lang=user_info.get("interface_lang"),
+        reaction_context=reaction_context,
+        meme_type=meme.type.value,
+    )
+    caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
+    return PreparedMemeDelivery(
+        caption=caption,
+        reply_markup=reply_markup,
+        share_button_variant=share_button_variant,
+        languages=frozenset(languages),
+    )

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -17,21 +17,12 @@ from src.recommendations.service import create_user_meme_reaction
 from src.storage.constants import MemeType
 from src.storage.schemas import MemeData
 from src.tgbot.bot import bot
-from src.tgbot.senders.keyboards import (
-    meme_reaction_keyboard,
-)
-from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
-from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
+from src.tgbot.senders.delivery import prepare_meme_delivery
 from src.tgbot.senders.popups import (
     get_first_meme_nudge_variant_to_send,
     maybe_send_first_meme_nudge,
 )
-from src.tgbot.senders.utils import collect_user_languages
 from src.tgbot.service import mark_user_blocked
-from src.tgbot.sharing import (
-    get_meme_share_button_text,
-    get_or_assign_meme_share_button_variant,
-)
 from src.tgbot.telegram_retry import telegram_call_with_retry
 from src.tgbot.user_info import get_user_info
 
@@ -46,31 +37,16 @@ async def send_meme_to_user(
     first_meme_nudge_tasks: list[asyncio.Task[None]] | None = None,
 ):
     user_info = await get_user_info(user_id)
-    languages = await collect_user_languages(user_id, user_info["interface_lang"])
     is_first_meme = (user_info["nmemes_sent"] or 0) == 0
-    referral_button_text = get_meme_share_button_text(user_info["interface_lang"])
-    share_button_variant = await get_or_assign_meme_share_button_variant(user_id)
-    logger.debug(
-        "Sending meme %s to user %s with share button '%s' variant=%s (languages=%s)",
-        meme.id,
-        user_id,
-        referral_button_text,
-        share_button_variant,
-        sorted(languages),
-    )
-    reply_markup = meme_reaction_keyboard(
-        meme.id,
-        user_id,
-        referral_button_text,
-        visible_like_count=await get_visible_meme_like_count(user_id, meme.nlikes),
-        share_button_variant=share_button_variant,
-        interface_lang=user_info["interface_lang"],
+    prepared = await prepare_meme_delivery(
+        user_id=user_id,
+        meme=meme,
+        user_info=user_info,
         reaction_context=reaction_context,
-        meme_type=meme.type.value,
     )
-    meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
+    meme.caption = prepared.caption
 
-    sent_message = await send_new_message_with_meme(bot, user_id, meme, reply_markup)
+    sent_message = await send_new_message_with_meme(bot, user_id, meme, prepared.reply_markup)
     if sent_message is None:
         return
 

--- a/src/tgbot/senders/next_message.py
+++ b/src/tgbot/senders/next_message.py
@@ -15,25 +15,16 @@ from src.storage.service import update_meme
 from src.tgbot.constants import Reaction
 from src.tgbot.logs import log
 from src.tgbot.senders.alerts import send_queue_preparing_alert
-from src.tgbot.senders.keyboards import (
-    meme_reaction_keyboard,
-)
+from src.tgbot.senders.delivery import prepare_meme_delivery
 from src.tgbot.senders.meme import (
     edit_last_message_with_meme,
     send_new_message_with_meme,
 )
-from src.tgbot.senders.meme_caption import get_meme_caption_for_user_id
-from src.tgbot.senders.meme_like_count_experiment import get_visible_meme_like_count
 from src.tgbot.senders.popups import (
     get_or_assign_first_meme_nudge_variant,
     get_popup_to_send,
     maybe_send_first_meme_nudge,
     send_popup,
-)
-from src.tgbot.senders.utils import collect_user_languages
-from src.tgbot.sharing import (
-    get_meme_share_button_text,
-    get_or_assign_meme_share_button_variant,
 )
 from src.tgbot.user_info import get_user_info
 
@@ -73,7 +64,6 @@ async def next_message(
     prev_reaction_id: int | None = None,
 ) -> Message:
     user_info = await get_user_info(user_id)
-    languages = await collect_user_languages(user_id, user_info["interface_lang"])
     is_first_meme = (user_info["nmemes_sent"] or 0) == 0
     # TODO: if watched > 30 memes / day show paywall / tasks / donate
 
@@ -100,32 +90,20 @@ async def next_message(
             no_memes_left = True
             break
 
-        referral_button_text = get_meme_share_button_text(user_info["interface_lang"])
-        share_button_variant = await get_or_assign_meme_share_button_variant(user_id)
-        logger.debug(
-            "Next meme %s for user %s uses share button '%s' variant=%s (languages=%s)",
-            meme.id,
-            user_id,
-            referral_button_text,
-            share_button_variant,
-            sorted(languages),
+        prepared = await prepare_meme_delivery(
+            user_id=user_id,
+            meme=meme,
+            user_info=user_info,
         )
-        reply_markup = meme_reaction_keyboard(
-            meme.id,
-            user_id,
-            referral_button_text,
-            visible_like_count=await get_visible_meme_like_count(user_id, meme.nlikes),
-            share_button_variant=share_button_variant,
-            interface_lang=user_info["interface_lang"],
-            meme_type=meme.type.value,
-        )
-        meme.caption = await get_meme_caption_for_user_id(meme, user_id, user_info)
+        meme.caption = prepared.caption
 
         try:
             if should_replace_previous and previous_message is not None:
-                msg = await _replace_previous_message(bot, previous_message, meme, reply_markup)
+                msg = await _replace_previous_message(
+                    bot, previous_message, meme, prepared.reply_markup
+                )
             else:
-                msg = await send_new_message_with_meme(bot, user_id, meme, reply_markup)
+                msg = await send_new_message_with_meme(bot, user_id, meme, prepared.reply_markup)
         except BadRequest as error:
             await _disable_broken_meme(meme, error)
             attempt += 1

--- a/tests/recommendations/test_blender_experiments.py
+++ b/tests/recommendations/test_blender_experiments.py
@@ -15,9 +15,14 @@ from src.recommendations.blender_experiments import (
     TEXT_LIGHT_BLENDER_V1_EXPERIMENT_ID,
     TEXT_LIGHT_BLENDER_V1_MAX_OCR_WORDS,
     TEXT_LIGHT_BLENDER_V1_TREATMENT,
+    VIRAL_SHARES_BLENDER_V1_CONTROL,
+    VIRAL_SHARES_BLENDER_V1_TREATMENT,
+    VIRAL_SHARES_BLENDER_V1_WEIGHT,
     _lr_quartile_from_boundaries,
+    apply_viral_shares_treatment_weights,
     build_recently_liked_blender_v2_assignment,
     build_text_light_blender_v1_assignment,
+    build_viral_shares_blender_v1_assignment,
     get_or_assign_recently_liked_blender_v2_variant,
     get_or_assign_text_light_blender_v1_variant,
     get_recent_7d_lr_assignment_metrics,
@@ -95,6 +100,34 @@ def test_text_light_assignment_replaces_lr_engine_only_for_treatment():
         assert metadata["assigned_weights"]["text_light_lr_smoothed"] == 0.3
     else:
         assert metadata["assigned_weights"] == base_weights
+
+
+def test_viral_shares_treatment_steals_weight_from_lr_smoothed():
+    base_weights = dict(MATURE_BLENDER_CONTROL_WEIGHTS)
+    treated = apply_viral_shares_treatment_weights(base_weights)
+
+    assert treated["viral_shares"] == VIRAL_SHARES_BLENDER_V1_WEIGHT
+    assert treated["lr_smoothed"] == pytest.approx(
+        base_weights["lr_smoothed"] - VIRAL_SHARES_BLENDER_V1_WEIGHT
+    )
+    assert sum(treated.values()) == pytest.approx(sum(base_weights.values()))
+
+
+def test_viral_shares_assignment_is_stable():
+    base_weights = dict(MATURE_BLENDER_CONTROL_WEIGHTS)
+    first, first_meta = build_viral_shares_blender_v1_assignment(909, base_weights)
+    second, second_meta = build_viral_shares_blender_v1_assignment(909, base_weights)
+
+    assert first == second
+    assert first_meta == second_meta
+    assert first in {
+        VIRAL_SHARES_BLENDER_V1_CONTROL,
+        VIRAL_SHARES_BLENDER_V1_TREATMENT,
+    }
+    if first == VIRAL_SHARES_BLENDER_V1_TREATMENT:
+        assert first_meta["assigned_weights"]["viral_shares"] == VIRAL_SHARES_BLENDER_V1_WEIGHT
+    else:
+        assert "viral_shares" not in first_meta["assigned_weights"]
 
 
 def test_lr_quartile_uses_cached_boundaries():

--- a/tests/recommendations/test_engine_contracts.py
+++ b/tests/recommendations/test_engine_contracts.py
@@ -108,6 +108,7 @@ ENGINES_LEFT_JOIN_UMSS = [
     "text_light_lr_smoothed",
     "like_spread_and_recent_memes",
     "es_ranked",
+    "viral_shares",
 ]
 
 # Engines that require user_meme_source_stats via INNER JOIN

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -569,7 +569,7 @@ async def test_generate_above_100():
     with (
         patch("src.recommendations.meme_queue.blend", side_effect=capture_blend),
         patch(
-            "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+            "src.recommendations.meme_queue.get_mature_blend_weights_with_experiments",
             new_callable=AsyncMock,
             return_value=MATURE_BLENDER_CONTROL_WEIGHTS,
         ) as get_weights,
@@ -609,7 +609,7 @@ async def test_generate_above_100_treatment_uses_recently_liked_weights():
 
     with (
         patch(
-            "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+            "src.recommendations.meme_queue.get_mature_blend_weights_with_experiments",
             new_callable=AsyncMock,
             return_value=MATURE_BLENDER_TREATMENT_WEIGHTS,
         ) as get_weights,
@@ -655,7 +655,7 @@ async def test_text_light_blender_v1_is_disabled_in_queue_generation():
 
     with (
         patch(
-            "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+            "src.recommendations.meme_queue.get_mature_blend_weights_with_experiments",
             new_callable=AsyncMock,
             return_value=MATURE_BLENDER_CONTROL_WEIGHTS,
         ),
@@ -695,7 +695,7 @@ async def test_recently_liked_blender_v2_assignment_is_mature_only():
         }
 
     with patch(
-        "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+        "src.recommendations.meme_queue.get_mature_blend_weights_with_experiments",
         new_callable=AsyncMock,
         return_value=MATURE_BLENDER_TREATMENT_WEIGHTS,
     ) as get_weights:
@@ -729,7 +729,7 @@ async def test_recently_liked_blender_v2_skips_moderator_assignment():
 
     with (
         patch(
-            "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+            "src.recommendations.meme_queue.get_mature_blend_weights_with_experiments",
             new_callable=AsyncMock,
             return_value=MATURE_BLENDER_TREATMENT_WEIGHTS,
         ) as get_weights,
@@ -770,7 +770,7 @@ async def test_generate_empty_above_100():
         }
 
     with patch(
-        "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+        "src.recommendations.meme_queue.get_mature_blend_weights_with_experiments",
         new_callable=AsyncMock,
         return_value=MATURE_BLENDER_CONTROL_WEIGHTS,
     ):
@@ -1006,7 +1006,7 @@ async def test_gate_on_mature_user_unchanged():
         _patch_user_info(nsessions=5, nmemes_sent=120),
         patch("src.config.settings.COLD_START_NSESSIONS_GATE_ENABLED", True),
         patch(
-            "src.recommendations.meme_queue.get_recently_liked_blender_v2_weights",
+            "src.recommendations.meme_queue.get_mature_blend_weights_with_experiments",
             new_callable=AsyncMock,
             return_value=MATURE_BLENDER_TREATMENT_WEIGHTS,
         ) as get_weights,

--- a/tests/tgbot/test_delivery_prep.py
+++ b/tests/tgbot/test_delivery_prep.py
@@ -1,0 +1,56 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.storage.constants import MemeType
+from src.storage.schemas import MemeData
+from src.tgbot.senders import delivery
+
+
+@pytest.mark.asyncio
+async def test_prepare_meme_delivery_builds_keyboard_and_caption(monkeypatch):
+    meme = MemeData(
+        id=42,
+        type=MemeType.IMAGE,
+        telegram_file_id="file-id",
+        caption="hello",
+        recommended_by="test",
+        nlikes=7,
+    )
+    user_info = {"interface_lang": "en", "type": "user", "nmemes_sent": 10}
+
+    monkeypatch.setattr(
+        delivery,
+        "collect_user_languages",
+        AsyncMock(return_value={"en"}),
+    )
+    monkeypatch.setattr(delivery, "get_meme_share_button_text", lambda lang: "Share")
+    monkeypatch.setattr(
+        delivery,
+        "get_or_assign_meme_share_button_variant",
+        AsyncMock(return_value="url_share"),
+    )
+    monkeypatch.setattr(
+        delivery,
+        "get_visible_meme_like_count",
+        AsyncMock(return_value=None),
+    )
+    keyboard = MagicMock(name="keyboard")
+    monkeypatch.setattr(delivery, "meme_reaction_keyboard", lambda *a, **k: keyboard)
+    monkeypatch.setattr(
+        delivery,
+        "get_meme_caption_for_user_id",
+        AsyncMock(return_value="caption with link"),
+    )
+
+    prepared = await delivery.prepare_meme_delivery(
+        user_id=1001,
+        meme=meme,
+        user_info=user_info,
+        reaction_context="onboard",
+    )
+
+    assert prepared.caption == "caption with link"
+    assert prepared.reply_markup is keyboard
+    assert prepared.share_button_variant == "url_share"
+    assert prepared.languages == frozenset({"en"})

--- a/tests/tgbot/test_meme_sender.py
+++ b/tests/tgbot/test_meme_sender.py
@@ -7,7 +7,17 @@ from telegram.error import BadRequest, NetworkError
 from src.storage.constants import MemeType
 from src.storage.schemas import MemeData
 from src.tgbot.senders import meme as meme_sender
+from src.tgbot.senders.delivery import PreparedMemeDelivery
 from src.tgbot.senders.meme import edit_last_message_with_meme, send_new_message_with_meme
+
+
+def _prepared_delivery() -> PreparedMemeDelivery:
+    return PreparedMemeDelivery(
+        caption="<b>caption</b>",
+        reply_markup=object(),  # type: ignore[arg-type]
+        share_button_variant="url_share",
+        languages=frozenset({"en"}),
+    )
 
 
 def _meme() -> MemeData:
@@ -110,23 +120,10 @@ async def test_send_meme_to_user_assigns_first_meme_nudge_after_delivery(monkeyp
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
     )
-    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
-    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
     monkeypatch.setattr(
         meme_sender,
-        "get_or_assign_meme_share_button_variant",
-        AsyncMock(return_value="url_share"),
-    )
-    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(
-        meme_sender,
-        "meme_reaction_keyboard",
-        lambda *_args, **_kwargs: object(),
-    )
-    monkeypatch.setattr(
-        meme_sender,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
     monkeypatch.setattr(
@@ -156,23 +153,10 @@ async def test_send_meme_to_user_does_not_assign_first_meme_nudge_on_failed_deli
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
     )
-    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
-    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
     monkeypatch.setattr(
         meme_sender,
-        "get_or_assign_meme_share_button_variant",
-        AsyncMock(return_value="url_share"),
-    )
-    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(
-        meme_sender,
-        "meme_reaction_keyboard",
-        lambda *_args, **_kwargs: object(),
-    )
-    monkeypatch.setattr(
-        meme_sender,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
     monkeypatch.setattr(
@@ -204,23 +188,10 @@ async def test_send_meme_to_user_does_not_assign_first_meme_nudge_on_rejected_de
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
     )
-    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
-    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
     monkeypatch.setattr(
         meme_sender,
-        "get_or_assign_meme_share_button_variant",
-        AsyncMock(return_value="url_share"),
-    )
-    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(
-        meme_sender,
-        "meme_reaction_keyboard",
-        lambda *_args, **_kwargs: object(),
-    )
-    monkeypatch.setattr(
-        meme_sender,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock(return_value=None))
     monkeypatch.setattr(
@@ -261,23 +232,10 @@ async def test_send_meme_to_user_records_delivery_after_nudge_assignment_error(
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
     )
-    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
-    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
     monkeypatch.setattr(
         meme_sender,
-        "get_or_assign_meme_share_button_variant",
-        AsyncMock(return_value="url_share"),
-    )
-    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(
-        meme_sender,
-        "meme_reaction_keyboard",
-        lambda *_args, **_kwargs: object(),
-    )
-    monkeypatch.setattr(
-        meme_sender,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
     monkeypatch.setattr(
@@ -316,23 +274,10 @@ async def test_send_meme_to_user_continues_recording_after_cancellation(monkeypa
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
     )
-    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
-    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
     monkeypatch.setattr(
         meme_sender,
-        "get_or_assign_meme_share_button_variant",
-        AsyncMock(return_value="url_share"),
-    )
-    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(
-        meme_sender,
-        "meme_reaction_keyboard",
-        lambda *_args, **_kwargs: object(),
-    )
-    monkeypatch.setattr(
-        meme_sender,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
     monkeypatch.setattr(
@@ -391,23 +336,10 @@ async def test_send_meme_to_user_continues_post_delivery_after_nudge_assignment_
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
     )
-    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
-    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
     monkeypatch.setattr(
         meme_sender,
-        "get_or_assign_meme_share_button_variant",
-        AsyncMock(return_value="url_share"),
-    )
-    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(
-        meme_sender,
-        "meme_reaction_keyboard",
-        lambda *_args, **_kwargs: object(),
-    )
-    monkeypatch.setattr(
-        meme_sender,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", send_meme)
     monkeypatch.setattr(
@@ -463,23 +395,10 @@ async def test_send_meme_to_user_can_defer_first_meme_nudge_after_reaction(monke
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 0}),
     )
-    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
-    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
     monkeypatch.setattr(
         meme_sender,
-        "get_or_assign_meme_share_button_variant",
-        AsyncMock(return_value="url_share"),
-    )
-    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(
-        meme_sender,
-        "meme_reaction_keyboard",
-        lambda *_args, **_kwargs: object(),
-    )
-    monkeypatch.setattr(
-        meme_sender,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
     monkeypatch.setattr(
@@ -537,23 +456,10 @@ async def test_send_meme_to_user_retries_assigned_undelivered_nudge(monkeypatch)
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 2}),
     )
-    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
-    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
     monkeypatch.setattr(
         meme_sender,
-        "get_or_assign_meme_share_button_variant",
-        AsyncMock(return_value="url_share"),
-    )
-    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(
-        meme_sender,
-        "meme_reaction_keyboard",
-        lambda *_args, **_kwargs: object(),
-    )
-    monkeypatch.setattr(
-        meme_sender,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
     monkeypatch.setattr(
@@ -576,23 +482,10 @@ async def test_send_meme_to_user_does_not_assign_new_nudge_for_returning_user(mo
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 2}),
     )
-    monkeypatch.setattr(meme_sender, "collect_user_languages", AsyncMock(return_value={"en"}))
-    monkeypatch.setattr(meme_sender, "get_meme_share_button_text", lambda _lang: "Share")
     monkeypatch.setattr(
         meme_sender,
-        "get_or_assign_meme_share_button_variant",
-        AsyncMock(return_value="url_share"),
-    )
-    monkeypatch.setattr(meme_sender, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(
-        meme_sender,
-        "meme_reaction_keyboard",
-        lambda *_args, **_kwargs: object(),
-    )
-    monkeypatch.setattr(
-        meme_sender,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(meme_sender, "send_new_message_with_meme", AsyncMock())
     first_meme_nudge_variant = AsyncMock()

--- a/tests/tgbot/test_next_message.py
+++ b/tests/tgbot/test_next_message.py
@@ -7,6 +7,7 @@ from telegram.error import NetworkError
 from src.storage.constants import MemeType
 from src.storage.schemas import MemeData
 from src.tgbot.senders import next_message
+from src.tgbot.senders.delivery import PreparedMemeDelivery
 
 
 def _meme() -> MemeData:
@@ -15,6 +16,15 @@ def _meme() -> MemeData:
         type=MemeType.IMAGE,
         telegram_file_id="photo-file-id",
         caption="<b>caption</b>",
+    )
+
+
+def _prepared_delivery() -> PreparedMemeDelivery:
+    return PreparedMemeDelivery(
+        caption="<b>caption</b>",
+        reply_markup=object(),  # type: ignore[arg-type]
+        share_button_variant="url_share",
+        languages=frozenset({"en"}),
     )
 
 
@@ -32,15 +42,12 @@ async def test_next_message_does_not_try_another_meme_after_ambiguous_send_error
         "get_user_info",
         AsyncMock(return_value={"interface_lang": "en", "nmemes_sent": 1}),
     )
-    monkeypatch.setattr(next_message, "collect_user_languages", AsyncMock(return_value={"en"}))
     monkeypatch.setattr(next_message, "get_popup_to_send", AsyncMock(return_value=None))
     monkeypatch.setattr(next_message, "get_next_meme_for_user", get_next)
-    monkeypatch.setattr(next_message, "get_visible_meme_like_count", AsyncMock(return_value=0))
-    monkeypatch.setattr(next_message, "meme_reaction_keyboard", lambda *_args, **_kwargs: object())
     monkeypatch.setattr(
         next_message,
-        "get_meme_caption_for_user_id",
-        AsyncMock(return_value="<b>caption</b>"),
+        "prepare_meme_delivery",
+        AsyncMock(return_value=_prepared_delivery()),
     )
     monkeypatch.setattr(next_message, "send_new_message_with_meme", send_new)
     monkeypatch.setattr(next_message, "create_user_meme_reaction", create_reaction)


### PR DESCRIPTION
## Summary
- **Chosen design:** dedicated `viral_shares` engine + mature blend A/B (not a silent global boost, not a full re-ranker).
- Ranks by share-click conversion: \`invited_count / ln(nmemes_sent + e)\` with quality floors.
- Experiment \`viral_shares_blender_v1\`: treatment steals 0.2 from \`lr_smoothed\`; composes after recently_liked v2 base weights.
- Delivery prep seam: \`src/tgbot/senders/delivery.py\` shared by \`next_message\` and \`send_meme_to_user\`.
- Crosspost share-click CTEs now match both \`m_\` and \`s_\` deep links (prod emits \`m_\`).
- Readout: \`docs/analyst/viral-shares-blender-v1.sql\` + experiment note under \`docs/growth/\`.

## Why this option
| Option | Decision |
|--------|----------|
| A: viral engine + blend A/B | **Ship** — measurable via \`recommended_by\` + assignment |
| B: stronger global SHARE_CLICK_BOOST | Rejected — unmeasured, confounded |
| C: post-blend re-ranker | Deferred — higher blast radius |
| D: CTA-only | Partial — delivery seam shipped as foundation |

## Test plan
- [x] ruff on touched files
- [ ] CI pytest (engine contracts include \`viral_shares\`; blender assignment unit tests)
- [ ] After merge: confirm mature users get \`experiment_assignment\` rows for \`viral_shares_blender_v1\`
- [ ] Day 7: run analyst SQL; guardrails session length / LR