### PR TITLE
chore: ship recently_liked_v2 treatment as mature default

### DIFF
--- a/docs/analyst/recently-liked-blender-v2-closeout.md
+++ b/docs/analyst/recently-liked-blender-v2-closeout.md
@@ -1,0 +1,51 @@
+# Closeout: recently_liked_blender_v2
+
+**Decision date:** 2026-08-09  
+**Verdict:** **SHIP treatment weights as mature default**  
+**Experiment ID:** `recently_liked_blender_v2`
+
+## Why close now
+
+- Enrollment frozen since ~2026-07-22 (`RECENTLY_LIKED_BLENDER_V2_ENROLLMENT_FROZEN`).
+- Sample gate of 1000/arm is **unreachable** with ~360 mature active users / week.
+- Partial read at ~371 control / 409 treatment is directionally clear and guardrails hold.
+
+## Results (post-assignment, up to 30d sends / 14d sessions)
+
+| Metric | Control | Treatment | Delta |
+|--------|---------|-----------|-------|
+| Users with sends | 371 | 408 | — |
+| Sends | 136 350 | 174 183 | more exposure |
+| Global LR | **63.33%** | **63.67%** | **+0.34pp** |
+| % traffic `recently_liked` | 16.9% | **22.9%** | +6pp (intended) |
+| Median session (14d) | 18 | **19** | **+5.6%** (success bar was +5%) |
+| Avg session | 37.2 | **50.0** | large |
+| Median user LR (≥10 reacts) | 62.65% | **71.08%** | **+8.4pp** |
+| High-volume skippers in arms | 0 | 0 | excluded arm=63 |
+
+Skipper exclusion worked (v1 failure mode fixed).
+
+## Decision
+
+1. **Promote treatment blend to `MATURE_BLEND_WEIGHTS`** (SSOT in `feed_turn/planner.py`).
+2. **Stop dual-path assignment** — `get_recently_liked_blender_v2_weights` returns shipped default only.
+3. Mark experiment **completed** (not cancelled).
+4. Keep historical assignment rows for archaeology; do not re-open with gate 1000.
+
+## Learnings to keep
+
+1. **Stratify by user 7d LR quartile** + exclude high-volume skippers before reading blend experiments.
+2. **Sample gates must match WAU** (~200/arm or 14 days, not 1000) for this product scale.
+3. **Increasing `recently_liked` for mature users can improve session without LR damage** when assignment is clean.
+4. V1 failure was **design/imbalance**, not proof the engine is toxic.
+
+## Shipped weights
+
+```
+best_uploaded_memes: 0.3
+like_spread_and_recent_memes: 0.25
+lr_smoothed: 0.35
+recently_liked: 0.3
+goat: 0.1
+es_ranked: 0.1
+```

--- a/docs/growth/virality-loop.md
+++ b/docs/growth/virality-loop.md
@@ -55,6 +55,13 @@ A shippable ranking/growth experiment should have:
 4. **Readout SQL** committed under `docs/analyst/` or `experiments/active/…`
 5. **Control weights** imported from `src/feed_turn/planner.py` (`MATURE_BLEND_WEIGHTS` / `GROWING_BLEND_WEIGHTS`), never copy-pasted.
 
+## Shipped: recently_liked blender v2 closeout (2026-08-09)
+
+Treatment mature blend is now the **default** (`MATURE_BLEND_WEIGHTS`): more
+`recently_liked` (0.3), slightly less `lr_smoothed` / `like_spread`. Evidence:
+session median +5.6%, user median LR +8pp, global LR flat/slightly up.
+Full readout: [docs/analyst/recently-liked-blender-v2-closeout.md](../analyst/recently-liked-blender-v2-closeout.md).
+
 ## Shipped: viral_shares blender v1 (2026-08-09)
 
 | Piece | Location |

--- a/experiments/completed/2026-05-09-recently-liked-blender-v2.md
+++ b/experiments/completed/2026-05-09-recently-liked-blender-v2.md
@@ -58,7 +58,21 @@ The v1 failure is therefore treated as an experiment-design failure, not proof t
 
 ## Metrics After
 
-Pending deployment and measurement.
+See [docs/analyst/recently-liked-blender-v2-closeout.md](../../docs/analyst/recently-liked-blender-v2-closeout.md).
+
+| Metric | Control | Treatment |
+|--------|---------|-----------|
+| Global LR (30d post-assign) | 63.33% | 63.67% |
+| Median session 14d | 18 | 19 (+5.6%) |
+| Median user LR | 62.65% | 71.08% |
+| recently_liked traffic share | 16.9% | 22.9% |
+
+## Conclusion
+
+**Ship treatment as mature default.** Stratified assignment fixed v1 failure mode.
+Enrollment frozen; sample gate 1000 unreachable at current WAU — closed on partial
+but consistent evidence. Do not re-open without a realistic sample gate.
+
 
 ## Conclusion
 

--- a/src/feed_turn/planner.py
+++ b/src/feed_turn/planner.py
@@ -25,12 +25,15 @@ GROWING_BLEND_WEIGHTS: Mapping[str, float] = MappingProxyType(
         "like_spread_and_recent_memes": 0.2,
     }
 )
+# Shipped 2026-08-09 from recently_liked_blender_v2 treatment (see
+# docs/analyst/recently-liked-blender-v2-closeout.md). Relative weights;
+# blender normalizes.
 MATURE_BLEND_WEIGHTS: Mapping[str, float] = MappingProxyType(
     {
         "best_uploaded_memes": 0.3,
-        "like_spread_and_recent_memes": 0.3,
-        "lr_smoothed": 0.4,
-        "recently_liked": 0.2,
+        "like_spread_and_recent_memes": 0.25,
+        "lr_smoothed": 0.35,
+        "recently_liked": 0.3,
         "goat": 0.1,
         "es_ranked": 0.1,
     }

--- a/src/recommendations/blender_experiments.py
+++ b/src/recommendations/blender_experiments.py
@@ -43,12 +43,16 @@ TEXT_LIGHT_BLENDER_V1_MAX_OCR_WORDS = 30
 TEXT_LIGHT_BLENDER_V1_SAMPLE_GATE_PER_VARIANT = 1000
 
 # Control = default mature plan weights (SSOT in feed_turn.planner).
+# After recently_liked_blender_v2 closeout (2026-08-09), the shipped default IS
+# the former treatment map. Historical treatment alias kept for old tests/docs.
 MATURE_BLENDER_CONTROL_WEIGHTS = dict(MATURE_BLEND_WEIGHTS)
-MATURE_BLENDER_TREATMENT_WEIGHTS = {
+MATURE_BLENDER_TREATMENT_WEIGHTS = dict(MATURE_BLEND_WEIGHTS)
+# Pre-closeout control (for archaeology / partial-read comparisons only).
+MATURE_BLENDER_LEGACY_CONTROL_WEIGHTS = {
     "best_uploaded_memes": 0.3,
-    "like_spread_and_recent_memes": 0.25,
-    "lr_smoothed": 0.35,
-    "recently_liked": 0.3,
+    "like_spread_and_recent_memes": 0.3,
+    "lr_smoothed": 0.4,
+    "recently_liked": 0.2,
     "goat": 0.1,
     "es_ranked": 0.1,
 }
@@ -359,17 +363,14 @@ async def get_or_assign_recently_liked_blender_v2_variant(user_id: int) -> str:
 
 
 async def get_recently_liked_blender_v2_weights(user_id: int) -> dict[str, float]:
-    try:
-        variant = await get_or_assign_recently_liked_blender_v2_variant(user_id)
-    except Exception:
-        logger.warning(
-            "recently_liked blender v2 assignment failed for user %d",
-            user_id,
-            exc_info=True,
-        )
-        return dict(MATURE_BLENDER_CONTROL_WEIGHTS)
+    """Mature blend weights after recently_liked_blender_v2 closeout.
 
-    return _weights_for_variant(variant)
+    Treatment won on session depth and user-level LR with no LR regression
+    (see docs/analyst/recently-liked-blender-v2-closeout.md). All mature users
+    now receive the shipped default; no new assignment / dual-path.
+    """
+    del user_id  # API kept for pipeline mature_weights_func signature
+    return dict(MATURE_BLEND_WEIGHTS)
 
 
 def build_text_light_blender_v1_assignment(

--- a/tests/feed_turn/test_planner.py
+++ b/tests/feed_turn/test_planner.py
@@ -79,11 +79,12 @@ def test_growing_blend_plan():
 def test_mature_blend_plan():
     plan = plan_candidate_selection(100)
 
+    # Shipped recently_liked_blender_v2 treatment as default (2026-08-09).
     assert dict(plan.blend_weights) == {
         "best_uploaded_memes": 0.3,
-        "like_spread_and_recent_memes": 0.3,
-        "lr_smoothed": 0.4,
-        "recently_liked": 0.2,
+        "like_spread_and_recent_memes": 0.25,
+        "lr_smoothed": 0.35,
+        "recently_liked": 0.3,
         "goat": 0.1,
         "es_ranked": 0.1,
     }

--- a/tests/recommendations/test_blender_experiments.py
+++ b/tests/recommendations/test_blender_experiments.py
@@ -313,29 +313,13 @@ async def test_recently_liked_blender_v2_defers_assignment_without_real_boundari
 
 
 @pytest.mark.asyncio
-async def test_recently_liked_blender_v2_weights_fall_back_to_control_on_assignment_error():
-    with patch(
-        "src.recommendations.blender_experiments.get_or_assign_recently_liked_blender_v2_variant",
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("assignment unavailable"),
-    ):
-        weights = await get_recently_liked_blender_v2_weights(100)
+async def test_recently_liked_blender_v2_weights_ship_default_after_closeout():
+    # Experiment closed: no assignment path; always return shipped mature default.
+    weights = await get_recently_liked_blender_v2_weights(100)
 
     assert weights == MATURE_BLENDER_CONTROL_WEIGHTS
-
-
-@pytest.mark.asyncio
-async def test_recently_liked_blender_v2_treatment_increases_recently_liked_weight():
-    with patch(
-        "src.recommendations.blender_experiments.get_or_assign_recently_liked_blender_v2_variant",
-        new_callable=AsyncMock,
-        return_value=RECENTLY_LIKED_BLENDER_V2_TREATMENT,
-    ):
-        weights = await get_recently_liked_blender_v2_weights(100)
-
-    assert weights == MATURE_BLENDER_TREATMENT_WEIGHTS
-    assert weights["recently_liked"] > MATURE_BLENDER_CONTROL_WEIGHTS["recently_liked"]
-    assert weights["lr_smoothed"] < MATURE_BLENDER_CONTROL_WEIGHTS["lr_smoothed"]
+    assert weights["recently_liked"] == 0.3
+    assert weights["lr_smoothed"] == 0.35
 
 
 @pytest.mark.asyncio

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -620,8 +620,10 @@ async def test_generate_above_100_treatment_uses_recently_liked_weights():
         )
 
     assert candidates == [{"id": 4, "recommended_by": "recently_liked"}]
+    # After v2 closeout, treatment weights == shipped control default.
     assert captured_weights == MATURE_BLENDER_TREATMENT_WEIGHTS
-    assert captured_weights["recently_liked"] > MATURE_BLENDER_CONTROL_WEIGHTS["recently_liked"]
+    assert captured_weights == MATURE_BLENDER_CONTROL_WEIGHTS
+    assert captured_weights["recently_liked"] == 0.3
     get_weights.assert_awaited_once_with(TEST_USER_ID)
 
 


### PR DESCRIPTION
## Summary
- **Close** \`recently_liked_blender_v2\` with verdict **SHIP treatment**.
- Evidence (prod readout 2026-08-09): median session 19 vs 18 (+5.6%), median user LR 71% vs 63%, global LR 63.7% vs 63.3%; skipper exclusion worked.
- Sample gate 1000/arm unreachable at ~360 mature actives; enrollment already frozen since July.
- \`MATURE_BLEND_WEIGHTS\` updated; \`get_recently_liked_blender_v2_weights\` always returns shipped default (no dual-path).
- Closeout: \`docs/analyst/recently-liked-blender-v2-closeout.md\`.

## Test plan
- [x] Update planner + blender unit tests for new mature weights
- [ ] CI green
- [ ] After merge: mature users all get treatment-like mix; viral_shares still overlays on top