### PR TITLE
feat: cold-start quality floors + HQ broadcast pick

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -14,6 +14,14 @@
 **Rules + all open hypotheses:** [`experiments/HYPOTHESES.md`](experiments/HYPOTHESES.md).  
 Do **not** close from interim n (~20 users); day-7 needs ≥80/arm or wait day-14.
 
+### Cold-start first-session quality floors — SHIPPING
+**What:** explore raw-LR ≥0.50 / n≥25; CS3 blend uses best_uploaded + text_light (no like_spread).
+**Check:** H5 in `experiments/HYPOTHESES.md` — smoke 2026-08-12, primary 2026-08-16.
+
+### Broadcast HQ meme pick — SHIPPING
+**What:** retention pushes pick affinity×LR meme (`broadcast_reengagement_hq`) vs queue fallback.
+**SQL:** `docs/analyst/broadcast-reengagement.sql`. Kill switch `BROADCAST_HIGH_QUALITY_PICK_ENABLED`.
+
 ### Per-engine session continuation rate (dashboard)
 **What:** SQL/readout for % of times a user continues scrolling after a meme from each `recommended_by` engine.
 **Why:** Better engine evaluation than LR; aligns with session-length north star.

--- a/docs/analyst/README.md
+++ b/docs/analyst/README.md
@@ -12,7 +12,8 @@ The Analyst agent monitors product health, tracks experiments, and produces dail
 - `docs/analyst/metrics.sql` — SQL queries organized by section (health, north star, engines, retention, etc.)
 - `docs/analyst/viral-shares-blender-v1.sql` — readout for `viral_shares_blender_v1` (share clickers + invites vs control + session guardrail).
 - `docs/analyst/dwell-feed-vs-broadcast.sql` — `sec_to_react` percentiles: like vs skip × feed vs broadcast; dwell buckets; demote inventory risk.
-- `docs/analyst/source-affinity-demote-guardrails.sql` — post-deploy volume / LR / broadcast label checks for soft-demote (#340).
+- `docs/analyst/source-affinity-demote-guardrails.sql` — post-deploy volume / LR checks for soft-demote (#340).
+- `docs/analyst/broadcast-reengagement.sql` — retention push HQ vs queue fallback vs feed.
 - Living decision calendar: [`experiments/HYPOTHESES.md`](../../experiments/HYPOTHESES.md).
 - `docs/growth/2026-08-09-viral-shares-blender-v1.md` — experiment design note (also under `experiments/active/` when tracked).
 - `docs/analyst/crossposting.sql` — reusable read-only queries for Telegram channel views/forwards, 24h labels, and pre-posting share signals.

--- a/docs/analyst/broadcast-reengagement.sql
+++ b/docs/analyst/broadcast-reengagement.sql
@@ -1,0 +1,87 @@
+-- Retention broadcast effectiveness readout
+--
+-- Labels (after HQ pick ship):
+--   broadcast_reengagement_hq  — affinity + proven-LR picker
+--   broadcast_reengagement     — feed-queue fallback (or pre-HQ era)
+--
+-- Compare to in-session feed engines (recommended_by NOT LIKE 'broadcast%').
+-- Primary: reactivation (react within 1h), LR, sec_to_react p50.
+--
+-- See experiments/HYPOTHESES.md H3 / H5.
+
+\set ON_ERROR_STOP on
+
+-- 1) Volume by broadcast label (14d)
+SELECT
+  recommended_by,
+  count(*) AS sends,
+  count(DISTINCT user_id) AS users,
+  count(*) FILTER (WHERE reaction_id IS NOT NULL) AS reactions,
+  round(
+    100.0 * count(*) FILTER (WHERE reaction_id = 1)
+    / nullif(count(*) FILTER (WHERE reaction_id IS NOT NULL), 0),
+    1
+  ) AS like_rate_pct,
+  round(
+    100.0 * count(*) FILTER (
+      WHERE reacted_at IS NOT NULL
+        AND reacted_at - sent_at < interval '1 hour'
+    ) / nullif(count(*), 0),
+    1
+  ) AS react_within_1h_pct,
+  round(
+    percentile_cont(0.50) WITHIN GROUP (
+      ORDER BY EXTRACT(EPOCH FROM reacted_at - sent_at)
+    ) FILTER (
+      WHERE reaction_id IS NOT NULL
+        AND reacted_at >= sent_at
+        AND EXTRACT(EPOCH FROM reacted_at - sent_at) BETWEEN 0 AND 86400
+    )::numeric,
+    1
+  ) AS p50_sec_to_react
+FROM user_meme_reaction
+WHERE sent_at > now() - interval '14 days'
+  AND recommended_by LIKE 'broadcast%'
+GROUP BY 1
+ORDER BY sends DESC;
+
+-- 2) HQ vs queue-fallback vs feed (7d reacted)
+WITH base AS (
+  SELECT
+    CASE
+      WHEN recommended_by = 'broadcast_reengagement_hq' THEN 'broadcast_hq'
+      WHEN recommended_by LIKE 'broadcast%' THEN 'broadcast_queue_or_legacy'
+      ELSE 'feed'
+    END AS path,
+    reaction_id,
+    EXTRACT(EPOCH FROM reacted_at - sent_at) AS sec
+  FROM user_meme_reaction
+  WHERE reacted_at > now() - interval '7 days'
+    AND reaction_id IN (1, 2)
+    AND reacted_at >= sent_at
+    AND EXTRACT(EPOCH FROM reacted_at - sent_at) BETWEEN 0 AND 86400
+)
+SELECT
+  path,
+  count(*) AS n,
+  round(100.0 * count(*) FILTER (WHERE reaction_id = 1) / nullif(count(*), 0), 1)
+    AS like_rate_pct,
+  round(percentile_cont(0.50) WITHIN GROUP (ORDER BY sec)::numeric, 1) AS p50_s,
+  round(
+    100.0 * count(*) FILTER (WHERE sec < 120) / nullif(count(*), 0),
+    1
+  ) AS pct_react_under_2m
+FROM base
+GROUP BY 1
+ORDER BY 1;
+
+-- 3) Daily HQ adoption (post-deploy)
+SELECT
+  date_trunc('day', sent_at)::date AS day_utc,
+  count(*) FILTER (WHERE recommended_by = 'broadcast_reengagement_hq') AS hq,
+  count(*) FILTER (WHERE recommended_by = 'broadcast_reengagement') AS queue_fallback,
+  count(*) FILTER (WHERE recommended_by LIKE 'broadcast%') AS all_broadcast
+FROM user_meme_reaction
+WHERE sent_at > now() - interval '14 days'
+GROUP BY 1
+ORDER BY 1 DESC;

--- a/docs/growth/HYPOTHESES.md
+++ b/docs/growth/HYPOTHESES.md
@@ -3,7 +3,7 @@
 **Purpose:** When an agent (or human) resumes after days/weeks, this file answers:
 what is live, what we expected, when to re-measure, and what “good / kill” means.
 
-**Last updated:** 2026-08-09 (UTC)  
+**Last updated:** 2026-08-09 (UTC) — added H5 cold-start + H3b HQ broadcast pick  
 **Prod DB clock at last interim:** `2026-08-09 15:44 UTC`
 
 How to use on resume:
@@ -21,9 +21,9 @@ How to use on resume:
 
 | Date (UTC) | What to run | Hypotheses |
 |------------|-------------|------------|
-| **2026-08-12** (day ~3) | Smoke only — not a ship decision | H1 viral_shares, H2 demote |
-| **2026-08-16** (day ~7) | **Primary readout** | H1, H2, H3 broadcast label |
-| **2026-08-23** (day ~14) | Final keep/kill if day-7 underpowered | H1 primarily |
+| **2026-08-12** (day ~3) | Smoke only — not a ship decision | H1, H2, H3/H3b, H5 |
+| **2026-08-16** (day ~7) | **Primary readout** | H1, H2, H3/H3b, H5 |
+| **2026-08-23** (day ~14) | Final keep/kill if day-7 underpowered | H1 primarily; H3b/H5 if thin |
 | Ad-hoc | After any ranking/deploy incident | all active |
 
 Agent prompt on resume (copy-paste):
@@ -140,29 +140,66 @@ volume collapse.
 | Field | Value |
 |-------|--------|
 | **ID** | `broadcast_reengagement_label` |
-| **Status** | **shipped** (label on new retention pushes) |
+| **Status** | **shipped** — labels live (39 rows within hours of #340) |
 | **Shipped** | 2026-08-09 with #340 |
-| **Code** | `flows/broadcasts/meme.py` → `recommended_by=broadcast_reengagement` |
-| **SQL** | `docs/analyst/dwell-feed-vs-broadcast.sql` sections 1–3, 6 |
+| **Code** | `flows/broadcasts/meme.py` → `recommended_by=broadcast_*` |
+| **SQL** | `docs/analyst/broadcast-reengagement.sql`, dwell SQL |
 
 ### Hypothesis
 
 Labeling retention pushes separately from feed engines lets us measure true
-in-session `sec_to_react` and optimize broadcast timing for **fast** reaction
-(not content affinity from stale opens).
+in-session `sec_to_react` and optimize broadcast timing for **fast** reaction.
 
-### Success criteria (day-7+)
+### Success criteria
 
-1. Rows with `recommended_by = 'broadcast_reengagement'` appear after ≥1
-   scheduled reengagement run;
-2. Broadcast p50 `sec_to_react` **higher** than feed (delayed opens expected);
-3. Share of broadcast reactions with `sec_to_react > 1h` documented (exclude
-   from affinity later).
+1. ✅ Labeled rows exist (`broadcast_reengagement` / `_hq`)
+2. Broadcast p50 `sec_to_react` **higher** than feed (delayed opens expected)
+3. Share of broadcast reactions with `sec_to_react > 1h` documented
 
 ### Next check
 
-- **2026-08-12** — any labeled rows yet?  
-- **2026-08-16** — full feed vs broadcast dwell table  
+- **2026-08-12 / 16** — full feed vs broadcast dwell table
+
+---
+
+## H3b — High-quality meme pick for retention broadcasts
+
+| Field | Value |
+|-------|--------|
+| **ID** | `broadcast_reengagement_hq_pick` |
+| **Status** | **shipping** (this PR) |
+| **Code** | `src/recommendations/broadcast_pick.py`, kill switch `BROADCAST_HIGH_QUALITY_PICK_ENABLED` |
+| **Labels** | `broadcast_reengagement_hq` (SQL pick) vs `broadcast_reengagement` (queue fallback) |
+| **SQL** | `docs/analyst/broadcast-reengagement.sql` |
+
+### Hypothesis
+
+Choosing the reengagement meme by **user×source affinity × raw like rate**
+(avoiding majority-dislike sources) beats blind feed-queue pop on:
+
+1. **react_within_1h %** (primary — “came back because of this push”)
+2. like rate among reacted
+3. p50 `sec_to_react` among in-window reactions (secondary)
+
+### Pre-HQ baseline (2026-08-09, ~39 `broadcast_reengagement` sends)
+
+- like rate ~54% (small n)
+- only ~4 reacts under 2 minutes — delayed open is the norm
+
+### Decision rules (day-7 from HQ deploy)
+
+**Keep HQ ON** if:
+
+- `broadcast_reengagement_hq` react_within_1h ≥ queue-fallback **or** ≥ pre-HQ baseline + directionally better LR;
+- no send failure spike (empty HQ → fallback should keep volume).
+
+**Disable** (`BROADCAST_HIGH_QUALITY_PICK_ENABLED=false`) if HQ pool empty for
+most users (fallback rate &gt;80%) or LR collapses &gt;5 pp vs fallback.
+
+### Next check
+
+- **2026-08-12** smoke: any `_hq` rows? fallback share?  
+- **2026-08-16** primary HQ vs fallback vs feed  
 
 ---
 
@@ -188,6 +225,43 @@ ignore `>1h` reactions in affinity.
 
 ---
 
+## H5 — Cold-start first-session quality floors
+
+| Field | Value |
+|-------|--------|
+| **ID** | `cold_start_first_impression_v2` |
+| **Status** | **shipping** (this PR) |
+| **Code** | `cold_start_explore` raw-LR floor; CS3 blend → `best_uploaded` + text-light |
+| **SQL** | engine slice in `docs/analyst/metrics.sql` / cold_start quality scripts |
+
+### Hypothesis
+
+**A1.** Raising `cold_start_explore` floors (raw like rate ≥0.50, ≥25 reactions,
+order by `lr_smoothed`) lifts first-10 LR and reached-10 vs pre-change
+(guarded explore was ~**18%** LR on 7d — too weak for first impression).
+
+**A2.** CS3 (memes 16–29) replacing `like_spread` with `best_uploaded_memes`
+improves LR/continuation in that band without starving personalization
+(`cold_start_adapt` stays fixed_pos 0).
+
+### Decision rules (day-7)
+
+**Keep** if first-10 LR for `cold_start_explore*` ≥ pre-change + directionally
+higher reached-5/10; no empty-queue spike for new users.
+
+**Rollback explore floors** if explore pool empty → fallback share spikes and
+session depth drops.
+
+**Rollback CS3** if `best_uploaded` share causes lower continuation vs prior
+week CS3 band.
+
+### Next check
+
+- **2026-08-12** smoke: explore volume + LR  
+- **2026-08-16** first-10 / CS3 band metrics  
+
+---
+
 ## Explicitly not open experiments
 
 | Item | State |
@@ -207,6 +281,7 @@ ignore `>1h` reactions in affinity.
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/viral-shares-blender-v1.sql
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/source-affinity-demote-guardrails.sql
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/dwell-feed-vs-broadcast.sql
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/broadcast-reengagement.sql
 # 3) Update this file Status/Decision + write
 #    docs/analyst/readouts/YYYY-MM-DD-weekly-hypotheses.md
 ```

--- a/experiments/HYPOTHESES.md
+++ b/experiments/HYPOTHESES.md
@@ -3,7 +3,7 @@
 **Purpose:** When an agent (or human) resumes after days/weeks, this file answers:
 what is live, what we expected, when to re-measure, and what “good / kill” means.
 
-**Last updated:** 2026-08-09 (UTC)  
+**Last updated:** 2026-08-09 (UTC) — added H5 cold-start + H3b HQ broadcast pick  
 **Prod DB clock at last interim:** `2026-08-09 15:44 UTC`
 
 How to use on resume:
@@ -21,9 +21,9 @@ How to use on resume:
 
 | Date (UTC) | What to run | Hypotheses |
 |------------|-------------|------------|
-| **2026-08-12** (day ~3) | Smoke only — not a ship decision | H1 viral_shares, H2 demote |
-| **2026-08-16** (day ~7) | **Primary readout** | H1, H2, H3 broadcast label |
-| **2026-08-23** (day ~14) | Final keep/kill if day-7 underpowered | H1 primarily |
+| **2026-08-12** (day ~3) | Smoke only — not a ship decision | H1, H2, H3/H3b, H5 |
+| **2026-08-16** (day ~7) | **Primary readout** | H1, H2, H3/H3b, H5 |
+| **2026-08-23** (day ~14) | Final keep/kill if day-7 underpowered | H1 primarily; H3b/H5 if thin |
 | Ad-hoc | After any ranking/deploy incident | all active |
 
 Agent prompt on resume (copy-paste):
@@ -140,29 +140,66 @@ volume collapse.
 | Field | Value |
 |-------|--------|
 | **ID** | `broadcast_reengagement_label` |
-| **Status** | **shipped** (label on new retention pushes) |
+| **Status** | **shipped** — labels live (39 rows within hours of #340) |
 | **Shipped** | 2026-08-09 with #340 |
-| **Code** | `flows/broadcasts/meme.py` → `recommended_by=broadcast_reengagement` |
-| **SQL** | `docs/analyst/dwell-feed-vs-broadcast.sql` sections 1–3, 6 |
+| **Code** | `flows/broadcasts/meme.py` → `recommended_by=broadcast_*` |
+| **SQL** | `docs/analyst/broadcast-reengagement.sql`, dwell SQL |
 
 ### Hypothesis
 
 Labeling retention pushes separately from feed engines lets us measure true
-in-session `sec_to_react` and optimize broadcast timing for **fast** reaction
-(not content affinity from stale opens).
+in-session `sec_to_react` and optimize broadcast timing for **fast** reaction.
 
-### Success criteria (day-7+)
+### Success criteria
 
-1. Rows with `recommended_by = 'broadcast_reengagement'` appear after ≥1
-   scheduled reengagement run;
-2. Broadcast p50 `sec_to_react` **higher** than feed (delayed opens expected);
-3. Share of broadcast reactions with `sec_to_react > 1h` documented (exclude
-   from affinity later).
+1. ✅ Labeled rows exist (`broadcast_reengagement` / `_hq`)
+2. Broadcast p50 `sec_to_react` **higher** than feed (delayed opens expected)
+3. Share of broadcast reactions with `sec_to_react > 1h` documented
 
 ### Next check
 
-- **2026-08-12** — any labeled rows yet?  
-- **2026-08-16** — full feed vs broadcast dwell table  
+- **2026-08-12 / 16** — full feed vs broadcast dwell table
+
+---
+
+## H3b — High-quality meme pick for retention broadcasts
+
+| Field | Value |
+|-------|--------|
+| **ID** | `broadcast_reengagement_hq_pick` |
+| **Status** | **shipping** (this PR) |
+| **Code** | `src/recommendations/broadcast_pick.py`, kill switch `BROADCAST_HIGH_QUALITY_PICK_ENABLED` |
+| **Labels** | `broadcast_reengagement_hq` (SQL pick) vs `broadcast_reengagement` (queue fallback) |
+| **SQL** | `docs/analyst/broadcast-reengagement.sql` |
+
+### Hypothesis
+
+Choosing the reengagement meme by **user×source affinity × raw like rate**
+(avoiding majority-dislike sources) beats blind feed-queue pop on:
+
+1. **react_within_1h %** (primary — “came back because of this push”)
+2. like rate among reacted
+3. p50 `sec_to_react` among in-window reactions (secondary)
+
+### Pre-HQ baseline (2026-08-09, ~39 `broadcast_reengagement` sends)
+
+- like rate ~54% (small n)
+- only ~4 reacts under 2 minutes — delayed open is the norm
+
+### Decision rules (day-7 from HQ deploy)
+
+**Keep HQ ON** if:
+
+- `broadcast_reengagement_hq` react_within_1h ≥ queue-fallback **or** ≥ pre-HQ baseline + directionally better LR;
+- no send failure spike (empty HQ → fallback should keep volume).
+
+**Disable** (`BROADCAST_HIGH_QUALITY_PICK_ENABLED=false`) if HQ pool empty for
+most users (fallback rate &gt;80%) or LR collapses &gt;5 pp vs fallback.
+
+### Next check
+
+- **2026-08-12** smoke: any `_hq` rows? fallback share?  
+- **2026-08-16** primary HQ vs fallback vs feed  
 
 ---
 
@@ -188,6 +225,43 @@ ignore `>1h` reactions in affinity.
 
 ---
 
+## H5 — Cold-start first-session quality floors
+
+| Field | Value |
+|-------|--------|
+| **ID** | `cold_start_first_impression_v2` |
+| **Status** | **shipping** (this PR) |
+| **Code** | `cold_start_explore` raw-LR floor; CS3 blend → `best_uploaded` + text-light |
+| **SQL** | engine slice in `docs/analyst/metrics.sql` / cold_start quality scripts |
+
+### Hypothesis
+
+**A1.** Raising `cold_start_explore` floors (raw like rate ≥0.50, ≥25 reactions,
+order by `lr_smoothed`) lifts first-10 LR and reached-10 vs pre-change
+(guarded explore was ~**18%** LR on 7d — too weak for first impression).
+
+**A2.** CS3 (memes 16–29) replacing `like_spread` with `best_uploaded_memes`
+improves LR/continuation in that band without starving personalization
+(`cold_start_adapt` stays fixed_pos 0).
+
+### Decision rules (day-7)
+
+**Keep** if first-10 LR for `cold_start_explore*` ≥ pre-change + directionally
+higher reached-5/10; no empty-queue spike for new users.
+
+**Rollback explore floors** if explore pool empty → fallback share spikes and
+session depth drops.
+
+**Rollback CS3** if `best_uploaded` share causes lower continuation vs prior
+week CS3 band.
+
+### Next check
+
+- **2026-08-12** smoke: explore volume + LR  
+- **2026-08-16** first-10 / CS3 band metrics  
+
+---
+
 ## Explicitly not open experiments
 
 | Item | State |
@@ -207,6 +281,7 @@ ignore `>1h` reactions in affinity.
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/viral-shares-blender-v1.sql
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/source-affinity-demote-guardrails.sql
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/dwell-feed-vs-broadcast.sql
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/broadcast-reengagement.sql
 # 3) Update this file Status/Decision + write
 #    docs/analyst/readouts/YYYY-MM-DD-weekly-hypotheses.md
 ```

--- a/src/config.py
+++ b/src/config.py
@@ -74,6 +74,9 @@ class Config(BaseSettings):
     RECOMMENDATION_BLOCK_DISLIKED_SOURCES: bool = False
     RECOMMENDATION_BLOCK_DISLIKED_MIN_REACTIONS: int = 15
     RECOMMENDATION_BLOCK_DISLIKED_RATIO: float = 3.0  # ndislikes >= 3 * nlikes
+    # Retention broadcasts: pick high-confidence meme (affinity + LR) instead of
+    # blind Redis queue pop. Kill switch rolls back to queue path.
+    BROADCAST_HIGH_QUALITY_PICK_ENABLED: bool = True
 
     PREFECT_API_URL: str | None = None
     PREFECT_AUTH_STRING: str | None = None

--- a/src/feed_turn/planner.py
+++ b/src/feed_turn/planner.py
@@ -89,13 +89,16 @@ def plan_candidate_selection(nmemes_sent: int) -> CandidateSelectionPlan:
         )
 
     if nmemes_sent < 30:
+        # CS3 (memes 16-29): still personalizing. Prefer proven social proof
+        # (best_uploaded + text-light) over like_spread virality — early users
+        # lack signal for spread engines, and uploads historically hold LR better.
         return CandidateSelectionPlan(
             maturity_stage=COLD_START_3,
             primary_engine=None,
             blend_weights={
-                "cold_start_adapt": 0.5,
+                "cold_start_adapt": 0.4,
+                "best_uploaded_memes": 0.3,
                 "text_light_lr_smoothed": 0.3,
-                "like_spread_and_recent_memes": 0.2,
             },
             fixed_pos={0: "cold_start_adapt"},
             fallback_engines=(

--- a/src/flows/broadcasts/meme.py
+++ b/src/flows/broadcasts/meme.py
@@ -7,7 +7,7 @@ from src.broadcasts.service import (
     get_users_active_more_than_days_ago,
 )
 from src.flows.hooks import notify_telegram_on_failure
-from src.recommendations.meme_queue import check_queue, get_next_meme_for_user
+from src.recommendations.broadcast_pick import pick_reengagement_meme
 from src.tgbot.bot import bot
 from src.tgbot.senders.meme import send_meme_to_user
 
@@ -49,19 +49,19 @@ async def _send_to_user(
     user_id: int,
     first_meme_nudge_tasks: list[asyncio.Task[None]],
     *,
-    broadcast_label: str = "broadcast_reengagement",
+    broadcast_label: str | None = None,
 ) -> None:
-    await check_queue(user_id)
-    meme = await get_next_meme_for_user(user_id)
+    # HQ pick (affinity + proven LR) when enabled; else feed-queue fallback.
+    # recommended_by is broadcast_reengagement_hq vs broadcast_reengagement
+    # so we can measure push effectiveness separately from in-session feed.
+    meme, picked_label = await pick_reengagement_meme(user_id)
     if meme:
         await send_meme_to_user(
             bot,
             user_id,
             meme,
             first_meme_nudge_tasks=first_meme_nudge_tasks,
-            # Distinguish retention pushes from in-session feed for analytics
-            # (dwell / sec_to_react distributions differ by delivery path).
-            recommended_by=broadcast_label,
+            recommended_by=broadcast_label or picked_label,
         )
 
 

--- a/src/recommendations/broadcast_pick.py
+++ b/src/recommendations/broadcast_pick.py
@@ -1,0 +1,115 @@
+"""High-confidence meme selection for retention broadcasts.
+
+Feed queue pop is optimized for continuous scrolling. Reengagement pushes need
+a single strong meme that earns a *fast* reaction when the user returns —
+prefer liked sources + proven like rate, never majority-dislike sources.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+
+from src.config import settings
+from src.database import fetch_one
+from src.recommendations.meme_queue import check_queue, get_next_meme_for_user
+from src.recommendations.utils import (
+    block_disliked_sources_sql_filter,
+    disliked_source_demote_sql,
+)
+from src.storage.schemas import MemeData
+
+logger = logging.getLogger(__name__)
+
+# Delivery-path labels for analytics (dwell / reactivation).
+BROADCAST_RECOMMENDED_BY = "broadcast_reengagement"
+BROADCAST_HQ_RECOMMENDED_BY = "broadcast_reengagement_hq"
+
+# Quality floors for the HQ pick (explicit reactions, not lr_smoothed alone).
+_HQ_MIN_EXPLICIT_REACTIONS = 15
+_HQ_MIN_RAW_LIKE_RATE = 0.45
+
+
+async def pick_reengagement_meme(user_id: int) -> tuple[MemeData | None, str]:
+    """Return (meme, recommended_by_label) for a retention push.
+
+    When ``BROADCAST_HIGH_QUALITY_PICK_ENABLED`` is on, tries an affinity-aware
+    SQL pick first (label ``broadcast_reengagement_hq``). Falls back to the
+    normal feed queue (label ``broadcast_reengagement``) so we never skip a user
+    solely because the HQ pool is empty.
+    """
+    if settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED:
+        meme = await _fetch_high_quality_reengagement_meme(user_id)
+        if meme is not None:
+            return meme, BROADCAST_HQ_RECOMMENDED_BY
+        logger.info(
+            "broadcast HQ pick empty for user_id=%s; falling back to feed queue",
+            user_id,
+        )
+
+    await check_queue(user_id)
+    meme = await get_next_meme_for_user(user_id)
+    if meme is None:
+        return None, BROADCAST_RECOMMENDED_BY
+    return meme, BROADCAST_RECOMMENDED_BY
+
+
+async def _fetch_high_quality_reengagement_meme(user_id: int) -> MemeData | None:
+    """Single best unseen meme: user×source affinity × raw like rate × demote."""
+    query = f"""
+        SELECT
+            M.id
+            , M.type
+            , M.telegram_file_id
+            , M.caption
+            , COALESCE(MS.nlikes, 0) AS nlikes
+        FROM meme M
+        INNER JOIN meme_stats MS
+            ON MS.meme_id = M.id
+        INNER JOIN user_language L
+            ON L.language_code = M.language_code
+            AND L.user_id = :user_id
+        LEFT JOIN user_meme_reaction R
+            ON R.meme_id = M.id
+            AND R.user_id = :user_id
+        LEFT JOIN user_meme_source_stats UMSS
+            ON UMSS.meme_source_id = M.meme_source_id
+            AND UMSS.user_id = :user_id
+        WHERE 1=1
+            AND M.status = 'ok'
+            AND M.telegram_file_id IS NOT NULL
+            AND R.meme_id IS NULL
+            AND (MS.nlikes + MS.ndislikes) >= :min_reactions
+            AND (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0))
+                >= :min_raw_like_rate
+            {block_disliked_sources_sql_filter()}
+        ORDER BY -1
+            * COALESCE(
+                (UMSS.nlikes + 1.) / (UMSS.nlikes + UMSS.ndislikes + 1.),
+                0.5
+            )
+            * {disliked_source_demote_sql()}
+            * (MS.nlikes + 1.) / (MS.nlikes + MS.ndislikes + 1.)
+            * COALESCE(MS.lr_smoothed, 0.0)
+        NULLS LAST
+        LIMIT 1
+    """
+    row = await fetch_one(
+        text(query),
+        {
+            "user_id": user_id,
+            "min_reactions": _HQ_MIN_EXPLICIT_REACTIONS,
+            "min_raw_like_rate": _HQ_MIN_RAW_LIKE_RATE,
+        },
+    )
+    if not row:
+        return None
+    return MemeData(
+        id=row["id"],
+        type=row["type"],
+        telegram_file_id=row["telegram_file_id"],
+        caption=row.get("caption"),
+        recommended_by=BROADCAST_HQ_RECOMMENDED_BY,
+        nlikes=int(row.get("nlikes") or 0),
+    )

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -20,6 +20,12 @@ GOAT_MIN_LR = 0.20  # lr_smoothed — minimum proven like rate
 GOAT_MIN_AGE_DAYS = 3  # days since created_at — must have aged enough to accumulate reactions
 GOAT_RECENTLY_SENT_WINDOW_DAYS = 30
 TEXT_LIGHT_MAX_OCR_WORDS = 30
+# Cold-start first-impression floors (raw LR, not bias-corrected lr_smoothed).
+# 7d prod: cold_start_explore_guarded LR ~18% — raise the bar so phase-1 only
+# serves memes the crowd already likes at a majority rate.
+COLD_START_EXPLORE_MIN_EXPLICIT_REACTIONS = 25
+COLD_START_EXPLORE_MIN_LR_SMOOTHED = 0.10
+COLD_START_EXPLORE_MIN_RAW_LIKE_RATE = 0.50
 COLD_START_GUARDRAIL_SOURCE_URLS = (
     "https://vk.com/dfzwe4",
     "https://vk.com/eternalclassic",
@@ -525,27 +531,35 @@ async def cold_start_explore(
         WHERE 1=1
             AND M.status = 'ok'
             AND R.meme_id IS NULL
-            AND (MS.nlikes + MS.ndislikes) >= 20
-            AND MS.lr_smoothed >= 0.10
+            AND (MS.nlikes + MS.ndislikes) >= :cold_start_explore_min_reactions
+            AND MS.lr_smoothed >= :cold_start_explore_min_lr_smoothed
+            AND (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0))
+                >= :cold_start_explore_min_raw_like_rate
             {TEXT_LIGHT_OCR_FILTER_SQL}
             {_cold_start_guardrail_source_filter(candidate_guardrails_enabled)}
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
             {block_disliked_sources_sql_filter()}
 
-        ORDER BY (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0)) DESC,
+        ORDER BY MS.lr_smoothed DESC NULLS LAST,
+                 (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0)) DESC,
                  (MS.nlikes + MS.ndislikes) DESC
         LIMIT :limit
     """
-    return await fetch_all(
-        text(query),
-        _cold_start_params(
-            user_id,
-            limit,
-            exclude_meme_ids,
-            engine=COLD_START_EXPLORE_RECOMMENDED_BY,
-            candidate_guardrails_enabled=candidate_guardrails_enabled,
-        ),
+    params = _cold_start_params(
+        user_id,
+        limit,
+        exclude_meme_ids,
+        engine=COLD_START_EXPLORE_RECOMMENDED_BY,
+        candidate_guardrails_enabled=candidate_guardrails_enabled,
     )
+    params.update(
+        {
+            "cold_start_explore_min_reactions": COLD_START_EXPLORE_MIN_EXPLICIT_REACTIONS,
+            "cold_start_explore_min_lr_smoothed": COLD_START_EXPLORE_MIN_LR_SMOOTHED,
+            "cold_start_explore_min_raw_like_rate": COLD_START_EXPLORE_MIN_RAW_LIKE_RATE,
+        }
+    )
+    return await fetch_all(text(query), params)
 
 
 async def cold_start_adapt(

--- a/tests/feed_turn/test_planner.py
+++ b/tests/feed_turn/test_planner.py
@@ -48,10 +48,11 @@ def test_cold_start_fallback_order_and_min_sends(nmemes_sent):
 def test_transition_blend_and_empty_blend_fallback_order():
     plan = plan_candidate_selection(16)
 
+    # CS3 prefers proven social proof over like_spread for early personalization.
     assert dict(plan.blend_weights) == {
-        "cold_start_adapt": 0.5,
+        "cold_start_adapt": 0.4,
+        "best_uploaded_memes": 0.3,
         "text_light_lr_smoothed": 0.3,
-        "like_spread_and_recent_memes": 0.2,
     }
     assert dict(plan.fixed_pos) == {0: "cold_start_adapt"}
     assert _fallbacks(16) == (

--- a/tests/flows/test_broadcasts_meme.py
+++ b/tests/flows/test_broadcasts_meme.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.flows.broadcasts import meme as broadcast_meme
+from src.storage.constants import MemeType
+from src.storage.schemas import MemeData
 
 
 @pytest.mark.asyncio
@@ -32,6 +34,27 @@ async def test_broadcast_drains_deferred_first_meme_nudge(monkeypatch):
     nudge_can_finish.set()
     await asyncio.wait_for(broadcast_task, timeout=0.2)
     logger.info.assert_any_call("Sent meme to #12001")
+
+
+@pytest.mark.asyncio
+async def test_send_to_user_uses_picker_label(monkeypatch):
+    meme = MemeData(
+        id=55,
+        type=MemeType.IMAGE,
+        telegram_file_id="tg",
+        caption=None,
+        recommended_by="broadcast_reengagement_hq",
+    )
+    send = AsyncMock()
+    pick = AsyncMock(return_value=(meme, "broadcast_reengagement_hq"))
+    monkeypatch.setattr(broadcast_meme, "pick_reengagement_meme", pick)
+    monkeypatch.setattr(broadcast_meme, "send_meme_to_user", send)
+    monkeypatch.setattr(broadcast_meme, "bot", object())
+
+    await broadcast_meme._send_to_user(99, [])
+
+    pick.assert_awaited_once_with(99)
+    assert send.await_args.kwargs["recommended_by"] == "broadcast_reengagement_hq"
 
 
 @pytest.mark.asyncio

--- a/tests/recommendations/test_broadcast_pick.py
+++ b/tests/recommendations/test_broadcast_pick.py
@@ -1,0 +1,112 @@
+"""Unit tests for retention-broadcast HQ meme picker."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.recommendations.broadcast_pick import (
+    BROADCAST_HQ_RECOMMENDED_BY,
+    BROADCAST_RECOMMENDED_BY,
+    pick_reengagement_meme,
+)
+from src.storage.constants import MemeType
+from src.storage.schemas import MemeData
+
+
+@pytest.mark.asyncio
+async def test_hq_pick_uses_sql_row_and_hq_label(monkeypatch):
+    monkeypatch.setattr(
+        "src.recommendations.broadcast_pick.settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED",
+        True,
+    )
+    row = {
+        "id": 42,
+        "type": MemeType.IMAGE,
+        "telegram_file_id": "file-42",
+        "caption": "hi",
+        "nlikes": 99,
+    }
+    with patch(
+        "src.recommendations.broadcast_pick.fetch_one",
+        new_callable=AsyncMock,
+        return_value=row,
+    ) as fetch_one:
+        meme, label = await pick_reengagement_meme(7)
+
+    fetch_one.assert_awaited_once()
+    assert label == BROADCAST_HQ_RECOMMENDED_BY
+    assert meme is not None
+    assert meme.id == 42
+    assert meme.recommended_by == BROADCAST_HQ_RECOMMENDED_BY
+
+
+@pytest.mark.asyncio
+async def test_hq_empty_falls_back_to_queue(monkeypatch):
+    monkeypatch.setattr(
+        "src.recommendations.broadcast_pick.settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED",
+        True,
+    )
+    queue_meme = MemeData(
+        id=9,
+        type=MemeType.IMAGE,
+        telegram_file_id="q",
+        caption=None,
+        recommended_by="lr_smoothed",
+    )
+    with (
+        patch(
+            "src.recommendations.broadcast_pick.fetch_one",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "src.recommendations.broadcast_pick.check_queue",
+            new_callable=AsyncMock,
+        ) as check_queue,
+        patch(
+            "src.recommendations.broadcast_pick.get_next_meme_for_user",
+            new_callable=AsyncMock,
+            return_value=queue_meme,
+        ) as get_next,
+    ):
+        meme, label = await pick_reengagement_meme(7)
+
+    check_queue.assert_awaited_once_with(7)
+    get_next.assert_awaited_once_with(7)
+    assert meme is queue_meme
+    assert label == BROADCAST_RECOMMENDED_BY
+
+
+@pytest.mark.asyncio
+async def test_hq_disabled_uses_queue_only(monkeypatch):
+    monkeypatch.setattr(
+        "src.recommendations.broadcast_pick.settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED",
+        False,
+    )
+    queue_meme = MemeData(
+        id=3,
+        type=MemeType.IMAGE,
+        telegram_file_id="q",
+        caption=None,
+        recommended_by="goat",
+    )
+    with (
+        patch(
+            "src.recommendations.broadcast_pick.fetch_one",
+            new_callable=AsyncMock,
+        ) as fetch_one,
+        patch(
+            "src.recommendations.broadcast_pick.check_queue",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.recommendations.broadcast_pick.get_next_meme_for_user",
+            new_callable=AsyncMock,
+            return_value=queue_meme,
+        ),
+    ):
+        meme, label = await pick_reengagement_meme(1)
+
+    fetch_one.assert_not_called()
+    assert meme is queue_meme
+    assert label == BROADCAST_RECOMMENDED_BY

--- a/tests/recommendations/test_cold_start_candidate_guardrails.py
+++ b/tests/recommendations/test_cold_start_candidate_guardrails.py
@@ -31,6 +31,10 @@ async def test_cold_start_explore_guardrails_exclude_weak_sources_and_mark_treat
     assert "S.url = ANY(:cold_start_guardrail_source_urls)" in query_sql
     assert params["recommended_by"] == COLD_START_EXPLORE_GUARDED_RECOMMENDED_BY
     assert params["cold_start_guardrail_source_urls"] == list(COLD_START_GUARDRAIL_SOURCE_URLS)
+    assert params["cold_start_explore_min_raw_like_rate"] == 0.50
+    assert params["cold_start_explore_min_reactions"] == 25
+    assert "cold_start_explore_min_raw_like_rate" in query_sql
+    assert "lr_smoothed DESC" in query_sql
 
 
 @pytest.mark.asyncio

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -454,7 +454,7 @@ async def test_cold_start_phase2_fallback():
 
 @pytest.mark.asyncio
 async def test_cold_start_phase3_blends():
-    """Phase 3 (16-30 memes): blends cold_start_adapt + growing engines"""
+    """Phase 3 (16-30 memes): blends adapt + best_uploaded + text_light."""
 
     async def cold_start_adapt(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return [{"id": 201}, {"id": 202}, {"id": 203}]
@@ -462,18 +462,14 @@ async def test_cold_start_phase3_blends():
     async def lr_smoothed(self, user_id, limit=10, exclude_meme_ids=[], **kw):
         return [{"id": 301}, {"id": 302}]
 
-    async def like_spread(self, user_id, limit=10, exclude_meme_ids=[], **kw):
-        return [{"id": 501}, {"id": 502}]
-
     async def best_uploaded(self, user_id, limit=10, exclude_meme_ids=[], **kw):
-        return [{"id": 401}]
+        return [{"id": 401}, {"id": 402}, {"id": 403}]
 
     class TestRetriever(CandidatesRetriever):
         engine_map = {
             "cold_start_adapt": cold_start_adapt,
             "text_light_lr_smoothed": lr_smoothed,
             "lr_smoothed": lr_smoothed,
-            "like_spread_and_recent_memes": like_spread,
             "best_uploaded_memes": best_uploaded,
             "cold_start_explore": cold_start_adapt,  # unused but needed in map
         }
@@ -484,6 +480,8 @@ async def test_cold_start_phase3_blends():
     assert len(candidates) == 7
     # cold_start_adapt is pinned at position 0
     assert candidates[0]["id"] in [201, 202, 203]
+    sources = {c["id"] for c in candidates}
+    assert sources & {401, 402, 403}, "CS3 should pull best_uploaded memes"
 
 
 # ── Growing (30-100) and Mature (100+) — existing behavior ──


### PR DESCRIPTION
## Summary

### A — Cold-start first-session quality
- **Explore floors:** raw like rate ≥ **0.50**, ≥ **25** explicit reactions, order by `lr_smoothed` (7d prod: `cold_start_explore_guarded` LR was ~**18%** — too weak for first impression).
- **CS3 (memes 16–29):** blend `cold_start_adapt 0.4` + `best_uploaded 0.3` + `text_light 0.3` (drops premature `like_spread`).

### B — Retention broadcast meme pick
- New `pick_reengagement_meme()`: affinity × raw LR × demote (not queue head).
- Labels: `broadcast_reengagement_hq` (HQ) vs `broadcast_reengagement` (queue fallback).
- Kill switch: `BROADCAST_HIGH_QUALITY_PICK_ENABLED` (default ON).
- Readout: `docs/analyst/broadcast-reengagement.sql`.

Does **not** touch mature blend / `viral_shares` A/B (H1).

## Hypotheses / recheck
See `experiments/HYPOTHESES.md` **H3b**, **H5** — smoke **2026-08-12**, primary **2026-08-16**.

## Test plan
- [x] Unit: planner CS3, explore params, broadcast pick HQ/fallback, flow wiring
- [ ] After deploy: `_hq` rows appear on next retention flows; cold explore LR up
- [ ] Day-7: HYPOTHESES checklist