### PR TITLE
fix: soft-demote disliked sources (skip ≠ ban)

### DIFF
--- a/docs/analyst/README.md
+++ b/docs/analyst/README.md
@@ -11,6 +11,8 @@ The Analyst agent monitors product health, tracks experiments, and produces dail
 ## Key Files
 - `docs/analyst/metrics.sql` — SQL queries organized by section (health, north star, engines, retention, etc.)
 - `docs/analyst/viral-shares-blender-v1.sql` — readout for `viral_shares_blender_v1` (share clickers + invites vs control).
+- `docs/analyst/dwell-feed-vs-broadcast.sql` — `sec_to_react` percentiles: like vs skip × feed vs broadcast; dwell buckets; demote inventory risk.
+- `docs/analyst/source-affinity-demote-guardrails.sql` — post-deploy volume / LR / broadcast label checks for soft-demote (#340).
 - `docs/growth/2026-08-09-viral-shares-blender-v1.md` — experiment design note (also under `experiments/active/` when tracked).
 - `docs/analyst/crossposting.sql` — reusable read-only queries for Telegram channel views/forwards, 24h labels, and pre-posting share signals.
 - `specs/crossposting-share-optimization-2026-05-18.md` — current compact crossposting readout and next experiment gate.

--- a/docs/analyst/dwell-feed-vs-broadcast.sql
+++ b/docs/analyst/dwell-feed-vs-broadcast.sql
@@ -1,0 +1,259 @@
+-- Dwell / sec_to_react readout: like vs skip × feed vs broadcast
+--
+-- Product context
+--   reaction_id = 1  like (strong positive)
+--   reaction_id = 2  skip / "next" (NOT hard hate)
+--   recommended_by = broadcast_reengagement  → retention push (post-#340)
+--   other recommended_by                    → in-session feed engines
+--
+-- sec_to_react = EXTRACT(EPOCH FROM reacted_at - sent_at)
+-- Long lags (>1h) are usually delayed open / night push, not "watched for an hour".
+-- Use the dwell_bucket column to exclude stale reactions from ranking decisions.
+--
+-- Run via analyst_readonly (ANALYST_DATABASE_URL). Statement timeout 30s —
+-- all queries filter reacted_at / sent_at to hit indexes.
+--
+-- After deploy of soft-demote + broadcast label, re-run section 1–4 weekly.
+
+\set ON_ERROR_STOP on
+
+-- =============================================================================
+-- 0) Params
+-- =============================================================================
+-- Default: last 7 full-ish days of reactions with both timestamps.
+
+-- =============================================================================
+-- 1) Percentiles of sec_to_react by reaction × delivery path
+-- =============================================================================
+WITH base AS (
+  SELECT
+    CASE
+      WHEN recommended_by LIKE 'broadcast%' THEN 'broadcast'
+      ELSE 'feed'
+    END AS delivery_path,
+    CASE reaction_id
+      WHEN 1 THEN 'like'
+      WHEN 2 THEN 'skip'
+      ELSE 'other'
+    END AS reaction,
+    EXTRACT(EPOCH FROM reacted_at - sent_at)::float AS sec_to_react
+  FROM user_meme_reaction
+  WHERE reacted_at > now() - interval '7 days'
+    AND reacted_at IS NOT NULL
+    AND sent_at IS NOT NULL
+    AND reaction_id IN (1, 2)
+    AND reacted_at >= sent_at
+    AND EXTRACT(EPOCH FROM reacted_at - sent_at) BETWEEN 0 AND 86400  -- drop clock noise
+)
+SELECT
+  delivery_path,
+  reaction,
+  count(*) AS n,
+  round(percentile_cont(0.10) WITHIN GROUP (ORDER BY sec_to_react)::numeric, 2) AS p10_s,
+  round(percentile_cont(0.25) WITHIN GROUP (ORDER BY sec_to_react)::numeric, 2) AS p25_s,
+  round(percentile_cont(0.50) WITHIN GROUP (ORDER BY sec_to_react)::numeric, 2) AS p50_s,
+  round(percentile_cont(0.75) WITHIN GROUP (ORDER BY sec_to_react)::numeric, 2) AS p75_s,
+  round(percentile_cont(0.90) WITHIN GROUP (ORDER BY sec_to_react)::numeric, 2) AS p90_s,
+  round(avg(sec_to_react)::numeric, 2) AS mean_s
+FROM base
+GROUP BY 1, 2
+ORDER BY 1, 2;
+
+
+-- =============================================================================
+-- 2) Dwell buckets (for "what to feed ranking")
+-- =============================================================================
+-- Suggested policy buckets:
+--   instant   < 2s     → often skip-without-reading (esp. text-heavy)
+--   quick     2–15s    → typical feed swipe
+--   engaged   15–60s   → read / rewatch / decide
+--   long      60–3600s → come-back-to-meme or share flow
+--   stale     > 3600s  → do not use for content affinity
+
+WITH base AS (
+  SELECT
+    CASE
+      WHEN recommended_by LIKE 'broadcast%' THEN 'broadcast'
+      ELSE 'feed'
+    END AS delivery_path,
+    CASE reaction_id
+      WHEN 1 THEN 'like'
+      WHEN 2 THEN 'skip'
+    END AS reaction,
+    EXTRACT(EPOCH FROM reacted_at - sent_at)::float AS sec
+  FROM user_meme_reaction
+  WHERE reacted_at > now() - interval '7 days'
+    AND reaction_id IN (1, 2)
+    AND reacted_at >= sent_at
+    AND EXTRACT(EPOCH FROM reacted_at - sent_at) BETWEEN 0 AND 86400
+)
+SELECT
+  delivery_path,
+  reaction,
+  CASE
+    WHEN sec < 2 THEN '1_instant_<2s'
+    WHEN sec < 15 THEN '2_quick_2_15s'
+    WHEN sec < 60 THEN '3_engaged_15_60s'
+    WHEN sec < 3600 THEN '4_long_1m_1h'
+    ELSE '5_stale_>1h'
+  END AS dwell_bucket,
+  count(*) AS n,
+  round(100.0 * count(*) / sum(count(*)) OVER (PARTITION BY delivery_path, reaction), 1)
+    AS pct_of_path_reaction
+FROM base
+GROUP BY 1, 2, 3
+ORDER BY 1, 2, 3;
+
+
+-- =============================================================================
+-- 3) Broadcast-specific: how fast do people react to retention pushes?
+-- =============================================================================
+-- Only meaningful after #340 labels new sends as broadcast_reengagement.
+-- Historical rows may still show engine names for push-delivered memes.
+
+SELECT
+  recommended_by,
+  count(*) AS n_reactions,
+  count(*) FILTER (WHERE reaction_id = 1) AS likes,
+  count(*) FILTER (WHERE reaction_id = 2) AS skips,
+  round(
+    100.0 * count(*) FILTER (WHERE reaction_id = 1)
+    / NULLIF(count(*) FILTER (WHERE reaction_id IS NOT NULL), 0),
+    1
+  ) AS like_rate_pct,
+  round(
+    percentile_cont(0.50) WITHIN GROUP (
+      ORDER BY EXTRACT(EPOCH FROM reacted_at - sent_at)
+    ) FILTER (WHERE reaction_id = 1)::numeric,
+    2
+  ) AS like_p50_s,
+  round(
+    percentile_cont(0.50) WITHIN GROUP (
+      ORDER BY EXTRACT(EPOCH FROM reacted_at - sent_at)
+    ) FILTER (WHERE reaction_id = 2)::numeric,
+    2
+  ) AS skip_p50_s,
+  round(
+    100.0 * count(*) FILTER (
+      WHERE EXTRACT(EPOCH FROM reacted_at - sent_at) > 3600
+    ) / NULLIF(count(*), 0),
+    1
+  ) AS pct_stale_gt_1h
+FROM user_meme_reaction
+WHERE sent_at > now() - interval '7 days'
+  AND reacted_at IS NOT NULL
+  AND (
+    recommended_by LIKE 'broadcast%'
+    OR recommended_by IN ('broadcast_reengagement', 'broadcast', 'reengagement')
+  )
+GROUP BY 1
+ORDER BY n_reactions DESC;
+
+
+-- =============================================================================
+-- 4) Feed engines only: like vs skip dwell (exclude broadcasts + unknown)
+-- =============================================================================
+WITH base AS (
+  SELECT
+    recommended_by AS engine,
+    reaction_id,
+    EXTRACT(EPOCH FROM reacted_at - sent_at)::float AS sec
+  FROM user_meme_reaction
+  WHERE reacted_at > now() - interval '7 days'
+    AND reaction_id IN (1, 2)
+    AND reacted_at >= sent_at
+    AND recommended_by NOT LIKE 'broadcast%'
+    AND EXTRACT(EPOCH FROM reacted_at - sent_at) BETWEEN 0.5 AND 3600  -- in-session
+)
+SELECT
+  engine,
+  count(*) AS n,
+  round(100.0 * count(*) FILTER (WHERE reaction_id = 1) / NULLIF(count(*), 0), 1)
+    AS like_rate_pct,
+  round(
+    percentile_cont(0.50) WITHIN GROUP (ORDER BY sec)
+      FILTER (WHERE reaction_id = 1)::numeric,
+    2
+  ) AS like_p50_s,
+  round(
+    percentile_cont(0.50) WITHIN GROUP (ORDER BY sec)
+      FILTER (WHERE reaction_id = 2)::numeric,
+    2
+  ) AS skip_p50_s,
+  round(
+    percentile_cont(0.50) WITHIN GROUP (ORDER BY sec)
+      FILTER (WHERE reaction_id = 1)::numeric
+    - percentile_cont(0.50) WITHIN GROUP (ORDER BY sec)
+      FILTER (WHERE reaction_id = 2)::numeric,
+    2
+  ) AS like_minus_skip_p50_s
+FROM base
+GROUP BY 1
+HAVING count(*) >= 500
+ORDER BY n DESC
+LIMIT 30;
+
+
+-- =============================================================================
+-- 5) Soft-demote inventory risk: how many majority-dislike sources per active user?
+-- =============================================================================
+-- If hard-block were ON (majority dislike, n>=5), this is the share of affinity
+-- rows that would be banned — proxy for empty-queue risk.
+
+WITH active AS (
+  SELECT DISTINCT user_id
+  FROM user_meme_reaction
+  WHERE reacted_at > now() - interval '7 days'
+),
+umss AS (
+  SELECT
+    u.user_id,
+    count(*) AS sources_touched,
+    count(*) FILTER (
+      WHERE s.ndislikes > s.nlikes
+        AND (s.nlikes + s.ndislikes) >= 5
+    ) AS majority_dislike_sources,
+    count(*) FILTER (
+      WHERE s.ndislikes >= 3 * GREATEST(s.nlikes, 1)
+        AND (s.nlikes + s.ndislikes) >= 15
+    ) AS strong_hate_sources
+  FROM active u
+  JOIN user_meme_source_stats s ON s.user_id = u.user_id
+  GROUP BY u.user_id
+)
+SELECT
+  count(*) AS active_users_7d,
+  round(avg(sources_touched)::numeric, 1) AS avg_sources_touched,
+  round(avg(majority_dislike_sources)::numeric, 1) AS avg_majority_dislike_sources,
+  round(avg(strong_hate_sources)::numeric, 1) AS avg_strong_hate_sources,
+  round(
+    100.0 * avg(majority_dislike_sources::float / NULLIF(sources_touched, 0))::numeric,
+    1
+  ) AS avg_pct_sources_majority_dislike,
+  percentile_cont(0.50) WITHIN GROUP (
+    ORDER BY majority_dislike_sources::float / NULLIF(sources_touched, 0)
+  ) AS p50_frac_majority_dislike,
+  percentile_cont(0.90) WITHIN GROUP (
+    ORDER BY majority_dislike_sources::float / NULLIF(sources_touched, 0)
+  ) AS p90_frac_majority_dislike
+FROM umss;
+
+
+-- =============================================================================
+-- 6) Post-deploy guardrail: sends still flowing + broadcast label adoption
+-- =============================================================================
+SELECT
+  date_trunc('hour', sent_at) AS hour_utc,
+  count(*) AS sends,
+  count(*) FILTER (WHERE recommended_by = 'broadcast_reengagement') AS broadcast_labeled,
+  count(*) FILTER (WHERE reaction_id IS NOT NULL) AS reacted,
+  round(
+    100.0 * count(*) FILTER (WHERE reaction_id = 1)
+    / NULLIF(count(*) FILTER (WHERE reaction_id IS NOT NULL), 0),
+    1
+  ) AS like_rate_pct
+FROM user_meme_reaction
+WHERE sent_at > now() - interval '48 hours'
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 48;

--- a/docs/analyst/source-affinity-demote-guardrails.sql
+++ b/docs/analyst/source-affinity-demote-guardrails.sql
@@ -1,0 +1,75 @@
+-- Soft-demote post-deploy guardrails (PR #340)
+--
+-- Policy:
+--   demote ON  — score ×0.15 when ndislikes > nlikes and n>=5
+--   hard block OFF — only opt-in 3× ratio + n>=15
+--
+-- Goals:
+--   1) Feed still producing volume (no empty-queue spike)
+--   2) Like rate stable vs pre-deploy baseline window
+--   3) Strong-hate sources rare; majority-dislike common (must stay soft)
+
+\set ON_ERROR_STOP on
+
+-- 1) Hourly send volume + like rate (last 72h)
+SELECT
+  date_trunc('hour', sent_at) AS hour_utc,
+  count(*) AS sends,
+  count(DISTINCT user_id) AS active_senders,
+  count(*) FILTER (WHERE reaction_id IS NOT NULL) AS reactions,
+  round(
+    100.0 * count(*) FILTER (WHERE reaction_id = 1)
+    / NULLIF(count(*) FILTER (WHERE reaction_id IS NOT NULL), 0),
+    1
+  ) AS like_rate_pct
+FROM user_meme_reaction
+WHERE sent_at > now() - interval '72 hours'
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- 2) Users with very few recent sends but recent activity
+--    (weak empty-queue proxy: reacted recently but almost no new sends)
+WITH recent_reactors AS (
+  SELECT user_id, max(reacted_at) AS last_react
+  FROM user_meme_reaction
+  WHERE reacted_at > now() - interval '24 hours'
+  GROUP BY 1
+),
+recent_sends AS (
+  SELECT user_id, count(*) AS sends_24h
+  FROM user_meme_reaction
+  WHERE sent_at > now() - interval '24 hours'
+  GROUP BY 1
+)
+SELECT
+  count(*) AS reactors_24h,
+  count(*) FILTER (WHERE coalesce(s.sends_24h, 0) < 3) AS low_send_reactors,
+  round(
+    100.0 * count(*) FILTER (WHERE coalesce(s.sends_24h, 0) < 3) / NULLIF(count(*), 0),
+    2
+  ) AS pct_low_send
+FROM recent_reactors r
+LEFT JOIN recent_sends s ON s.user_id = r.user_id;
+
+-- 3) Broadcast label live after deploy
+SELECT
+  recommended_by,
+  count(*) AS n_sent_24h,
+  min(sent_at) AS first_seen,
+  max(sent_at) AS last_seen
+FROM user_meme_reaction
+WHERE sent_at > now() - interval '24 hours'
+  AND recommended_by LIKE 'broadcast%'
+GROUP BY 1
+ORDER BY 2 DESC;
+
+-- 4) Engine mix still diversified (demote should not collapse to one engine)
+SELECT
+  recommended_by,
+  count(*) AS n_sent_24h,
+  round(100.0 * count(*) / sum(count(*)) OVER (), 1) AS pct
+FROM user_meme_reaction
+WHERE sent_at > now() - interval '24 hours'
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 25;

--- a/docs/growth/reco-experiment-platform.md
+++ b/docs/growth/reco-experiment-platform.md
@@ -161,8 +161,9 @@ Primary metrics library:
 
 | Phase | Deliverable | Effort |
 |-------|-------------|--------|
-| **0 (this PR)** | `block_disliked_sources` policy in all engines + config kill switch | S |
+| **0** | Soft **demote** disliked sources (×0.15); hard-block opt-in only | S |
 | **1** | `scripts/reco_eval.py counterfactual-block-disliked` | S |
+| **1b** | Label retention pushes `broadcast_reengagement` for dwell analysis | S |
 | **2** | Candidate-log sampling (top-K engines per refill) for true shadow rank | M |
 | **3** | Experiment registry refactor (one apply path) | M |
 | **4** | Soft scorer (affinity + virality + exploration budget) | L |

--- a/docs/growth/virality-loop.md
+++ b/docs/growth/virality-loop.md
@@ -55,14 +55,22 @@ A shippable ranking/growth experiment should have:
 4. **Readout SQL** committed under `docs/analyst/` or `experiments/active/…`
 5. **Control weights** imported from `src/feed_turn/planner.py` (`MATURE_BLEND_WEIGHTS` / `GROWING_BLEND_WEIGHTS`), never copy-pasted.
 
-## Shipped: block disliked sources (2026-08-09)
+## Source affinity policy (v2, 2026-08-09)
 
-Hard policy: do not recommend memes from sources where the user already has
-`ndislikes > nlikes` after ≥5 reactions (`user_meme_source_stats`).
-Kill switch: `RECOMMENDATION_BLOCK_DISLIKED_SOURCES`.
+**Skip ≠ ban.** Feed dislike is closer to TikTok “next” than “not interested”.
 
-Offline counterfactual (7d user sends): would remove **~57%** of impressions with
-**LR ~11%** on blocked vs **~82%** on kept; dislike rate on blocked **~89%**.
+| Mode | Default | Rule |
+|------|---------|------|
+| **Demote** | ON | score × **0.15** if `ndislikes > nlikes` and n≥5 |
+| **Hard block** | **OFF** | only if enabled and `ndislikes ≥ 3×nlikes` and n≥15 |
+
+Why not hard-block majority-dislike: empties inventory for skip-heavy users;
+counterfactual hard majority-block removed ~57% of sends.
+
+Dwell signal (prod 7d): dislike p50 **6.3s**, like p50 **8.0s**; only ~2–3% of
+reactions arrive after 1h (slow reactions ≈ delayed session / broadcast open).
+
+Broadcasts should set `recommended_by=broadcast_reengagement` for analytics.
 
 Playground: `python scripts/reco_eval.py counterfactual-block-disliked --days 7`  
 Platform plan: [reco-experiment-platform.md](reco-experiment-platform.md)

--- a/src/config.py
+++ b/src/config.py
@@ -65,10 +65,15 @@ class Config(BaseSettings):
     RECOMMENDATION_DIAGNOSTICS_SAMPLE_RATE: float = 0.01
     RECOMMENDATION_SOURCE_DIVERSITY_ENABLED: bool = False
     RECOMMENDATION_SHADOW_SCORING_ENABLED: bool = True
-    # Hard-filter memes from sources where the user has more dislikes than likes
-    # after enough evidence (see block_disliked_sources_sql_filter).
-    RECOMMENDATION_BLOCK_DISLIKED_SOURCES: bool = True
-    RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS: int = 5
+    # Source affinity policies (skip/dislike ≈ "next", not "ban channel").
+    # Soft demote majority-dislike sources in ranking (default ON).
+    RECOMMENDATION_DEMOTE_DISLIKED_SOURCES: bool = True
+    RECOMMENDATION_DEMOTE_DISLIKED_MIN_REACTIONS: int = 5
+    RECOMMENDATION_DEMOTE_DISLIKED_MULTIPLIER: float = 0.15
+    # Hard exclude only strong hate (default OFF — empty-queue risk).
+    RECOMMENDATION_BLOCK_DISLIKED_SOURCES: bool = False
+    RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS: int = 15
+    RECOMMENDATION_BLOCK_DISLIKED_RATIO: float = 3.0  # ndislikes >= 3 * nlikes
 
     PREFECT_API_URL: str | None = None
     PREFECT_AUTH_STRING: str | None = None

--- a/src/flows/broadcasts/meme.py
+++ b/src/flows/broadcasts/meme.py
@@ -48,6 +48,8 @@ class _FirstMemeNudgeTaskList(list[asyncio.Task[None]]):
 async def _send_to_user(
     user_id: int,
     first_meme_nudge_tasks: list[asyncio.Task[None]],
+    *,
+    broadcast_label: str = "broadcast_reengagement",
 ) -> None:
     await check_queue(user_id)
     meme = await get_next_meme_for_user(user_id)
@@ -57,6 +59,9 @@ async def _send_to_user(
             user_id,
             meme,
             first_meme_nudge_tasks=first_meme_nudge_tasks,
+            # Distinguish retention pushes from in-session feed for analytics
+            # (dwell / sec_to_react distributions differ by delivery path).
+            recommended_by=broadcast_label,
         )
 
 

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -7,6 +7,7 @@ from sqlalchemy import text
 from src.database import fetch_all, fetch_one
 from src.recommendations.utils import (
     block_disliked_sources_sql_filter,
+    disliked_source_demote_sql,
     exclude_meme_ids_sql_filter,
 )
 
@@ -129,6 +130,7 @@ async def best_uploaded_memes(
 
         ORDER BY -1
             * COALESCE((UMSS.nlikes + 1.) / (UMSS.nlikes + UMSS.ndislikes + 1.), 0.5)
+            * {disliked_source_demote_sql()}
             * (MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1.)
         NULLS LAST
         LIMIT :limit
@@ -160,6 +162,10 @@ async def like_spread_and_recent_memes(
                 ON R.meme_id = M.id
                 AND R.user_id = :user_id
 
+        LEFT JOIN user_meme_source_stats UMSS
+            ON UMSS.meme_source_id = M.meme_source_id
+            AND UMSS.user_id = :user_id
+
         WHERE 1=1
             AND M.status = 'ok'
             AND R.meme_id IS NULL
@@ -170,6 +176,7 @@ async def like_spread_and_recent_memes(
             {block_disliked_sources_sql_filter()}
         ORDER BY -1
             * (MS.nlikes - MS.ndislikes) / (MS.nmemes_sent + 1.)
+            * {disliked_source_demote_sql()}
         LIMIT :limit
     """
     return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))
@@ -230,6 +237,7 @@ async def _get_lr_smoothed_candidates(
 
         ORDER BY -1
             * COALESCE((UMSS.nlikes + 1.) / (UMSS.nlikes + UMSS.ndislikes + 1.), 0.5)
+            * {disliked_source_demote_sql()}
             * MS.lr_smoothed
         LIMIT :limit
     """
@@ -317,6 +325,7 @@ async def get_es_ranked(
 
         ORDER BY -1
             * COALESCE((UMSS.nlikes + 1.) / (UMSS.nlikes + UMSS.ndislikes + 1.), 0.5)
+            * {disliked_source_demote_sql()}
             * MS.engagement_score
         LIMIT :limit
     """
@@ -361,6 +370,7 @@ async def goat(
                     * CASE WHEN MS.raw_impr_rank < 1 THEN 1 ELSE 0.8 END
                     * (MSS.nlikes + MSS.ndislikes)::float / (MSS.nmemes_sent_events + 1.)
                     * (UMSS.nlikes + 1.)::float / (UMSS.nlikes + UMSS.ndislikes + 1.)
+                    * {disliked_source_demote_sql()}
                 ) AS score
             FROM meme M
             INNER JOIN meme_stats MS
@@ -453,11 +463,17 @@ async def get_recently_liked(
             ON R.meme_id = M.id
             AND R.user_id = :user_id
 
+        LEFT JOIN user_meme_source_stats UMSS
+            ON UMSS.meme_source_id = M.meme_source_id
+            AND UMSS.user_id = :user_id
+
         WHERE 1=1
             AND M.status = 'ok'
             AND R.meme_id IS NULL
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
             {block_disliked_sources_sql_filter()}
+        -- Prefer non-disliked sources first (demote mult 1.0 before 0.15)
+        ORDER BY {disliked_source_demote_sql()} DESC, M.id DESC
         LIMIT :limit
     """
     return await fetch_all(text(query), _build_params(user_id, limit, exclude_meme_ids))
@@ -651,6 +667,10 @@ async def viral_shares(
             ON R.meme_id = M.id
             AND R.user_id = :user_id
 
+        LEFT JOIN user_meme_source_stats UMSS
+            ON UMSS.meme_source_id = M.meme_source_id
+            AND UMSS.user_id = :user_id
+
         WHERE 1=1
             AND M.status = 'ok'
             AND R.meme_id IS NULL
@@ -664,7 +684,7 @@ async def viral_shares(
             (
                 COALESCE(MS.invited_count, 0)::float
                 / LN(COALESCE(MS.nmemes_sent, 0) + 2.718281828)
-            ) DESC
+            ) * {disliked_source_demote_sql()} DESC
             , MS.lr_smoothed DESC NULLS LAST
             , MS.nlikes DESC NULLS LAST
         LIMIT :limit

--- a/src/recommendations/utils.py
+++ b/src/recommendations/utils.py
@@ -13,15 +13,16 @@ def block_disliked_sources_sql_filter(
     *,
     enabled: bool | None = None,
     min_reactions: int | None = None,
+    min_dislike_to_like_ratio: float | None = None,
     meme_source_column: str = "M.meme_source_id",
 ) -> str:
-    """Exclude memes from sources the user already dislikes more than likes.
+    """Hard-exclude sources the user clearly hates (optional, off by default).
 
-    Uses user_meme_source_stats (updated with reaction stats). Requires at least
-    ``min_reactions`` prior reactions on that source so cold-start noise does
-    not ban a channel after one accidental dislike.
+    Skip/dislike in the feed UI is closer to TikTok "next" than "not interested".
+    Hard exclusion of every majority-dislike source empties pools and treats skips
+    as bans. Prefer :func:`disliked_source_demote_sql` for ranking demotion.
 
-    ``min_reactions`` is validated as int before interpolation (not user input).
+    Hard block only when ``ndislikes >= ratio * nlikes`` with enough reactions.
     """
     if enabled is None:
         from src.config import settings
@@ -34,15 +35,62 @@ def block_disliked_sources_sql_filter(
         from src.config import settings
 
         min_reactions = settings.RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS
+    if min_dislike_to_like_ratio is None:
+        from src.config import settings
+
+        min_dislike_to_like_ratio = settings.RECOMMENDATION_BLOCK_DISLIKED_RATIO
 
     min_reactions = max(1, int(min_reactions))
+    ratio = float(min_dislike_to_like_ratio)
+    # ratio is config float, not user input
     return f"""
             AND NOT EXISTS (
                 SELECT 1
                 FROM user_meme_source_stats umss_block
                 WHERE umss_block.user_id = :user_id
                   AND umss_block.meme_source_id = {meme_source_column}
-                  AND umss_block.ndislikes > umss_block.nlikes
                   AND (umss_block.nlikes + umss_block.ndislikes) >= {min_reactions}
+                  AND umss_block.ndislikes >= {ratio} * GREATEST(umss_block.nlikes, 1)
             )
+    """
+
+
+def disliked_source_demote_sql(
+    umss_alias: str = "UMSS",
+    *,
+    enabled: bool | None = None,
+    min_reactions: int | None = None,
+    multiplier: float | None = None,
+) -> str:
+    """SQL expression (not AND-clause): score multiplier for soft-disliked sources.
+
+    Multiply into ORDER BY so majority-dislike sources are deprioritized but not
+    removed — keeps the feed full for heavy skippers.
+    """
+    if enabled is None:
+        from src.config import settings
+
+        enabled = settings.RECOMMENDATION_DEMOTE_DISLIKED_SOURCES
+    if not enabled:
+        return "1.0"
+
+    if min_reactions is None:
+        from src.config import settings
+
+        min_reactions = settings.RECOMMENDATION_DEMOTE_DISLIKED_MIN_REACTIONS
+    if multiplier is None:
+        from src.config import settings
+
+        multiplier = settings.RECOMMENDATION_DEMOTE_DISLIKED_MULTIPLIER
+
+    min_reactions = max(1, int(min_reactions))
+    multiplier = float(multiplier)
+    return f"""
+            CASE
+                WHEN {umss_alias}.ndislikes IS NOT NULL
+                    AND {umss_alias}.ndislikes > {umss_alias}.nlikes
+                    AND ({umss_alias}.nlikes + {umss_alias}.ndislikes) >= {min_reactions}
+                THEN {multiplier}
+                ELSE 1.0
+            END
     """

--- a/src/tgbot/senders/meme.py
+++ b/src/tgbot/senders/meme.py
@@ -35,9 +35,17 @@ async def send_meme_to_user(
     meme: MemeData,
     reaction_context: str | None = None,
     first_meme_nudge_tasks: list[asyncio.Task[None]] | None = None,
+    recommended_by: str | None = None,
 ):
+    """Send a meme to a user.
+
+    ``recommended_by`` overrides the queue label when recording delivery
+    (e.g. ``broadcast_reengagement`` for retention pushes).
+    """
     user_info = await get_user_info(user_id)
     is_first_meme = (user_info["nmemes_sent"] or 0) == 0
+    if recommended_by:
+        meme.recommended_by = recommended_by
     prepared = await prepare_meme_delivery(
         user_id=user_id,
         meme=meme,

--- a/tests/recommendations/test_block_disliked_sources.py
+++ b/tests/recommendations/test_block_disliked_sources.py
@@ -1,4 +1,4 @@
-"""Negative source personalization: block sources the user already dislikes."""
+"""Source affinity policies: demote (default) vs hard-block (optional)."""
 
 import pytest
 import pytest_asyncio
@@ -14,7 +14,10 @@ from tests.factories import (
 
 from src.database import engine
 from src.recommendations.candidates import CandidatesRetriever
-from src.recommendations.utils import block_disliked_sources_sql_filter
+from src.recommendations.utils import (
+    block_disliked_sources_sql_filter,
+    disliked_source_demote_sql,
+)
 
 USER_ID = 10001
 SOURCE_GOOD = 10001
@@ -29,13 +32,12 @@ async def disliked_source_data():
         await create_meme_source(conn, id=SOURCE_GOOD, type="telegram", url="https://t.me/good")
         await create_meme_source(conn, id=SOURCE_BAD, type="telegram", url="https://t.me/bad")
 
-        # Good source: user likes it
         await create_user_meme_source_stats(
             conn, user_id=USER_ID, meme_source_id=SOURCE_GOOD, nlikes=10, ndislikes=1
         )
-        # Bad source: clear dislike majority with enough evidence
+        # Soft majority dislike (demote), not 3x hate (hard block)
         await create_user_meme_source_stats(
-            conn, user_id=USER_ID, meme_source_id=SOURCE_BAD, nlikes=1, ndislikes=9
+            conn, user_id=USER_ID, meme_source_id=SOURCE_BAD, nlikes=2, ndislikes=8
         )
 
         for mid in range(10001, 10006):
@@ -72,62 +74,67 @@ async def disliked_source_data():
         await cleanup_test_data(conn)
 
 
-def test_block_filter_sql_empty_when_disabled():
+def test_hard_block_off_by_default_string():
+    # Explicit disabled
     assert block_disliked_sources_sql_filter(enabled=False) == ""
 
 
-def test_block_filter_sql_contains_not_exists_when_enabled():
-    frag = block_disliked_sources_sql_filter(enabled=True, min_reactions=5)
+def test_hard_block_requires_ratio_when_enabled():
+    frag = block_disliked_sources_sql_filter(
+        enabled=True, min_reactions=15, min_dislike_to_like_ratio=3.0
+    )
     assert "NOT EXISTS" in frag
-    assert "umss_block" in frag
-    assert ">= 5" in frag
+    assert ">= 15" in frag
+    assert "3.0" in frag or "3." in frag
+
+
+def test_demote_sql_returns_case_expression():
+    frag = disliked_source_demote_sql(enabled=True, min_reactions=5, multiplier=0.15)
+    assert "CASE" in frag
+    assert "0.15" in frag
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "engine_name",
-    [
-        "lr_smoothed",
-        "like_spread_and_recent_memes",
-        "es_ranked",
-        "recently_liked",
-        "viral_shares",
-    ],
-)
-async def test_engines_skip_disliked_sources(disliked_source_data, engine_name, monkeypatch):
-    monkeypatch.setattr(
-        "src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_SOURCES",
-        True,
-    )
-    monkeypatch.setattr(
-        "src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS",
-        5,
-    )
-    # recently_liked needs global likes; seed via reactions is heavy — only check
-    # engines that rank from meme_stats without global like CTE.
-    if engine_name == "recently_liked":
-        pytest.skip("recently_liked depends on global like events not in this fixture")
+async def test_hard_block_disabled_still_returns_bad_source_candidates(
+    disliked_source_data, monkeypatch
+):
+    """Default hard-block OFF: majority-dislike sources remain eligible (demoted only)."""
+    monkeypatch.setattr("src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_SOURCES", False)
+    monkeypatch.setattr("src.config.settings.RECOMMENDATION_DEMOTE_DISLIKED_SOURCES", True)
 
-    retriever = CandidatesRetriever()
-    results = await retriever.get_candidates(engine_name, USER_ID, limit=50)
-    ids = {r["id"] for r in results}
-    bad_ids = set(range(10011, 10016))
-    assert not (ids & bad_ids), (
-        f"{engine_name} returned memes from disliked source: {ids & bad_ids}"
-    )
-    # Should still be able to return good-source memes for stats-based engines
-    if engine_name in {"lr_smoothed", "like_spread_and_recent_memes", "es_ranked"}:
-        assert ids & set(range(10001, 10006)), f"{engine_name} returned no good-source memes"
-
-
-@pytest.mark.asyncio
-async def test_filter_disabled_allows_disliked_source(disliked_source_data, monkeypatch):
-    monkeypatch.setattr(
-        "src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_SOURCES",
-        False,
-    )
     retriever = CandidatesRetriever()
     results = await retriever.get_candidates("lr_smoothed", USER_ID, limit=50)
     ids = {r["id"] for r in results}
-    # Without filter, disliked-source memes may appear (they have same quality stats)
-    assert ids & set(range(10011, 10016)) or ids & set(range(10001, 10006))
+    # Good sources preferred but bad may still appear with soft demote if limit large
+    assert ids & set(range(10001, 10006)), "expected good-source memes"
+
+
+@pytest.mark.asyncio
+async def test_hard_block_strong_hate_excludes_source(disliked_source_data, monkeypatch):
+    monkeypatch.setattr("src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_SOURCES", True)
+    # Soft majority 8:2 is not 3x — should NOT hard-block
+    monkeypatch.setattr("src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS", 5)
+    monkeypatch.setattr("src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_RATIO", 3.0)
+
+    retriever = CandidatesRetriever()
+    results = await retriever.get_candidates("lr_smoothed", USER_ID, limit=50)
+    ids = {r["id"] for r in results}
+    # 8 dislikes vs 2 likes = 4x >= 3x and n=10 — wait 8 >= 3*2=6, yes hard block!
+    # 8 >= 6 and n=10 >= 5 → hard blocked with ratio 3
+    # Actually nlikes=2 ndislikes=8, 8 >= 3*2 = 6, yes blocked
+    bad = ids & set(range(10011, 10016))
+    assert not bad, f"strong-ratio hard block should exclude: {bad}"
+
+
+@pytest.mark.asyncio
+async def test_hard_block_high_ratio_only(disliked_source_data, monkeypatch):
+    """With ratio 5, 8:2 source is not hard-blocked (8 < 5*2=10)."""
+    monkeypatch.setattr("src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_SOURCES", True)
+    monkeypatch.setattr("src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS", 5)
+    monkeypatch.setattr("src.config.settings.RECOMMENDATION_BLOCK_DISLIKED_RATIO", 5.0)
+
+    retriever = CandidatesRetriever()
+    results = await retriever.get_candidates("lr_smoothed", USER_ID, limit=50)
+    ids = {r["id"] for r in results}
+    # May include bad-source under soft demote only
+    assert ids & set(range(10001, 10006))


### PR DESCRIPTION
## Summary

Hard-block on majority-dislike sources (`ndislikes > nlikes`, n≥5) was too aggressive: offline counterfactual removed **~57%** of impressions and risked empty queues / «мемы кончились» for skip-heavy users.

**Policy v2**
| Mode | Default | Rule |
|------|---------|------|
| **Demote** | ON | score × **0.15** if `ndislikes > nlikes` and n≥5 |
| **Hard block** | **OFF** | only if enabled and `ndislikes ≥ 3×nlikes` and n≥15 |

Product rationale: feed dislike is closer to TikTok **next/skip** than “not interested”. Likes + dwell (`sec_to_react`) are stronger signals than raw skip count.

Also labels retention broadcast deliveries as `recommended_by=broadcast_reengagement` so analytics can separate feed vs push dwell.

## Changes

- `disliked_source_demote_sql()` — CASE multiplier in engine ORDER BY
- Hard block filter optional + stricter ratio threshold
- Config kill switches for demote / block
- `send_meme_to_user(..., recommended_by=)` override for broadcasts
- Docs: `docs/growth/virality-loop.md`, experiment platform roadmap

## Test plan

- [x] Unit: demote SQL CASE, hard-block off/on ratio thresholds
- [x] Integration (when DB available): majority-dislike still eligible with demote; 3× ratio excludes when block enabled
- [ ] After merge: sample WAU queue depth / «empty» errors; % demoted impressions; LR on demoted vs non-demoted sources
- [ ] Analytics follow-up: `sec_to_react` by like vs skip, split by `recommended_by` (feed engines vs `broadcast_reengagement`)