### PR TITLE
feat: block disliked sources + reco playground

### DIFF
--- a/docs/growth/reco-experiment-platform.md
+++ b/docs/growth/reco-experiment-platform.md
@@ -1,0 +1,179 @@
+# Recommendation experiment platform (plan)
+
+**Status:** design (2026-08-09)  
+**Why:** WAU ~380, mature ~360 — online A/B is slow and underpowered. We need
+offline/shadow eval on existing events + a thin experiment registry so hypotheses
+are cheap to test and hard to mis-measure.
+
+## Goals
+
+1. **Playground** — run a candidate policy against historical `user_meme_reaction`
+   rows without shipping code.
+2. **Systemic experiments** — one registry, one assignment API, realistic sample gates.
+3. **Reliable metrics** — primary + guardrails defined before ship; auto readout SQL.
+4. **Less hardcode** — no more copy-pasted weight maps and silent `enabled=False`.
+
+## Non-goals (v1)
+
+- Full ML training loop / embeddings (later).
+- Perfect multi-armed bandits.
+- Replacing Prefect stats jobs.
+
+---
+
+## Architecture (3 layers, Reels/Twitter-shaped)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Generators (engines)                                   │
+│  viral_shares | lr_smoothed | recently_liked | …        │
+│  pure SQL → list[meme] + diagnostics                    │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+┌───────────────────────▼─────────────────────────────────┐
+│  Policies / filters (hard rules)                        │
+│  unseen | language | block_disliked_sources | diversity │
+│  shared SQL fragments in recommendations/utils.py       │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+┌───────────────────────▼─────────────────────────────────┐
+│  Allocator (blender + maturity plan + experiments)      │
+│  plan = planner(nmemes_sent)                            │
+│  weights = experiment_registry.apply(user, plan)        │
+│  blend(candidates, weights)                             │
+└─────────────────────────────────────────────────────────┘
+```
+
+Hard personalization (negative sources) lives in **policies**, not buried inside
+one engine’s ORDER BY. Soft personalization (affinity multiply) stays in engines.
+
+---
+
+## Playground (offline eval)
+
+### Location
+
+```
+src/recommendations/eval/
+  metrics.py          # pure functions: LR, continuation, avoided-dislike rate
+  replay.py           # load events, apply policy, score
+scripts/reco_eval.py  # CLI: python scripts/reco_eval.py --policy block_disliked --days 7
+```
+
+### Inputs (from prod/analyst DB, read-only)
+
+- `user_meme_reaction` (sent_at, reaction_id, recommended_by)
+- `user_meme_source_stats` (at eval time — approx; true as-of needs history)
+- `meme_stats`, `meme`, `user_language`
+
+### Metrics (always the same set)
+
+| Metric | Definition |
+|--------|------------|
+| **Like rate** | likes / (likes+dislikes) on evaluated impressions |
+| **Avoided-dislike rate** | 1 − (dislikes / sends) among impressions policy would change |
+| **Continuation@30m** | next send within 30m |
+| **Blocked share** | % of historical sends that policy would have blocked |
+| **Empty-pool risk** | % of refill moments with 0 candidates after policy |
+
+### Modes
+
+1. **Counterfactual filter** — “if block_disliked had been on, which past sends vanish; what was their LR?”
+2. **Shadow rank** — re-score a logged candidate set (when we start logging candidates)
+3. **Engine ablation** — drop/add engine weight on a fixed date range (simpler blend replay)
+
+### CLI sketch
+
+```bash
+# Impact of disliked-source block on last 7 days of real sends
+python scripts/reco_eval.py counterfactual-block-disliked \
+  --days 7 --min-reactions 5
+
+# Output: blocked_pct, LR_of_blocked, LR_of_kept, est_session_impact
+```
+
+**Honesty:** without as-of source stats history, we use **current**
+`user_meme_source_stats` as approximation (good enough for v1 triage).
+
+---
+
+## Experiment registry (online)
+
+### Today’s pain
+
+- Assignment helpers duplicated in `blender_experiments.py`
+- Gates of 1000/arm with 360 mature actives
+- Hard-disabled zombies (`text_light`)
+- Weights copy-pasted vs planner SSOT (partially fixed)
+
+### Target
+
+```python
+# src/recommendations/experiments/registry.py
+EXPERIMENTS = {
+  "viral_shares_blender_v1": ViralSharesBlenderV1(),
+  "block_disliked_sources_v1": FeatureFlag("RECOMMENDATION_BLOCK_DISLIKED_SOURCES"),
+}
+
+class Experiment(Protocol):
+    id: str
+    sample_gate_per_arm: int  # default max(150, f(wau))
+    def apply_weights(self, user_id, base_weights) -> dict: ...
+    def apply_flags(self, user_id, flags) -> Flags: ...
+```
+
+Rules:
+
+1. **One entrypoint** for mature weights: `get_mature_blend_weights_with_experiments`
+2. **Base weights only from** `feed_turn.planner`
+3. **Sample gate** = `min(1000, max(150, mature_wau // 2))` or fixed 14 days
+4. **Ship path** = “close experiment” updates planner/flags, assignment returns constant
+
+### Feature flags vs A/B
+
+| Change type | Vehicle |
+|-------------|---------|
+| Clear safety (disliked sources) | **Default ON** + kill switch env |
+| Weight / engine mix | A/B with registry |
+| CTA copy | A/B via `delivery.py` + assignment |
+| Risky demotions | Shadow 3–7d → A/B → ship |
+
+---
+
+## Measurement contract (every online experiment)
+
+Before merge, required files:
+
+1. `experiments/active/YYYY-MM-DD-name.md` — hypothesis, gates, kill rules  
+2. `docs/analyst/<name>.sql` — primary + guardrails  
+3. `recommended_by` or assignment variant for slice  
+
+Primary metrics library:
+
+- Session: median memes / session (30m gap)  
+- Quality: LR, fast-dislike rate  
+- Growth: non-self `m_`/`s_` clicks per 1k sends, new invites  
+- Guardrails: block rate, empty queue rate  
+
+---
+
+## Roadmap
+
+| Phase | Deliverable | Effort |
+|-------|-------------|--------|
+| **0 (this PR)** | `block_disliked_sources` policy in all engines + config kill switch | S |
+| **1** | `scripts/reco_eval.py counterfactual-block-disliked` | S |
+| **2** | Candidate-log sampling (top-K engines per refill) for true shadow rank | M |
+| **3** | Experiment registry refactor (one apply path) | M |
+| **4** | Soft scorer (affinity + virality + exploration budget) | L |
+| **5** | Online bandit / learned rank (only after volume grows) | L |
+
+---
+
+## Relation to growth
+
+Better source selection → less “I hate this channel” → longer sessions → more
+share attempts. It does **not** replace CTA / cold-start / distribution.
+
+Ship hard negative personalization first (cheap, high face-validity), then
+playground so the next ranking ideas don’t each take a quarter of calendar time.

--- a/docs/growth/virality-loop.md
+++ b/docs/growth/virality-loop.md
@@ -55,6 +55,18 @@ A shippable ranking/growth experiment should have:
 4. **Readout SQL** committed under `docs/analyst/` or `experiments/active/…`
 5. **Control weights** imported from `src/feed_turn/planner.py` (`MATURE_BLEND_WEIGHTS` / `GROWING_BLEND_WEIGHTS`), never copy-pasted.
 
+## Shipped: block disliked sources (2026-08-09)
+
+Hard policy: do not recommend memes from sources where the user already has
+`ndislikes > nlikes` after ≥5 reactions (`user_meme_source_stats`).
+Kill switch: `RECOMMENDATION_BLOCK_DISLIKED_SOURCES`.
+
+Offline counterfactual (7d user sends): would remove **~57%** of impressions with
+**LR ~11%** on blocked vs **~82%** on kept; dislike rate on blocked **~89%**.
+
+Playground: `python scripts/reco_eval.py counterfactual-block-disliked --days 7`  
+Platform plan: [reco-experiment-platform.md](reco-experiment-platform.md)
+
 ## Shipped: recently_liked blender v2 closeout (2026-08-09)
 
 Treatment mature blend is now the **default** (`MATURE_BLEND_WEIGHTS`): more

--- a/scripts/reco_eval.py
+++ b/scripts/reco_eval.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Offline reco playground (v1): counterfactual policies on historical sends.
+
+Usage (read-only DB recommended):
+
+  set -a; source .env; set +a
+  python scripts/reco_eval.py counterfactual-block-disliked --days 7
+
+Requires ANALYST_DATABASE_URL or DATABASE_URL. Never prints connection strings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("ANALYST_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        print("Set ANALYST_DATABASE_URL or DATABASE_URL", file=sys.stderr)
+        sys.exit(2)
+    return dsn
+
+
+def cmd_counterfactual_block_disliked(days: int, min_reactions: int) -> None:
+    try:
+        import psycopg2
+        import psycopg2.extras
+    except ImportError:
+        print("psycopg2 required for scripts/reco_eval.py", file=sys.stderr)
+        sys.exit(2)
+
+    dsn = _dsn()
+    sql = """
+    WITH sends AS (
+      SELECT
+        r.user_id,
+        r.meme_id,
+        r.reaction_id,
+        r.recommended_by,
+        m.meme_source_id,
+        umss.nlikes AS src_likes,
+        umss.ndislikes AS src_dislikes
+      FROM user_meme_reaction r
+      JOIN meme m ON m.id = r.meme_id
+      JOIN "user" u ON u.id = r.user_id AND u.type = 'user'
+      LEFT JOIN user_meme_source_stats umss
+        ON umss.user_id = r.user_id
+       AND umss.meme_source_id = m.meme_source_id
+      WHERE r.sent_at > now() - (%s || ' days')::interval
+    ),
+    labeled AS (
+      SELECT
+        *,
+        (
+          src_dislikes IS NOT NULL
+          AND src_dislikes > src_likes
+          AND (src_likes + src_dislikes) >= %s
+        ) AS would_block
+      FROM sends
+    )
+    SELECT
+      count(*) AS total_sends,
+      count(*) FILTER (WHERE would_block) AS would_block_sends,
+      round(100.0 * count(*) FILTER (WHERE would_block) / nullif(count(*),0), 2)
+        AS would_block_pct,
+      round(
+        100.0 * count(*) FILTER (WHERE would_block AND reaction_id = 1)
+        / nullif(count(*) FILTER (WHERE would_block AND reaction_id IS NOT NULL), 0),
+        2
+      ) AS lr_blocked_pct,
+      round(
+        100.0 * count(*) FILTER (WHERE NOT would_block AND reaction_id = 1)
+        / nullif(count(*) FILTER (WHERE NOT would_block AND reaction_id IS NOT NULL), 0),
+        2
+      ) AS lr_kept_pct,
+      round(
+        100.0 * count(*) FILTER (WHERE would_block AND reaction_id = 2)
+        / nullif(count(*) FILTER (WHERE would_block AND reaction_id IS NOT NULL), 0),
+        2
+      ) AS dislike_rate_blocked_pct
+    FROM labeled;
+    """
+    with psycopg2.connect(dsn) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SET statement_timeout = '120s'")
+            cur.execute(sql, (str(days), min_reactions))
+            row = cur.fetchone()
+    print("counterfactual-block-disliked")
+    print(f"  days={days} min_reactions={min_reactions}")
+    for k, v in row.items():
+        print(f"  {k}: {v}")
+    print()
+    print("Interpretation:")
+    print("  would_block_pct ~ share of feed that policy removes.")
+    print("  If lr_blocked_pct << lr_kept_pct, filter removes junk (good).")
+    print("  If dislike_rate_blocked_pct is high, filter targets real negatives.")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Reco offline playground")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p1 = sub.add_parser(
+        "counterfactual-block-disliked",
+        help="Estimate impact of blocking disliked sources on past sends",
+    )
+    p1.add_argument("--days", type=int, default=7)
+    p1.add_argument("--min-reactions", type=int, default=5)
+
+    args = parser.parse_args(argv)
+    if args.cmd == "counterfactual-block-disliked":
+        cmd_counterfactual_block_disliked(args.days, args.min_reactions)
+    else:
+        parser.error(f"unknown command {args.cmd}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config.py
+++ b/src/config.py
@@ -65,6 +65,10 @@ class Config(BaseSettings):
     RECOMMENDATION_DIAGNOSTICS_SAMPLE_RATE: float = 0.01
     RECOMMENDATION_SOURCE_DIVERSITY_ENABLED: bool = False
     RECOMMENDATION_SHADOW_SCORING_ENABLED: bool = True
+    # Hard-filter memes from sources where the user has more dislikes than likes
+    # after enough evidence (see block_disliked_sources_sql_filter).
+    RECOMMENDATION_BLOCK_DISLIKED_SOURCES: bool = True
+    RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS: int = 5
 
     PREFECT_API_URL: str | None = None
     PREFECT_AUTH_STRING: str | None = None

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -5,7 +5,10 @@ from typing import Any
 from sqlalchemy import text
 
 from src.database import fetch_all, fetch_one
-from src.recommendations.utils import exclude_meme_ids_sql_filter
+from src.recommendations.utils import (
+    block_disliked_sources_sql_filter,
+    exclude_meme_ids_sql_filter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +125,7 @@ async def best_uploaded_memes(
             AND R.meme_id IS NULL
             AND S.type = 'user upload'
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+            {block_disliked_sources_sql_filter()}
 
         ORDER BY -1
             * COALESCE((UMSS.nlikes + 1.) / (UMSS.nlikes + UMSS.ndislikes + 1.), 0.5)
@@ -163,6 +167,7 @@ async def like_spread_and_recent_memes(
             AND MS.nlikes > MS.ndislikes
             AND MS.raw_impr_rank = 0
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+            {block_disliked_sources_sql_filter()}
         ORDER BY -1
             * (MS.nlikes - MS.ndislikes) / (MS.nmemes_sent + 1.)
         LIMIT :limit
@@ -221,6 +226,7 @@ async def _get_lr_smoothed_candidates(
             {min_sends_filter}
             {text_light_filter}
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+            {block_disliked_sources_sql_filter()}
 
         ORDER BY -1
             * COALESCE((UMSS.nlikes + 1.) / (UMSS.nlikes + UMSS.ndislikes + 1.), 0.5)
@@ -307,6 +313,7 @@ async def get_es_ranked(
             AND R.meme_id IS NULL
             AND MS.engagement_score > 0
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+            {block_disliked_sources_sql_filter()}
 
         ORDER BY -1
             * COALESCE((UMSS.nlikes + 1.) / (UMSS.nlikes + UMSS.ndislikes + 1.), 0.5)
@@ -390,6 +397,7 @@ async def goat(
 
         WHERE 1=1
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+            {block_disliked_sources_sql_filter()}
         ORDER BY SCORES.score DESC NULLS LAST
         LIMIT :limit
     """
@@ -449,6 +457,7 @@ async def get_recently_liked(
             AND M.status = 'ok'
             AND R.meme_id IS NULL
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+            {block_disliked_sources_sql_filter()}
         LIMIT :limit
     """
     return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))
@@ -505,6 +514,7 @@ async def cold_start_explore(
             {TEXT_LIGHT_OCR_FILTER_SQL}
             {_cold_start_guardrail_source_filter(candidate_guardrails_enabled)}
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+            {block_disliked_sources_sql_filter()}
 
         ORDER BY (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0)) DESC,
                  (MS.nlikes + MS.ndislikes) DESC
@@ -585,6 +595,7 @@ async def cold_start_adapt(
             {TEXT_LIGHT_OCR_FILTER_SQL}
             {_cold_start_guardrail_source_filter(candidate_guardrails_enabled)}
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+            {block_disliked_sources_sql_filter()}
 
         ORDER BY -1
             * GREATEST(COALESCE(RR.raw_weight, 0) + 0.5, 0.1)
@@ -647,6 +658,7 @@ async def viral_shares(
             AND COALESCE(MS.nmemes_sent, 0) >= 20
             AND COALESCE(MS.lr_smoothed, 0) >= 0.05
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
+            {block_disliked_sources_sql_filter()}
 
         ORDER BY
             (

--- a/src/recommendations/utils.py
+++ b/src/recommendations/utils.py
@@ -7,3 +7,42 @@ def exclude_meme_ids_sql_filter(exclude_meme_ids: list[int], meme_id_column: str
     if exclude_meme_ids:
         return f"AND {meme_id_column} != ALL(:exclude_meme_ids)"
     return ""
+
+
+def block_disliked_sources_sql_filter(
+    *,
+    enabled: bool | None = None,
+    min_reactions: int | None = None,
+    meme_source_column: str = "M.meme_source_id",
+) -> str:
+    """Exclude memes from sources the user already dislikes more than likes.
+
+    Uses user_meme_source_stats (updated with reaction stats). Requires at least
+    ``min_reactions`` prior reactions on that source so cold-start noise does
+    not ban a channel after one accidental dislike.
+
+    ``min_reactions`` is validated as int before interpolation (not user input).
+    """
+    if enabled is None:
+        from src.config import settings
+
+        enabled = settings.RECOMMENDATION_BLOCK_DISLIKED_SOURCES
+    if not enabled:
+        return ""
+
+    if min_reactions is None:
+        from src.config import settings
+
+        min_reactions = settings.RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS
+
+    min_reactions = max(1, int(min_reactions))
+    return f"""
+            AND NOT EXISTS (
+                SELECT 1
+                FROM user_meme_source_stats umss_block
+                WHERE umss_block.user_id = :user_id
+                  AND umss_block.meme_source_id = {meme_source_column}
+                  AND umss_block.ndislikes > umss_block.nlikes
+                  AND (umss_block.nlikes + umss_block.ndislikes) >= {min_reactions}
+            )
+    """

--- a/tests/recommendations/test_block_disliked_sources.py
+++ b/tests/recommendations/test_block_disliked_sources.py
@@ -1,0 +1,133 @@
+"""Negative source personalization: block sources the user already dislikes."""
+
+import pytest
+import pytest_asyncio
+from tests.factories import (
+    cleanup_test_data,
+    create_meme,
+    create_meme_source,
+    create_meme_stats,
+    create_user,
+    create_user_language,
+    create_user_meme_source_stats,
+)
+
+from src.database import engine
+from src.recommendations.candidates import CandidatesRetriever
+from src.recommendations.utils import block_disliked_sources_sql_filter
+
+USER_ID = 10001
+SOURCE_GOOD = 10001
+SOURCE_BAD = 10002
+
+
+@pytest_asyncio.fixture()
+async def disliked_source_data():
+    async with engine.connect() as conn:
+        await create_user(conn, id=USER_ID)
+        await create_user_language(conn, user_id=USER_ID, language_code="ru")
+        await create_meme_source(conn, id=SOURCE_GOOD, type="telegram", url="https://t.me/good")
+        await create_meme_source(conn, id=SOURCE_BAD, type="telegram", url="https://t.me/bad")
+
+        # Good source: user likes it
+        await create_user_meme_source_stats(
+            conn, user_id=USER_ID, meme_source_id=SOURCE_GOOD, nlikes=10, ndislikes=1
+        )
+        # Bad source: clear dislike majority with enough evidence
+        await create_user_meme_source_stats(
+            conn, user_id=USER_ID, meme_source_id=SOURCE_BAD, nlikes=1, ndislikes=9
+        )
+
+        for mid in range(10001, 10006):
+            await create_meme(conn, id=mid, meme_source_id=SOURCE_GOOD)
+            await create_meme_stats(
+                conn,
+                meme_id=mid,
+                nlikes=20,
+                ndislikes=5,
+                nmemes_sent=40,
+                lr_smoothed=0.2,
+                engagement_score=0.15,
+                raw_impr_rank=0,
+                invited_count=2,
+            )
+        for mid in range(10011, 10016):
+            await create_meme(conn, id=mid, meme_source_id=SOURCE_BAD)
+            await create_meme_stats(
+                conn,
+                meme_id=mid,
+                nlikes=20,
+                ndislikes=5,
+                nmemes_sent=40,
+                lr_smoothed=0.2,
+                engagement_score=0.15,
+                raw_impr_rank=0,
+                invited_count=2,
+            )
+        await conn.commit()
+
+    yield
+
+    async with engine.connect() as conn:
+        await cleanup_test_data(conn)
+
+
+def test_block_filter_sql_empty_when_disabled():
+    assert block_disliked_sources_sql_filter(enabled=False) == ""
+
+
+def test_block_filter_sql_contains_not_exists_when_enabled():
+    frag = block_disliked_sources_sql_filter(enabled=True, min_reactions=5)
+    assert "NOT EXISTS" in frag
+    assert "umss_block" in frag
+    assert ">= 5" in frag
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "engine_name",
+    [
+        "lr_smoothed",
+        "like_spread_and_recent_memes",
+        "es_ranked",
+        "recently_liked",
+        "viral_shares",
+    ],
+)
+async def test_engines_skip_disliked_sources(disliked_source_data, engine_name, monkeypatch):
+    monkeypatch.setattr(
+        "src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_SOURCES",
+        True,
+    )
+    monkeypatch.setattr(
+        "src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS",
+        5,
+    )
+    # recently_liked needs global likes; seed via reactions is heavy — only check
+    # engines that rank from meme_stats without global like CTE.
+    if engine_name == "recently_liked":
+        pytest.skip("recently_liked depends on global like events not in this fixture")
+
+    retriever = CandidatesRetriever()
+    results = await retriever.get_candidates(engine_name, USER_ID, limit=50)
+    ids = {r["id"] for r in results}
+    bad_ids = set(range(10011, 10016))
+    assert not (ids & bad_ids), (
+        f"{engine_name} returned memes from disliked source: {ids & bad_ids}"
+    )
+    # Should still be able to return good-source memes for stats-based engines
+    if engine_name in {"lr_smoothed", "like_spread_and_recent_memes", "es_ranked"}:
+        assert ids & set(range(10001, 10006)), f"{engine_name} returned no good-source memes"
+
+
+@pytest.mark.asyncio
+async def test_filter_disabled_allows_disliked_source(disliked_source_data, monkeypatch):
+    monkeypatch.setattr(
+        "src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_SOURCES",
+        False,
+    )
+    retriever = CandidatesRetriever()
+    results = await retriever.get_candidates("lr_smoothed", USER_ID, limit=50)
+    ids = {r["id"] for r in results}
+    # Without filter, disliked-source memes may appear (they have same quality stats)
+    assert ids & set(range(10011, 10016)) or ids & set(range(10001, 10006))


### PR DESCRIPTION
## Summary
- **Negative source personalization:** engines skip memes from sources where \`user_meme_source_stats.ndislikes > nlikes\` after ≥5 reactions.
- Shared policy fragment: \`block_disliked_sources_sql_filter()\` in \`recommendations/utils.py\` (all main engines).
- Kill switch: \`RECOMMENDATION_BLOCK_DISLIKED_SOURCES\` (default **true**), \`RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS=5\`.
- **Offline playground v1:** \`scripts/reco_eval.py counterfactual-block-disliked\` — impact on historical sends.
- **Platform plan:** \`docs/growth/reco-experiment-platform.md\` (generators → policies → allocator + registry roadmap).

## Offline evidence (prod 7d, user type=user)
| Metric | Value |
|--------|-------|
| Would block | **56.9%** of sends |
| LR of blocked | **10.7%** |
| LR of kept | **82.1%** |
| Dislike rate of blocked | **89.3%** |

## Risk
Large filter surface — empty-pool risk mitigated by existing engine fallbacks / last_resort. Monitor queue empty rate post-deploy.

## Test plan
- [x] unit SQL fragment tests
- [x] integration: engines hide bad-source memes
- [ ] CI
- [ ] Post-deploy: session length, LR, empty-queue rate 24–48h