### PR TITLE
docs: hypotheses calendar + viral_shares interim HOLD

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -10,7 +10,9 @@
 
 ### ~~Virality score for ranking~~ — SHIPPED as viral_shares_blender_v1
 **What:** Engine `viral_shares` + mature blend A/B (`viral_shares_blender_v1`). See `experiments/active/2026-08-09-viral-shares-blender-v1.md`.
-**Next:** day-7 readout via `docs/analyst/viral-shares-blender-v1.sql`; decide keep/scale/kill.
+**Next checks (hard dates):** smoke **2026-08-12**, primary **2026-08-16**, final **2026-08-23**.  
+**Rules + all open hypotheses:** [`experiments/HYPOTHESES.md`](experiments/HYPOTHESES.md).  
+Do **not** close from interim n (~20 users); day-7 needs ≥80/arm or wait day-14.
 
 ### Per-engine session continuation rate (dashboard)
 **What:** SQL/readout for % of times a user continues scrolling after a meme from each `recommended_by` engine.

--- a/docs/analyst/README.md
+++ b/docs/analyst/README.md
@@ -10,9 +10,10 @@ The Analyst agent monitors product health, tracks experiments, and produces dail
 
 ## Key Files
 - `docs/analyst/metrics.sql` — SQL queries organized by section (health, north star, engines, retention, etc.)
-- `docs/analyst/viral-shares-blender-v1.sql` — readout for `viral_shares_blender_v1` (share clickers + invites vs control).
+- `docs/analyst/viral-shares-blender-v1.sql` — readout for `viral_shares_blender_v1` (share clickers + invites vs control + session guardrail).
 - `docs/analyst/dwell-feed-vs-broadcast.sql` — `sec_to_react` percentiles: like vs skip × feed vs broadcast; dwell buckets; demote inventory risk.
 - `docs/analyst/source-affinity-demote-guardrails.sql` — post-deploy volume / LR / broadcast label checks for soft-demote (#340).
+- Living decision calendar: [`experiments/HYPOTHESES.md`](../../experiments/HYPOTHESES.md).
 - `docs/growth/2026-08-09-viral-shares-blender-v1.md` — experiment design note (also under `experiments/active/` when tracked).
 - `docs/analyst/crossposting.sql` — reusable read-only queries for Telegram channel views/forwards, 24h labels, and pre-posting share signals.
 - `specs/crossposting-share-optimization-2026-05-18.md` — current compact crossposting readout and next experiment gate.

--- a/docs/analyst/readouts/2026-08-09-viral-shares-interim.md
+++ b/docs/analyst/readouts/2026-08-09-viral-shares-interim.md
@@ -1,0 +1,57 @@
+# Viral shares blender v1 — interim (not a closeout)
+
+**When:** 2026-08-09 15:44 UTC (~1.4h after first assignment)  
+**Experiment:** `viral_shares_blender_v1`  
+**Verdict:** **HOLD** — underpowered; do not ship or kill.
+
+Canonical schedule + decision rules: [`experiments/HYPOTHESES.md`](../../../experiments/HYPOTHESES.md) **H1**.
+
+## Enrollment
+
+| variant | n_users | first_assigned (UTC) |
+|---------|---------|----------------------|
+| control | 10 | 14:20 |
+| treatment_viral_shares | 12 | 14:30 |
+
+Sample gate in code (1000/arm) is **unrealistic** at current WAU; day-7 uses
+≥80 users/arm or wait day-14 (see HYPOTHESES).
+
+## Exposure
+
+| variant | memes_sent | active_users | LR % | viral_shares sends | % viral |
+|---------|------------|--------------|------|--------------------|---------|
+| control | 297 | 10 | 39.6 | 0 | 0 |
+| treatment | 367 | 12 | 54.2 | 13 | 3.5 |
+
+Treatment LR higher is **noise** (tiny n). Engine is wired (13 sends).
+
+## Primary metrics (growth)
+
+| variant | unique non-self clickers | clickers/1k sends | new invites | invites/1k |
+|---------|--------------------------|-------------------|-------------|------------|
+| control | 0 | 0 | 0 | 0 |
+| treatment | 0 | 0 | 0 | 0 |
+
+Expected at this horizon.
+
+## Guardrails (noisy)
+
+| variant | sessions | p50 session length | mean |
+|---------|----------|--------------------|------|
+| control | 6 | 16.5 | 47.5 |
+| treatment | 10 | 19.0 | 35.2 |
+
+## Engine slice (7d global, viral only today)
+
+| recommended_by | n | LR % | continuation@30m % |
+|----------------|---|------|---------------------|
+| lr_smoothed | 43 174 | 40.3 | 94.2 |
+| recently_liked | 18 260 | 36.7 | 96.3 |
+| es_ranked | 8 037 | 39.2 | 96.4 |
+| viral_shares | 13 | 81.8 | 84.6 |
+
+## Next actions
+
+1. **2026-08-12** smoke (cohort, viral %, LR)  
+2. **2026-08-16** primary readout → ship / hold / kill  
+3. **2026-08-23** final if day-7 underpowered  

--- a/docs/analyst/viral-shares-blender-v1.sql
+++ b/docs/analyst/viral-shares-blender-v1.sql
@@ -2,6 +2,21 @@
 -- Experiment: viral_shares_blender_v1
 -- Primary: unique share clickers + new-user invites per 1k memes sent
 -- Guardrails: session depth proxy, like rate
+--
+-- Decision calendar: experiments/HYPOTHESES.md (H1)
+--   smoke 2026-08-12 | primary 2026-08-16 | final 2026-08-23
+-- Realistic sample at current WAU: >=80 users/arm and >=2k sends/arm
+-- (code SAMPLE_GATE 1000 is aspirational, not a hard wait).
+
+\set ON_ERROR_STOP on
+
+-- 0) Age
+SELECT
+  now() AS as_of,
+  min(assigned_at) AS first_assignment,
+  round(extract(epoch from (now() - min(assigned_at))) / 86400.0, 2) AS days_since_start
+FROM experiment_assignment
+WHERE experiment_id = 'viral_shares_blender_v1';
 
 -- 1) Cohort sizes by variant
 SELECT
@@ -127,4 +142,104 @@ SELECT
 FROM assigned a
 LEFT JOIN invites i ON i.variant = a.variant
 GROUP BY a.variant
+ORDER BY 1;
+
+-- 5) Session depth guardrail (p50 memes per session, 30m gap)
+WITH assigned AS (
+  SELECT user_id, variant, assigned_at
+  FROM experiment_assignment
+  WHERE experiment_id = 'viral_shares_blender_v1'
+),
+reacts AS (
+  SELECT
+    a.variant,
+    r.user_id,
+    r.reacted_at,
+    CASE
+      WHEN lag(r.reacted_at) OVER (PARTITION BY r.user_id ORDER BY r.reacted_at) IS NULL
+        OR r.reacted_at - lag(r.reacted_at) OVER (PARTITION BY r.user_id ORDER BY r.reacted_at)
+           > interval '30 minutes'
+      THEN 1 ELSE 0
+    END AS new_session
+  FROM assigned a
+  JOIN user_meme_reaction r
+    ON r.user_id = a.user_id
+   AND r.reacted_at >= a.assigned_at
+   AND r.reacted_at IS NOT NULL
+),
+sess AS (
+  SELECT
+    variant,
+    user_id,
+    sum(new_session) OVER (PARTITION BY user_id ORDER BY reacted_at) AS session_id
+  FROM reacts
+),
+lengths AS (
+  SELECT variant, user_id, session_id, count(*) AS session_len
+  FROM sess
+  GROUP BY 1, 2, 3
+)
+SELECT
+  variant,
+  count(*) AS sessions,
+  round(percentile_cont(0.50) WITHIN GROUP (ORDER BY session_len)::numeric, 2)
+    AS p50_session_len,
+  round(avg(session_len)::numeric, 2) AS mean_session_len
+FROM lengths
+GROUP BY 1
+ORDER BY 1;
+
+-- 6) Engine slice: viral_shares vs peers (global 7d)
+WITH base AS (
+  SELECT
+    user_id, recommended_by, sent_at, reaction_id,
+    LEAD(sent_at) OVER (PARTITION BY user_id ORDER BY sent_at) AS next_sent_at
+  FROM user_meme_reaction
+  WHERE sent_at > now() - interval '7 days'
+    AND recommended_by IN (
+      'viral_shares', 'lr_smoothed', 'recently_liked', 'es_ranked', 'goat'
+    )
+)
+SELECT
+  recommended_by,
+  count(*) AS n,
+  round(
+    100.0 * count(*) FILTER (WHERE reaction_id = 1)
+    / nullif(count(*) FILTER (WHERE reaction_id IS NOT NULL), 0),
+    1
+  ) AS like_rate_pct,
+  round(
+    100.0 * count(*) FILTER (
+      WHERE next_sent_at IS NOT NULL
+        AND next_sent_at - sent_at < interval '30 minutes'
+    ) / nullif(count(*), 0),
+    1
+  ) AS continuation_30m_pct
+FROM base
+GROUP BY 1
+ORDER BY n DESC;
+
+-- 7) Pass/fail snapshot for decision day (fill by eye against HYPOTHESES.md)
+WITH assigned AS (
+  SELECT user_id, variant, assigned_at
+  FROM experiment_assignment
+  WHERE experiment_id = 'viral_shares_blender_v1'
+),
+stats AS (
+  SELECT
+    a.variant,
+    count(DISTINCT a.user_id) AS n_users,
+    count(r.*) AS memes_sent
+  FROM assigned a
+  LEFT JOIN user_meme_reaction r
+    ON r.user_id = a.user_id AND r.sent_at >= a.assigned_at
+  GROUP BY 1
+)
+SELECT
+  variant,
+  n_users,
+  memes_sent,
+  n_users >= 80 AS users_gate_ok,
+  memes_sent >= 2000 AS sends_gate_ok
+FROM stats
 ORDER BY 1;

--- a/docs/growth/2026-08-09-viral-shares-blender-v1.md
+++ b/docs/growth/2026-08-09-viral-shares-blender-v1.md
@@ -1,48 +1,22 @@
 # Experiment: Viral shares blender v1
 
+Canonical note: [`experiments/active/2026-08-09-viral-shares-blender-v1.md`](../../experiments/active/2026-08-09-viral-shares-blender-v1.md)  
+Decision calendar: [`experiments/HYPOTHESES.md`](../../experiments/HYPOTHESES.md) **H1**
+
 Created: 2026-08-09  
-Status: active  
-Owner: engineer / analyst  
-Deployed: pending merge  
-Measure after: +7 days and sample_gate_per_variant ≥ 1000
+Status: **active** (HOLD until day-7/14)  
+Deployed: 2026-08-09  
+**Measure after: 2026-08-16** · Final: 2026-08-23 · Smoke: 2026-08-12
 
 ## Hypothesis
 
-Injecting a dedicated `viral_shares` engine (memes ranked by share-click conversion)
-into the mature blend at weight 0.2 (stolen from `lr_smoothed`) increases unique
-share clickers and new-user invites per 1k memes sent without reducing session depth.
+Mature blend weight 0.2 on `viral_shares` (from `lr_smoothed`) lifts unique
+non-self share clickers and invites per 1k sends without harming session depth.
 
-## Changes Made
+## Interim
 
-- Engine: `src/recommendations/candidates.py::viral_shares`
-- Experiment: `viral_shares_blender_v1` in `src/recommendations/blender_experiments.py`
-- Wiring: mature path uses `get_mature_blend_weights_with_experiments` (recently_liked v2 base + viral overlay)
-- Delivery prep seam: `src/tgbot/senders/delivery.py` (shared by `next_message` + `send_meme_to_user`)
-- Crosspost fix: share-click CTEs accept both `m_` and `s_` deep links
-
-## Assignment
-
-- Eligible: mature users via existing mature blend path (`nmemes_sent ≥ 100`)
-- Strategy: `sha256(experiment_id:user_id) % 2`
-- Control: base mature weights (after recently_liked v2 assignment)
-- Treatment: base + `viral_shares: 0.2`, `lr_smoothed` reduced by 0.2
-- Sample gate: 1000 users/variant before day-7 read
-
-## Primary metrics
-
-1. Unique non-self share clickers (`user_deep_link_log` m_/s_) per 1k memes sent
-2. New-user invites (`user.inviter_id` attributed in window) per 1k memes sent
-
-## Guardrails
-
-- Median / p50 session length (memes with reaction gap < 30 min)
-- Like rate (7d)
-- Block rate
-
-## Engine slice
-
-Where `recommended_by = 'viral_shares'`: continuation rate vs `lr_smoothed`.
+See `docs/analyst/readouts/2026-08-09-viral-shares-interim.md` — underpowered, HOLD.
 
 ## Readout SQL
 
-See `docs/analyst/viral-shares-blender-v1.sql`.
+`docs/analyst/viral-shares-blender-v1.sql`

--- a/docs/growth/HYPOTHESES.md
+++ b/docs/growth/HYPOTHESES.md
@@ -1,0 +1,218 @@
+# Living hypotheses & check-in schedule
+
+**Purpose:** When an agent (or human) resumes after days/weeks, this file answers:
+what is live, what we expected, when to re-measure, and what “good / kill” means.
+
+**Last updated:** 2026-08-09 (UTC)  
+**Prod DB clock at last interim:** `2026-08-09 15:44 UTC`
+
+How to use on resume:
+
+1. Read this file top → bottom.
+2. For each row with `Next check ≤ today`, run the linked SQL against
+   `ANALYST_DATABASE_URL` (read-only).
+3. Write numbers into the linked readout path; update **Status** / **Decision**.
+4. If status becomes `ship` or `kill`, open a code PR (planner weights / freeze
+   enrollment) and move the experiment note `active/` → `completed/`.
+
+---
+
+## Check calendar (hard dates)
+
+| Date (UTC) | What to run | Hypotheses |
+|------------|-------------|------------|
+| **2026-08-12** (day ~3) | Smoke only — not a ship decision | H1 viral_shares, H2 demote |
+| **2026-08-16** (day ~7) | **Primary readout** | H1, H2, H3 broadcast label |
+| **2026-08-23** (day ~14) | Final keep/kill if day-7 underpowered | H1 primarily |
+| Ad-hoc | After any ranking/deploy incident | all active |
+
+Agent prompt on resume (copy-paste):
+
+```text
+Read experiments/HYPOTHESES.md. For every hypothesis with Next check ≤ today,
+run the readout SQL on ANALYST_DATABASE_URL, update the Status/Decision rows
+and the linked readout markdown, then recommend ship/hold/kill with numbers.
+```
+
+---
+
+## H1 — `viral_shares` in mature blend (A/B)
+
+| Field | Value |
+|-------|--------|
+| **ID** | `viral_shares_blender_v1` |
+| **Status** | **active — too early to close** (interim only) |
+| **Shipped** | 2026-08-09 ~14:20 UTC (first assignment) |
+| **Code** | `candidates.viral_shares`, `blender_experiments.get_viral_shares_blender_v1_weights` |
+| **Note** | `experiments/active/2026-08-09-viral-shares-blender-v1.md` |
+| **SQL** | `docs/analyst/viral-shares-blender-v1.sql` |
+| **Readout log** | `docs/analyst/readouts/2026-08-09-viral-shares-interim.md` |
+
+### Hypothesis (precise)
+
+Giving mature users (`nmemes_sent ≥ 100`) weight **0.2** on engine
+`viral_shares` (memes ranked by `invited_count / ln(nmemes_sent+e)`), taken from
+`lr_smoothed`, increases **unique non-self share clickers per 1k sends** and
+**new-user invites per 1k sends** vs control, without harming session depth.
+
+### Interim baseline (2026-08-09 15:44 UTC, ~1.4h)
+
+| Variant | n_users | memes_sent | LR % | viral_sends | clickers/1k | invites/1k | p50 session |
+|---------|---------|------------|------|-------------|-------------|------------|-------------|
+| control | 10 | 297 | 39.6 | 0 | 0 | 0 | 16.5 |
+| treatment | 12 | 367 | 54.2 | 13 (3.5%) | 0 | 0 | 19.0 |
+
+**Do not decide from this.** n≪gate; 0 growth events expected in first hours.
+Engine is live (13 sends, high LR noise).
+
+### Decision rules (day-7 / day-14)
+
+**Sample (realistic for WAU~380):**  
+Do **not** wait for 1000/arm (unrealistic). Prefer:
+
+- day-7 if **≥80 users/variant** and **≥2k sends/variant**, else hold to day-14;
+- day-14 decide even if underpowered (ship only if direction clear + guardrails OK).
+
+**Ship treatment → mature default** if all:
+
+1. `unique_clickers_per_1k_sends` treatment ≥ control **and** absolute lift makes
+   sense at our volume (or invites/1k clearly higher);
+2. Guardrail: p50 session length treatment ≥ control − **10%** relative;
+3. Guardrail: like rate treatment ≥ control − **3 pp**;
+4. Engine slice: `viral_shares` continuation@30m not &lt; lr_smoothed − **5 pp**
+   (on ≥100 viral sends).
+
+**Kill (remove weight, freeze enrollment to control)** if:
+
+- session p50 drops &gt;10% relative, or
+- LR drops &gt;5 pp with ≥2k sends/arm, or
+- day-14 still ~0 viral_engine exposure on treatment (wiring bug).
+
+**Hold** if underpowered or metrics mixed.
+
+### Next check
+
+- **2026-08-12** smoke: cohort sizes, viral % of treatment sends, LR  
+- **2026-08-16** primary  
+- **2026-08-23** final if needed  
+
+---
+
+## H2 — Soft demote majority-dislike sources
+
+| Field | Value |
+|-------|--------|
+| **ID** | `source_affinity_demote_v1` (config flags, not A/B) |
+| **Status** | **shipped default ON** (PR #340) |
+| **Shipped** | 2026-08-09 deploy `687fd46a` |
+| **Code** | `RECOMMENDATION_DEMOTE_*`, `disliked_source_demote_sql` |
+| **SQL** | `docs/analyst/source-affinity-demote-guardrails.sql` + inventory section of `dwell-feed-vs-broadcast.sql` |
+| **Baseline** | `docs/analyst/readouts/2026-08-09-dwell-and-source-demote-baseline.md` |
+
+### Hypothesis
+
+Deprioritizing sources with `ndislikes > nlikes` (n≥5) by score ×0.15 increases
+feed quality (higher session continuation / slightly higher LR on demotable
+traffic) **without** increasing empty-queue symptoms, unlike hard-block (~57%
+inventory cut offline).
+
+### Decision rules (day-7)
+
+**Keep ON** if:
+
+1. Sends/day and active users not cliffing vs week before deploy;
+2. Global like rate not down &gt;3 pp vs pre-deploy 7d window;
+3. No spike in empty-queue alerts (Sentry/logs: `has empty meme queue`).
+
+**Tune** multiplier (0.15 → 0.3) if LR up but users complain of “same sources”.  
+**Disable** (`RECOMMENDATION_DEMOTE_DISLIKED_SOURCES=false`) if empty-queue or
+volume collapse.
+
+### Next check
+
+- **2026-08-12** smoke volume/LR  
+- **2026-08-16** full guardrails vs baseline  
+
+---
+
+## H3 — Broadcast delivery label for dwell analytics
+
+| Field | Value |
+|-------|--------|
+| **ID** | `broadcast_reengagement_label` |
+| **Status** | **shipped** (label on new retention pushes) |
+| **Shipped** | 2026-08-09 with #340 |
+| **Code** | `flows/broadcasts/meme.py` → `recommended_by=broadcast_reengagement` |
+| **SQL** | `docs/analyst/dwell-feed-vs-broadcast.sql` sections 1–3, 6 |
+
+### Hypothesis
+
+Labeling retention pushes separately from feed engines lets us measure true
+in-session `sec_to_react` and optimize broadcast timing for **fast** reaction
+(not content affinity from stale opens).
+
+### Success criteria (day-7+)
+
+1. Rows with `recommended_by = 'broadcast_reengagement'` appear after ≥1
+   scheduled reengagement run;
+2. Broadcast p50 `sec_to_react` **higher** than feed (delayed opens expected);
+3. Share of broadcast reactions with `sec_to_react > 1h` documented (exclude
+   from affinity later).
+
+### Next check
+
+- **2026-08-12** — any labeled rows yet?  
+- **2026-08-16** — full feed vs broadcast dwell table  
+
+---
+
+## H4 — Skip ≠ hate (measurement contract, not a ship)
+
+| Field | Value |
+|-------|--------|
+| **ID** | `skip_is_next_not_ban` |
+| **Status** | **accepted product doctrine** |
+| **Evidence** | skip p50 4.7s vs like 7.1s; instant skip 19% vs like 9% (7d feed) |
+| **SQL** | `docs/analyst/dwell-feed-vs-broadcast.sql` |
+
+### Hypothesis (ongoing)
+
+Dislike button is primarily “next”; ranking must prefer **likes + dwell**, not
+raw skip counts as bans. Future work: down-weight `sec_to_react < 2s` skips and
+ignore `>1h` reactions in affinity.
+
+### Next check
+
+- **2026-08-16** re-run dwell percentiles; compare to baseline readout  
+- No ship decision until a dedicated dwell-weight PR with offline counterfactual  
+
+---
+
+## Explicitly not open experiments
+
+| Item | State |
+|------|--------|
+| `recently_liked_blender_v2` | **Shipped as mature default** (completed) |
+| Hard-block majority-dislike | **Rejected** as default; opt-in flag only |
+| Full Feed Turn rewrite | Not doing |
+| New blender A/B | Do not start until H1 day-7 done |
+
+---
+
+## Agent checklist (weekly resume)
+
+```bash
+# 1) Hypotheses file
+# 2) Run:
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/viral-shares-blender-v1.sql
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/source-affinity-demote-guardrails.sql
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/dwell-feed-vs-broadcast.sql
+# 3) Update this file Status/Decision + write
+#    docs/analyst/readouts/YYYY-MM-DD-weekly-hypotheses.md
+```
+
+Healthy product snapshot (rough, not ship gates):
+
+- new_memes_24h &gt; 100, ok_pct ~90–96%
+- active reactors 24h not collapsing vs prior week
+- multi-engine mix still present (not 100% one engine)

--- a/experiments/HYPOTHESES.md
+++ b/experiments/HYPOTHESES.md
@@ -1,0 +1,218 @@
+# Living hypotheses & check-in schedule
+
+**Purpose:** When an agent (or human) resumes after days/weeks, this file answers:
+what is live, what we expected, when to re-measure, and what “good / kill” means.
+
+**Last updated:** 2026-08-09 (UTC)  
+**Prod DB clock at last interim:** `2026-08-09 15:44 UTC`
+
+How to use on resume:
+
+1. Read this file top → bottom.
+2. For each row with `Next check ≤ today`, run the linked SQL against
+   `ANALYST_DATABASE_URL` (read-only).
+3. Write numbers into the linked readout path; update **Status** / **Decision**.
+4. If status becomes `ship` or `kill`, open a code PR (planner weights / freeze
+   enrollment) and move the experiment note `active/` → `completed/`.
+
+---
+
+## Check calendar (hard dates)
+
+| Date (UTC) | What to run | Hypotheses |
+|------------|-------------|------------|
+| **2026-08-12** (day ~3) | Smoke only — not a ship decision | H1 viral_shares, H2 demote |
+| **2026-08-16** (day ~7) | **Primary readout** | H1, H2, H3 broadcast label |
+| **2026-08-23** (day ~14) | Final keep/kill if day-7 underpowered | H1 primarily |
+| Ad-hoc | After any ranking/deploy incident | all active |
+
+Agent prompt on resume (copy-paste):
+
+```text
+Read experiments/HYPOTHESES.md. For every hypothesis with Next check ≤ today,
+run the readout SQL on ANALYST_DATABASE_URL, update the Status/Decision rows
+and the linked readout markdown, then recommend ship/hold/kill with numbers.
+```
+
+---
+
+## H1 — `viral_shares` in mature blend (A/B)
+
+| Field | Value |
+|-------|--------|
+| **ID** | `viral_shares_blender_v1` |
+| **Status** | **active — too early to close** (interim only) |
+| **Shipped** | 2026-08-09 ~14:20 UTC (first assignment) |
+| **Code** | `candidates.viral_shares`, `blender_experiments.get_viral_shares_blender_v1_weights` |
+| **Note** | `experiments/active/2026-08-09-viral-shares-blender-v1.md` |
+| **SQL** | `docs/analyst/viral-shares-blender-v1.sql` |
+| **Readout log** | `docs/analyst/readouts/2026-08-09-viral-shares-interim.md` |
+
+### Hypothesis (precise)
+
+Giving mature users (`nmemes_sent ≥ 100`) weight **0.2** on engine
+`viral_shares` (memes ranked by `invited_count / ln(nmemes_sent+e)`), taken from
+`lr_smoothed`, increases **unique non-self share clickers per 1k sends** and
+**new-user invites per 1k sends** vs control, without harming session depth.
+
+### Interim baseline (2026-08-09 15:44 UTC, ~1.4h)
+
+| Variant | n_users | memes_sent | LR % | viral_sends | clickers/1k | invites/1k | p50 session |
+|---------|---------|------------|------|-------------|-------------|------------|-------------|
+| control | 10 | 297 | 39.6 | 0 | 0 | 0 | 16.5 |
+| treatment | 12 | 367 | 54.2 | 13 (3.5%) | 0 | 0 | 19.0 |
+
+**Do not decide from this.** n≪gate; 0 growth events expected in first hours.
+Engine is live (13 sends, high LR noise).
+
+### Decision rules (day-7 / day-14)
+
+**Sample (realistic for WAU~380):**  
+Do **not** wait for 1000/arm (unrealistic). Prefer:
+
+- day-7 if **≥80 users/variant** and **≥2k sends/variant**, else hold to day-14;
+- day-14 decide even if underpowered (ship only if direction clear + guardrails OK).
+
+**Ship treatment → mature default** if all:
+
+1. `unique_clickers_per_1k_sends` treatment ≥ control **and** absolute lift makes
+   sense at our volume (or invites/1k clearly higher);
+2. Guardrail: p50 session length treatment ≥ control − **10%** relative;
+3. Guardrail: like rate treatment ≥ control − **3 pp**;
+4. Engine slice: `viral_shares` continuation@30m not &lt; lr_smoothed − **5 pp**
+   (on ≥100 viral sends).
+
+**Kill (remove weight, freeze enrollment to control)** if:
+
+- session p50 drops &gt;10% relative, or
+- LR drops &gt;5 pp with ≥2k sends/arm, or
+- day-14 still ~0 viral_engine exposure on treatment (wiring bug).
+
+**Hold** if underpowered or metrics mixed.
+
+### Next check
+
+- **2026-08-12** smoke: cohort sizes, viral % of treatment sends, LR  
+- **2026-08-16** primary  
+- **2026-08-23** final if needed  
+
+---
+
+## H2 — Soft demote majority-dislike sources
+
+| Field | Value |
+|-------|--------|
+| **ID** | `source_affinity_demote_v1` (config flags, not A/B) |
+| **Status** | **shipped default ON** (PR #340) |
+| **Shipped** | 2026-08-09 deploy `687fd46a` |
+| **Code** | `RECOMMENDATION_DEMOTE_*`, `disliked_source_demote_sql` |
+| **SQL** | `docs/analyst/source-affinity-demote-guardrails.sql` + inventory section of `dwell-feed-vs-broadcast.sql` |
+| **Baseline** | `docs/analyst/readouts/2026-08-09-dwell-and-source-demote-baseline.md` |
+
+### Hypothesis
+
+Deprioritizing sources with `ndislikes > nlikes` (n≥5) by score ×0.15 increases
+feed quality (higher session continuation / slightly higher LR on demotable
+traffic) **without** increasing empty-queue symptoms, unlike hard-block (~57%
+inventory cut offline).
+
+### Decision rules (day-7)
+
+**Keep ON** if:
+
+1. Sends/day and active users not cliffing vs week before deploy;
+2. Global like rate not down &gt;3 pp vs pre-deploy 7d window;
+3. No spike in empty-queue alerts (Sentry/logs: `has empty meme queue`).
+
+**Tune** multiplier (0.15 → 0.3) if LR up but users complain of “same sources”.  
+**Disable** (`RECOMMENDATION_DEMOTE_DISLIKED_SOURCES=false`) if empty-queue or
+volume collapse.
+
+### Next check
+
+- **2026-08-12** smoke volume/LR  
+- **2026-08-16** full guardrails vs baseline  
+
+---
+
+## H3 — Broadcast delivery label for dwell analytics
+
+| Field | Value |
+|-------|--------|
+| **ID** | `broadcast_reengagement_label` |
+| **Status** | **shipped** (label on new retention pushes) |
+| **Shipped** | 2026-08-09 with #340 |
+| **Code** | `flows/broadcasts/meme.py` → `recommended_by=broadcast_reengagement` |
+| **SQL** | `docs/analyst/dwell-feed-vs-broadcast.sql` sections 1–3, 6 |
+
+### Hypothesis
+
+Labeling retention pushes separately from feed engines lets us measure true
+in-session `sec_to_react` and optimize broadcast timing for **fast** reaction
+(not content affinity from stale opens).
+
+### Success criteria (day-7+)
+
+1. Rows with `recommended_by = 'broadcast_reengagement'` appear after ≥1
+   scheduled reengagement run;
+2. Broadcast p50 `sec_to_react` **higher** than feed (delayed opens expected);
+3. Share of broadcast reactions with `sec_to_react > 1h` documented (exclude
+   from affinity later).
+
+### Next check
+
+- **2026-08-12** — any labeled rows yet?  
+- **2026-08-16** — full feed vs broadcast dwell table  
+
+---
+
+## H4 — Skip ≠ hate (measurement contract, not a ship)
+
+| Field | Value |
+|-------|--------|
+| **ID** | `skip_is_next_not_ban` |
+| **Status** | **accepted product doctrine** |
+| **Evidence** | skip p50 4.7s vs like 7.1s; instant skip 19% vs like 9% (7d feed) |
+| **SQL** | `docs/analyst/dwell-feed-vs-broadcast.sql` |
+
+### Hypothesis (ongoing)
+
+Dislike button is primarily “next”; ranking must prefer **likes + dwell**, not
+raw skip counts as bans. Future work: down-weight `sec_to_react < 2s` skips and
+ignore `>1h` reactions in affinity.
+
+### Next check
+
+- **2026-08-16** re-run dwell percentiles; compare to baseline readout  
+- No ship decision until a dedicated dwell-weight PR with offline counterfactual  
+
+---
+
+## Explicitly not open experiments
+
+| Item | State |
+|------|--------|
+| `recently_liked_blender_v2` | **Shipped as mature default** (completed) |
+| Hard-block majority-dislike | **Rejected** as default; opt-in flag only |
+| Full Feed Turn rewrite | Not doing |
+| New blender A/B | Do not start until H1 day-7 done |
+
+---
+
+## Agent checklist (weekly resume)
+
+```bash
+# 1) Hypotheses file
+# 2) Run:
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/viral-shares-blender-v1.sql
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/source-affinity-demote-guardrails.sql
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/dwell-feed-vs-broadcast.sql
+# 3) Update this file Status/Decision + write
+#    docs/analyst/readouts/YYYY-MM-DD-weekly-hypotheses.md
+```
+
+Healthy product snapshot (rough, not ship gates):
+
+- new_memes_24h &gt; 100, ok_pct ~90–96%
+- active reactors 24h not collapsing vs prior week
+- multi-engine mix still present (not 100% one engine)

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -2,10 +2,17 @@
 
 Structured experiment tracking for AI agents and manual development.
 
+## Start here on resume
+
+**[`HYPOTHESES.md`](HYPOTHESES.md)** — living list of open hypotheses, ship/kill
+rules, and **hard recheck dates** (day-3 / day-7 / day-14). Read it first when
+picking up the project after a break.
+
 ## Directory Structure
 
 ```
 experiments/
+├── HYPOTHESES.md     # Check-in schedule + decision rules (authoritative)
 ├── active/           # Currently running experiments
 │   └── YYYY-MM-DD-experiment-name.md
 ├── completed/        # Finished experiments (never deleted)

--- a/experiments/active/2026-08-09-viral-shares-blender-v1.md
+++ b/experiments/active/2026-08-09-viral-shares-blender-v1.md
@@ -1,48 +1,75 @@
 # Experiment: Viral shares blender v1
 
 Created: 2026-08-09  
-Status: active  
+Status: **active** (interim only — do not close)  
 Owner: engineer / analyst  
-Deployed: pending merge  
-Measure after: +7 days and sample_gate_per_variant ≥ 1000
+Deployed: 2026-08-09 (~14:20 UTC first assignment)  
+**Measure after: 2026-08-16** (primary)  
+**Final if underpowered: 2026-08-23**  
+Smoke: 2026-08-12  
+
+Living registry: [`../HYPOTHESES.md`](../HYPOTHESES.md) **H1**.
 
 ## Hypothesis
 
-Injecting a dedicated `viral_shares` engine (memes ranked by share-click conversion)
-into the mature blend at weight 0.2 (stolen from `lr_smoothed`) increases unique
-share clickers and new-user invites per 1k memes sent without reducing session depth.
+Injecting a dedicated `viral_shares` engine (memes ranked by share-click /
+invite conversion) into the mature blend at weight **0.2** (stolen from
+`lr_smoothed`) increases unique **non-self** share clickers and new-user
+invites per 1k memes sent without reducing session depth (p50 memes/session).
 
 ## Changes Made
 
 - Engine: `src/recommendations/candidates.py::viral_shares`
 - Experiment: `viral_shares_blender_v1` in `src/recommendations/blender_experiments.py`
-- Wiring: mature path uses `get_mature_blend_weights_with_experiments` (recently_liked v2 base + viral overlay)
-- Delivery prep seam: `src/tgbot/senders/delivery.py` (shared by `next_message` + `send_meme_to_user`)
+- Wiring: mature path uses `get_mature_blend_weights_with_experiments`
+- Delivery prep seam: `src/tgbot/senders/delivery.py`
 - Crosspost fix: share-click CTEs accept both `m_` and `s_` deep links
 
 ## Assignment
 
-- Eligible: mature users via existing mature blend path (`nmemes_sent ≥ 100`)
+- Eligible: mature users via mature blend path (`nmemes_sent ≥ 100`)
 - Strategy: `sha256(experiment_id:user_id) % 2`
-- Control: base mature weights (after recently_liked v2 assignment)
+- Control: base mature weights (after recently_liked v2 default)
 - Treatment: base + `viral_shares: 0.2`, `lr_smoothed` reduced by 0.2
-- Sample gate: 1000 users/variant before day-7 read
+- Code constant `SAMPLE_GATE_PER_VARIANT = 1000` is **legacy**; decision sample
+  for this WAU is **≥80 users/variant and ≥2k sends/variant** at day-7, else
+  decide at day-14 (see HYPOTHESES.md)
 
 ## Primary metrics
 
 1. Unique non-self share clickers (`user_deep_link_log` m_/s_) per 1k memes sent
-2. New-user invites (`user.inviter_id` attributed in window) per 1k memes sent
+2. New-user invites (`user.inviter_id`) per 1k memes sent
 
 ## Guardrails
 
-- Median / p50 session length (memes with reaction gap < 30 min)
-- Like rate (7d)
-- Block rate
+- p50 session length (30m gap) — kill if treatment &lt; control − 10% relative
+- Like rate — kill if treatment &lt; control − 5 pp (with enough volume)
+- Engine continuation@30m for `viral_shares` vs `lr_smoothed`
 
-## Engine slice
+## Ship / kill rules
 
-Where `recommended_by = 'viral_shares'`: continuation rate vs `lr_smoothed`.
+See **H1 Decision rules** in `experiments/HYPOTHESES.md`.
+
+## Interim (2026-08-09 15:44 UTC)
+
+Full numbers: `docs/analyst/readouts/2026-08-09-viral-shares-interim.md`
+
+- 10 control / 12 treatment users; 0 share clickers; 0 invites
+- 13 `viral_shares` sends on treatment (wiring OK)
+- **Verdict: HOLD**
+
+## Metrics Before / After
+
+| Window | control n | treatment n | clickers/1k C/T | invites/1k C/T | p50 session C/T | Decision |
+|--------|-----------|-------------|-----------------|----------------|-----------------|----------|
+| 2026-08-09 interim | 10 | 12 | 0 / 0 | 0 / 0 | 16.5 / 19.0 | HOLD |
+| 2026-08-16 day-7 | | | | | | TBD |
+| 2026-08-23 day-14 | | | | | | TBD |
+
+## Conclusion
+
+_Filled on completion only._
 
 ## Readout SQL
 
-See `docs/analyst/viral-shares-blender-v1.sql`.
+`docs/analyst/viral-shares-blender-v1.sql`


### PR DESCRIPTION
## Summary

- **viral_shares is too early to close** (~1.4h, 10/12 users, 0 growth events). Verdict: **HOLD**.
- Adds `experiments/HYPOTHESES.md` (+ mirror `docs/growth/HYPOTHESES.md`) with hard recheck dates and ship/kill rules for H1–H4.
- Extends viral_shares SQL with session guardrail + sample-gate snapshot.
- Interim readout under `docs/analyst/readouts/`.

## Check calendar

| Date | Action |
|------|--------|
| 2026-08-12 | Smoke |
| 2026-08-16 | Primary day-7 |
| 2026-08-23 | Final if underpowered |

Resume prompt is in `experiments/HYPOTHESES.md`.

## Test plan
- [x] Prod interim SQL run
- [ ] Day-7 re-run after 2026-08-16