### PR TITLE
feat: VK ETL parity with Telegram guards

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -33,10 +33,10 @@ Do **not** close from interim n (~20 users); day-7 needs ≥80/arm or wait day-1
 
 ## P2 — Supply side (ETL)
 
-### Align VK ETL guards with TG
-**What:** `parsing_enabled` gate, broken-link retry, auto-snooze after empty parses — currently TG-only in places.
-**Why:** Feature drift floods or starves VK content relative to TG.
+### ~~Align VK ETL guards with TG~~ — SHIPPED
+**What:** VK ETL `parsing_enabled` + top-view gate; unload broken-link retry; parse auto-snooze (same as TG).
 **Files:** `src/storage/etl.py`, `src/storage/service.py`, `src/flows/parsers/vk.py`
+**Tests:** `tests/storage/test_vk_etl_parity.py`
 
 ### Auto-discover sources from forwards
 **What:** Forwarded channel URLs → `meme_source_candidate` (partially shipped). Keep discovery + moderator vote loop healthy.

--- a/specs/parsing-etl.md
+++ b/specs/parsing-etl.md
@@ -39,18 +39,20 @@ Cron definitions: `scripts/serve_flows.py`
 ## Source Management
 
 - `meme_source` table: status includes `in_moderation` | `parsing_enabled` | `snoozed` (plus legacy strings)
-- Prepared sources (`in_moderation`) must not ETL into the user feed until promoted — TG ETL guards on `parsing_enabled` (ADR-0003). VK parity is incomplete debt.
+- Prepared sources (`in_moderation`) must not ETL into the user feed until promoted — **both TG and VK** ETL/unload paths guard on `parsing_enabled` (ADR-0003).
 - Sources can be added by users (`added_by` FK), moderators, or discovery → candidate promotion
+- **Auto-snooze after parse** (`maybe_auto_snooze_source`): TG + **VK** — 3× empty parse, low LR, high ad-rate. Stale no-raw-posts flow is shared (`auto_snooze_stale_sources`).
 
 ## ETL Filters
 
-1. **Single-media only**: `JSONB_ARRAY_LENGTH(media) = 1` — removes carousels
-2. **Type detection**: video / animation / image (TG); VK currently often forces image
+1. **Single-media only**: safe `JSONB_ARRAY_LENGTH` when media is an array — removes carousels
+2. **Type detection**: video / animation / image (TG); VK currently forces image
 3. **Repost dedup (TG only)**: `DISTINCT ON (COALESCE(forwarded_url, …))`
-4. **24h window**: only recent raw posts
+4. **24h window**: only recent raw posts (`fresh_only`, default true)
 5. **Ad filter**: stop words + length > 200 chars (`src/storage/ads.py`)
 6. **Link cleanup**: removes @mentions / http / t.me from captions
-7. **TG engagement filters**: top-view / median view quality gates (VK lacks these — drift)
+7. **Engagement filters (TG + VK)**: among latest 10 posts per source, promote top 5 by views; drop posts with views &lt; 30% of source median (when views &gt; 0)
+8. **Unload path**: `get_unloaded_tg_memes` / `get_unloaded_vk_memes` only `parsing_enabled`; retry `broken_content_link`
 
 ## Status Progression
 

--- a/src/flows/parsers/vk.py
+++ b/src/flows/parsers/vk.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from datetime import datetime
 
 from prefect import flow, get_run_logger
@@ -9,8 +10,10 @@ from src.storage.etl import insert_parsed_posts_from_vk
 from src.storage.parsers.vk import VkGroupScraper
 from src.storage.service import (
     get_vk_sources_to_parse,
+    maybe_auto_snooze_source,
     update_meme_source,
 )
+from src.tgbot.logs import log
 
 
 @flow(name="Parse VK Source", timeout_seconds=300)
@@ -19,6 +22,7 @@ async def parse_vk_source(
     meme_source_url: str,
     nposts: int = 10,
 ) -> None:
+    """Parse one VK source. Mirrors TG: empty-parse counter + auto-snooze."""
     logger = get_run_logger()
 
     vk = VkGroupScraper(meme_source_url)
@@ -29,6 +33,21 @@ async def parse_vk_source(
         await insert_parsed_posts_from_vk(meme_source_id, posts)
 
     await update_meme_source(meme_source_id=meme_source_id, parsed_at=datetime.utcnow())
+
+    # Same policy as TG: 3× empty parse / low LR / high ad-rate → snoozed.
+    snooze_reason = await maybe_auto_snooze_source(meme_source_id, len(posts))
+    if snooze_reason:
+        logger.warning(
+            "Auto-snoozed source %s (%s): %s",
+            meme_source_id,
+            meme_source_url,
+            snooze_reason,
+        )
+        await log(
+            f"🔕 Auto-snoozed VK source <b>{meme_source_url}</b> (id={meme_source_id})\n"
+            f"Reason: <code>{snooze_reason}</code>"
+        )
+
     await asyncio.sleep(5)
 
 
@@ -45,6 +64,7 @@ async def parse_vk_sources(
     nposts=10,
 ) -> None:
     logger = get_run_logger()
+    t0 = time.monotonic()
     vk_sources = await get_vk_sources_to_parse(limit=sources_batch_size)
     logger.info(f"Received {len(vk_sources)} vk sources to scrape.")
 
@@ -57,6 +77,12 @@ async def parse_vk_sources(
         except Exception as e:
             fail_count += 1
             logger.error(f"Source {vk_source['id']} ({vk_source['url']}) failed: {e}")
+
+    elapsed = time.monotonic() - t0
+    logger.info(
+        f"Parsing done: {ok_count} ok, {fail_count} failed "
+        f"out of {len(vk_sources)} sources in {elapsed:.0f}s"
+    )
 
     safe_emit(
         "ff.parser.vk.completed",

--- a/src/storage/etl.py
+++ b/src/storage/etl.py
@@ -376,45 +376,156 @@ async def etl_memes_from_raw_telegram_posts(
     await update_or_create_memes(transformed_memes, memes_not_in_memes_table)
 
 
-async def etl_memes_from_raw_vk_posts() -> None:
+async def etl_memes_from_raw_vk_posts(
+    meme_source_ids: list[int] | None = None,
+    *,
+    fresh_only: bool = True,
+) -> None:
+    """Promote raw VK posts into ``meme`` — only for ``parsing_enabled`` sources.
+
+    Parity with TG ETL (ADR-0003 / prepared-source guard):
+    - ``in_moderation`` / snoozed / etc. must not enter the user feed pool.
+    - Single-media only; optional 24h freshness window.
+    - Light engagement gate: top-viewed among latest posts (VK has ``views``).
+    """
+    # Safe media length: media may be non-array JSON in corrupted rows.
+    media_len_sql = """
+        JSONB_ARRAY_LENGTH(
+            CASE
+                WHEN JSONB_TYPEOF(MRV.media) = 'array' THEN MRV.media
+                ELSE '[]'::jsonb
+            END
+        ) = 1
+    """
     transformed_memes = await fetch_all(
         text(
-            """
+            f"""
+                WITH source_medians AS (
+                    SELECT
+                        meme_source_id,
+                        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY views) AS median_views
+                    FROM meme_raw_vk
+                    WHERE COALESCE(updated_at, created_at) >= NOW() - INTERVAL '24 hours'
+                      AND views > 0
+                    GROUP BY meme_source_id
+                ),
+                latest_source_posts AS (
+                    SELECT
+                        MRV.id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY MRV.meme_source_id
+                            ORDER BY MRV.date DESC, MRV.post_id DESC, MRV.id DESC
+                        ) AS recent_rank
+                    FROM meme_raw_vk MRV
+                    INNER JOIN meme_source MS
+                        ON MS.id = MRV.meme_source_id
+                    WHERE MS.status = 'parsing_enabled'
+                        AND MS.type = 'vk'
+                        AND (
+                            NOT :filter_meme_source_ids
+                            OR MRV.meme_source_id = ANY(:meme_source_ids)
+                        )
+                        AND (
+                            NOT :fresh_only
+                            OR COALESCE(MRV.updated_at, MRV.created_at)
+                                >= NOW() - INTERVAL '24 hours'
+                        )
+                ),
+                top_viewed_recent_posts AS (
+                    SELECT id
+                    FROM (
+                        SELECT
+                            MRV.id,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY MRV.meme_source_id
+                                ORDER BY MRV.views DESC, MRV.date DESC,
+                                         MRV.post_id DESC, MRV.id DESC
+                            ) AS views_rank
+                        FROM meme_raw_vk MRV
+                        INNER JOIN latest_source_posts LSP
+                            ON LSP.id = MRV.id
+                        WHERE LSP.recent_rank <= :recent_posts_window
+                    ) ranked_recent
+                    WHERE views_rank <= :top_viewed_posts_limit
+                )
                 SELECT
-                MRV.meme_source_id,
-                MRV.id AS raw_meme_id,
-                MRV.content AS caption,
-                'created' AS status,
-                'image' AS type,
-                MS.language_code AS language_code,
-                MRV.date AS published_at
-            FROM meme_raw_vk AS MRV
-            LEFT JOIN meme_source AS MS
-                ON MS.id = MRV.meme_source_id
-            WHERE 1=1
-                -- only one attachment
-                AND JSONB_ARRAY_LENGTH(MRV.media) = 1
-                AND COALESCE(MRV.updated_at, MRV.created_at) >= NOW() - INTERVAL '24 hours'
-            """  # noqa: E501
-        )
+                    MRV.meme_source_id,
+                    MRV.id AS raw_meme_id,
+                    MRV.content AS caption,
+                    'created' AS status,
+                    'image' AS type,
+                    MS.language_code AS language_code,
+                    MRV.date AS published_at
+                FROM meme_raw_vk AS MRV
+                INNER JOIN meme_source AS MS
+                    ON MS.id = MRV.meme_source_id
+                LEFT JOIN source_medians SM
+                    ON SM.meme_source_id = MRV.meme_source_id
+                INNER JOIN top_viewed_recent_posts TVRP
+                    ON TVRP.id = MRV.id
+                WHERE 1=1
+                    AND MS.status = 'parsing_enabled'
+                    AND MS.type = 'vk'
+                    AND (
+                        NOT :filter_meme_source_ids
+                        OR MRV.meme_source_id = ANY(:meme_source_ids)
+                    )
+                    AND {media_len_sql}
+                    AND (
+                        NOT :fresh_only
+                        OR COALESCE(MRV.updated_at, MRV.created_at)
+                            >= NOW() - INTERVAL '24 hours'
+                    )
+                    AND (
+                        MRV.views = 0
+                        OR SM.median_views IS NULL
+                        OR MRV.views >= SM.median_views * 0.3
+                    )
+            """
+        ),
+        {
+            "filter_meme_source_ids": meme_source_ids is not None,
+            "meme_source_ids": meme_source_ids or [],
+            "fresh_only": fresh_only,
+            "recent_posts_window": TG_RECENT_POSTS_WINDOW,
+            "top_viewed_posts_limit": TG_TOP_VIEWED_POSTS_LIMIT,
+        },
     )
 
     memes_not_in_memes_table = await fetch_all(
         text(
-            """
+            f"""
                 SELECT
                     MRV.meme_source_id,
                     MRV.id AS raw_meme_id
                 FROM meme_raw_vk MRV
+                INNER JOIN meme_source MS
+                    ON MS.id = MRV.meme_source_id
                 LEFT JOIN meme
                     ON meme.meme_source_id = MRV.meme_source_id
                     AND meme.raw_meme_id = MRV.id
                 WHERE 1=1
+                    AND MS.status = 'parsing_enabled'
+                    AND MS.type = 'vk'
+                    AND (
+                        NOT :filter_meme_source_ids
+                        OR MRV.meme_source_id = ANY(:meme_source_ids)
+                    )
+                    AND (
+                        NOT :fresh_only
+                        OR COALESCE(MRV.updated_at, MRV.created_at)
+                            >= NOW() - INTERVAL '24 hours'
+                    )
                     AND meme.meme_source_id IS NULL
                     AND meme.raw_meme_id IS NULL
-                    AND JSONB_ARRAY_LENGTH(MRV.media) = 1
+                    AND {media_len_sql}
             """
-        )
+        ),
+        {
+            "filter_meme_source_ids": meme_source_ids is not None,
+            "meme_source_ids": meme_source_ids or [],
+            "fresh_only": fresh_only,
+        },
     )
 
     await update_or_create_memes(transformed_memes, memes_not_in_memes_table)

--- a/src/storage/service.py
+++ b/src/storage/service.py
@@ -351,27 +351,61 @@ async def get_unloaded_tg_memes(
     )
 
 
-async def get_unloaded_vk_memes(limit: int) -> list[dict[str, Any]]:
-    """Returns memes from VK, that have not been yet uploaded to Telegram."""
+async def get_unloaded_vk_memes(
+    limit: int,
+    meme_source_ids: list[int] | None = None,
+    *,
+    fresh_only: bool = True,
+) -> list[dict[str, Any]]:
+    """Returns VK memes not yet uploaded to Telegram storage.
 
+    Parity with TG unload path:
+    - only ``parsing_enabled`` sources
+    - retry ``broken_content_link`` (ETL already resets → created periodically)
+    - optional fresh window on raw post timestamps
+    """
     select_query = f"""
         SELECT
             meme.id,
             meme.type,
-            meme_raw_vk.media->>0 content_url
+            CASE
+                WHEN JSONB_TYPEOF(meme_raw_vk.media) = 'array'
+                THEN meme_raw_vk.media->>0
+                ELSE meme_raw_vk.media::text
+            END AS content_url
         FROM meme
         INNER JOIN meme_source
             ON meme_source.id = meme.meme_source_id
             AND meme_source.type = '{MemeSourceType.VK.value}'
+            AND meme_source.status = '{MemeSourceStatus.PARSING_ENABLED.value}'
         INNER JOIN meme_raw_vk
             ON meme_raw_vk.id = meme.raw_meme_id
             AND meme_raw_vk.meme_source_id = meme.meme_source_id
         WHERE 1=1
-            AND meme.telegram_file_id IS NULL
+            AND (
+                meme.telegram_file_id IS NULL
+                OR meme.status = 'broken_content_link'
+            )
+            AND (
+                NOT :filter_meme_source_ids
+                OR meme.meme_source_id = ANY(:meme_source_ids)
+            )
+            AND (
+                NOT :fresh_only
+                OR COALESCE(meme_raw_vk.updated_at, meme_raw_vk.created_at)
+                    >= NOW() - INTERVAL '24 hours'
+            )
         ORDER BY meme.published_at DESC
-        LIMIT {limit}
+        LIMIT {int(limit)}
     """
-    return await fetch_all(text(select_query))
+    return await fetch_all(
+        text(select_query),
+        {
+            "filter_meme_source_ids": meme_source_ids is not None,
+            "meme_source_ids": meme_source_ids or [],
+            "fresh_only": fresh_only,
+        },
+    )
 
 
 async def update_meme_status_of_ready_memes(

--- a/tests/storage/test_vk_etl_parity.py
+++ b/tests/storage/test_vk_etl_parity.py
@@ -1,0 +1,219 @@
+"""VK ETL parity with Telegram: parsing_enabled gate + quality windows."""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from src.database import engine, fetch_one, meme, meme_raw_vk, meme_source
+from src.storage import etl as vk_etl
+from src.storage.constants import MemeSourceStatus, MemeSourceType
+from src.storage.etl import etl_memes_from_raw_vk_posts, insert_parsed_posts_from_vk
+from src.storage.parsers.schemas import VkGroupPostParsingResult
+from src.storage.service import get_unloaded_vk_memes
+from tests.factories import TEST_ID_START, cleanup_test_data, create_meme_source
+
+IN_MODERATION_SOURCE_ID = TEST_ID_START + 3100
+ENABLED_SOURCE_ID = TEST_ID_START + 3101
+TOP_VIEWED_SOURCE_ID = TEST_ID_START + 3102
+
+
+def _vk_post(
+    source_id: int,
+    post_id: str,
+    *,
+    views: int = 100,
+    date: datetime | None = None,
+    media: list[str] | None = None,
+) -> VkGroupPostParsingResult:
+    return VkGroupPostParsingResult(
+        post_id=post_id,
+        url=f"https://vk.com/wall-{source_id}_{post_id}",
+        content="мем",
+        media=media or [f"https://example.com/vk_{post_id}.jpg"],
+        date=date or datetime.utcnow(),
+        views=views,
+        likes=10,
+        reposts=1,
+        comments=0,
+    )
+
+
+@pytest_asyncio.fixture()
+async def conn():
+    async with engine.connect() as conn:
+        yield conn
+        await conn.execute(
+            delete(meme_source).where(
+                meme_source.c.id.in_(
+                    [
+                        IN_MODERATION_SOURCE_ID,
+                        ENABLED_SOURCE_ID,
+                        TOP_VIEWED_SOURCE_ID,
+                    ]
+                )
+            )
+        )
+        await conn.commit()
+        await cleanup_test_data(conn)
+
+
+@pytest.mark.asyncio
+async def test_vk_etl_sql_requires_parsing_enabled(monkeypatch):
+    captured = []
+
+    async def fake_fetch_all(query, params=None):
+        captured.append((str(query), params))
+        return []
+
+    async def fake_update_or_create(transformed, missing):
+        return None
+
+    monkeypatch.setattr(vk_etl, "fetch_all", fake_fetch_all)
+    monkeypatch.setattr(vk_etl, "update_or_create_memes", fake_update_or_create)
+
+    await etl_memes_from_raw_vk_posts(fresh_only=True)
+
+    transform_sql, transform_params = captured[0]
+    assert "MS.status = 'parsing_enabled'" in transform_sql
+    assert "top_viewed_recent_posts" in transform_sql
+    assert transform_params["fresh_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_vk_etl_skips_in_moderation_source(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=IN_MODERATION_SOURCE_ID,
+        type=MemeSourceType.VK.value,
+        url=f"https://vk.com/club{IN_MODERATION_SOURCE_ID}",
+        status=MemeSourceStatus.IN_MODERATION.value,
+    )
+    await conn.commit()
+
+    await insert_parsed_posts_from_vk(
+        IN_MODERATION_SOURCE_ID,
+        [_vk_post(IN_MODERATION_SOURCE_ID, "5001")],
+    )
+    await etl_memes_from_raw_vk_posts()
+
+    row = await fetch_one(
+        select(func.count().label("n"))
+        .select_from(meme)
+        .where(meme.c.meme_source_id == IN_MODERATION_SOURCE_ID)
+    )
+    assert row["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_vk_etl_processes_enabled_source(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=ENABLED_SOURCE_ID,
+        type=MemeSourceType.VK.value,
+        url=f"https://vk.com/club{ENABLED_SOURCE_ID}",
+        status=MemeSourceStatus.PARSING_ENABLED.value,
+    )
+    await conn.commit()
+
+    await insert_parsed_posts_from_vk(
+        ENABLED_SOURCE_ID,
+        [_vk_post(ENABLED_SOURCE_ID, "5002", views=200)],
+    )
+    await etl_memes_from_raw_vk_posts()
+
+    created = await fetch_one(select(meme).where(meme.c.meme_source_id == ENABLED_SOURCE_ID))
+    assert created is not None
+    assert created["status"] == "created"
+
+
+@pytest.mark.asyncio
+async def test_vk_etl_promotes_top_five_views_from_latest_ten(conn: AsyncConnection):
+    await create_meme_source(
+        conn,
+        id=TOP_VIEWED_SOURCE_ID,
+        type=MemeSourceType.VK.value,
+        url=f"https://vk.com/club{TOP_VIEWED_SOURCE_ID}",
+        status=MemeSourceStatus.PARSING_ENABLED.value,
+    )
+    await conn.commit()
+
+    base = datetime(2026, 1, 1, 12, 0, 0)
+    posts = [
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6001", views=9999, date=base),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6002", views=8888, date=base + timedelta(minutes=1)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6003", views=10, date=base + timedelta(minutes=2)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6004", views=900, date=base + timedelta(minutes=3)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6005", views=30, date=base + timedelta(minutes=4)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6006", views=800, date=base + timedelta(minutes=5)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6007", views=40, date=base + timedelta(minutes=6)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6008", views=700, date=base + timedelta(minutes=7)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6009", views=50, date=base + timedelta(minutes=8)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6010", views=600, date=base + timedelta(minutes=9)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6011", views=60, date=base + timedelta(minutes=10)),
+        _vk_post(TOP_VIEWED_SOURCE_ID, "6012", views=500, date=base + timedelta(minutes=11)),
+    ]
+    await insert_parsed_posts_from_vk(TOP_VIEWED_SOURCE_ID, posts)
+    await etl_memes_from_raw_vk_posts([TOP_VIEWED_SOURCE_ID], fresh_only=False)
+
+    created = await fetch_one(
+        select(func.count().label("n"))
+        .select_from(meme)
+        .where(meme.c.meme_source_id == TOP_VIEWED_SOURCE_ID)
+    )
+    rows = await conn.execute(
+        select(meme_raw_vk.c.post_id)
+        .select_from(meme)
+        .join(
+            meme_raw_vk,
+            (meme_raw_vk.c.id == meme.c.raw_meme_id)
+            & (meme_raw_vk.c.meme_source_id == meme.c.meme_source_id),
+        )
+        .where(meme.c.meme_source_id == TOP_VIEWED_SOURCE_ID)
+        .order_by(meme_raw_vk.c.post_id)
+    )
+
+    assert created["n"] == 5
+    assert [row.post_id for row in rows] == ["6004", "6006", "6008", "6010", "6012"]
+
+
+@pytest.mark.asyncio
+async def test_get_unloaded_vk_requires_parsing_enabled(monkeypatch):
+    captured = []
+
+    async def fake_fetch_all(query, params=None):
+        captured.append((str(query), params))
+        return []
+
+    monkeypatch.setattr("src.storage.service.fetch_all", fake_fetch_all)
+    await get_unloaded_vk_memes(limit=10)
+
+    sql, params = captured[0]
+    assert "parsing_enabled" in sql
+    assert "broken_content_link" in sql
+    assert params["fresh_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_parse_vk_source_calls_auto_snooze(monkeypatch):
+    from src.flows.parsers import vk as vk_flow
+
+    posts = [_vk_post(1, "1")]
+    scraper = AsyncMock()
+    scraper.get_items = AsyncMock(return_value=posts)
+    monkeypatch.setattr(vk_flow, "VkGroupScraper", lambda url: scraper)
+    monkeypatch.setattr(vk_flow, "insert_parsed_posts_from_vk", AsyncMock())
+    monkeypatch.setattr(vk_flow, "update_meme_source", AsyncMock())
+    monkeypatch.setattr(vk_flow, "maybe_auto_snooze_source", AsyncMock(return_value=None))
+    monkeypatch.setattr(vk_flow, "get_run_logger", lambda: MagicMock())
+    monkeypatch.setattr(vk_flow.asyncio, "sleep", AsyncMock())
+
+    # prefect flow wrapper — call underlying function if needed
+    fn = getattr(vk_flow.parse_vk_source, "fn", vk_flow.parse_vk_source)
+    await fn(42, "https://vk.com/club42", nposts=5)
+
+    vk_flow.maybe_auto_snooze_source.assert_awaited_once_with(42, 1)
+    vk_flow.insert_parsed_posts_from_vk.assert_awaited_once()


### PR DESCRIPTION
## Summary

Closes long-standing TG/VK drift that could flood feed from prepared/snoozed VK sources and skip auto-snooze on dead groups.

| Guard | TG | VK before | VK after |
|-------|----|-----------|----------|
| ETL `parsing_enabled` only | yes | **no** | **yes** |
| Top-view quality gate | yes | no | **yes** (same 10/5 windows) |
| Unload broken-link retry | yes | no | **yes** |
| Auto-snooze after parse | yes | **no** | **yes** |

Does not touch recommendation A/Bs (viral_shares / demote / cold-start).

## Test plan
- [x] Unit: SQL contains `parsing_enabled`; unload filters; parse calls `maybe_auto_snooze_source`
- [x] Integration tests in `tests/storage/test_vk_etl_parity.py` (CI DB)
- [ ] After deploy: no new memes from `in_moderation` VK sources; empty VK groups snooze after 3 parses