### PR TITLE
feat(crosspost): RU v4 meme like-volume ranker

### DIFF
--- a/docs/analyst/crossposting-v4-like-volume.sql
+++ b/docs/analyst/crossposting-v4-like-volume.sql
@@ -1,0 +1,73 @@
+-- RU crosspost score_version=4 (meme like volume) readout
+-- HIT := f1k >= 30.9 OR forwards >= 12  (refresh p75 from 120d quantiles periodically)
+-- Compare score_version 2 (control historical) vs 4 (like-volume) after deploy 2026-08-10+
+
+\set ON_ERROR_STOP on
+
+-- 1) Volume by score_version (30d)
+SELECT
+  score_version,
+  count(*) AS posts,
+  min(created_at)::date AS first_d,
+  max(created_at)::date AS last_d
+FROM crossposting
+WHERE channel = 'tgchannelru'
+  AND created_at > now() - interval '30 days'
+GROUP BY 1
+ORDER BY 1;
+
+-- 2) Mature ~24h outcomes by score_version (image)
+WITH posts AS (
+  SELECT cp.meme_id, cp.created_at, cp.score_version, cp.telegram_message_id
+  FROM crossposting cp
+  JOIN meme m ON m.id = cp.meme_id
+  WHERE cp.channel = 'tgchannelru'
+    AND cp.created_at > now() - interval '30 days'
+    AND cp.created_at < now() - interval '36 hours'
+    AND m.type = 'image'
+    AND cp.telegram_message_id IS NOT NULL
+),
+snap AS (
+  SELECT DISTINCT ON (p.meme_id)
+    p.score_version,
+    s.views,
+    s.forwards,
+    1000.0 * s.forwards / NULLIF(s.views, 0) AS f1k
+  FROM posts p
+  JOIN crossposting_snapshots s
+    ON s.channel = 'tgchannelru'
+   AND s.telegram_message_id = p.telegram_message_id
+   AND s.snapshot_at BETWEEN p.created_at + interval '18 hours'
+                         AND p.created_at + interval '36 hours'
+   AND s.views > 0
+  ORDER BY p.meme_id,
+    abs(extract(epoch from (s.snapshot_at - (p.created_at + interval '24 hours'))))
+)
+SELECT
+  score_version,
+  count(*) AS n,
+  round(avg(views)::numeric, 1) AS avg_views,
+  round(avg(forwards)::numeric, 2) AS avg_fwd,
+  round(avg(f1k)::numeric, 2) AS avg_f1k,
+  round(percentile_cont(0.50) WITHIN GROUP (ORDER BY f1k)::numeric, 2) AS p50_f1k,
+  round(
+    100.0 * count(*) FILTER (WHERE f1k >= 30.9 OR forwards >= 12) / nullif(count(*), 0),
+    1
+  ) AS hit_rate_pct
+FROM snap
+GROUP BY 1
+ORDER BY 1;
+
+-- 3) Decision log: like_volume_factor present on v4
+SELECT
+  score_version,
+  count(*) AS decisions,
+  count(*) FILTER (
+    WHERE (candidates->0->>'like_volume_enabled')::boolean IS TRUE
+  ) AS top1_like_vol_on,
+  round(avg((candidates->0->>'like_volume_factor')::float)::numeric, 3) AS avg_top1_like_vol
+FROM crossposting_decision_log
+WHERE channel = 'tgchannelru'
+  AND decided_at > now() - interval '14 days'
+GROUP BY 1
+ORDER BY 1;

--- a/docs/growth/HYPOTHESES.md
+++ b/docs/growth/HYPOTHESES.md
@@ -266,33 +266,46 @@ week CS3 band.
 
 | Field | Value |
 |-------|--------|
-| **ID** | `crosspost_meme_level_v1` |
-| **Status** | **offline PASS (partial)** — not in cron yet |
-| **Readout** | `docs/analyst/readouts/2026-08-09-crosspost-meme-level-offline.md` |
-| **n** | 611 RU image posts / 120d |
+| **ID** | `crosspost_meme_level_v1` / **score_version=4** |
+| **Status** | **SHIPPING** (RU scheduled ranker default ON) |
+| **Kill switch** | `CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED=false` → v2 |
+| **Readout offline** | `docs/analyst/readouts/2026-08-09-crosspost-meme-level-offline.md` |
+| **Readout online** | `docs/analyst/crossposting-v4-like-volume.sql` |
+| **n offline** | 611 RU image posts / 120d |
 
 ### Hypothesis
 
-Among channel candidates, **timestamp-safe pre-post like volume** (and engaged likes)
-improves 24h channel forwards **beyond source prior**. Bot **like rate** does not.
+Among channel candidates, **like volume** (`ln(nlikes+1)` via `meme_stats`) improves
+24h channel forwards beyond source prior. Bot **like rate** does not.
 
 ### Offline result (2026-08-09)
 
 - pre_lr vs channel: ~0 (reject LR feature)
-- pre_likes / engaged_likes residual Spearman ~**0.16–0.20**
+- pre_likes residual Spearman ~**0.16–0.20**
 - top-20% **src × log1p(pre_likes)** lift **1.14×** forwards (time-split test too)
-- pre_share coverage **2.6%** only
-- HIT threshold: f1k ≥ **~31** (p75) OR forwards ≥ **12**
+- HIT: f1k ≥ **~31** OR forwards ≥ **12**
 
-### Next
+### Production formula (score_version=4)
 
-1. Shadow-log meme score in `crossposting_decision_log` (no post change)
-2. RU canary / score_version bump only after shadow confirms ranking flip quality
-3. Optional ML only if beats `src × log1p(likes)` by ≥5% lift
+```text
+v2_score * LN(COALESCE(nlikes,0) + 1)
+```
+
+Logged in decision candidates: `like_volume_factor`, `like_volume_enabled`.
+
+### Online success (7–14d after deploy)
+
+Compare v4 mature posts vs last 30d v2 baseline:
+
+- hit_rate_pct not down; preferably **+3pp**
+- avg forwards_24h ≥ v2 baseline
+- avg views_24h not &lt; v2 − 15%
+- Kill if hit_rate collapses or empty slots spike
 
 ### Next check
 
-- After shadow deploy: weekly hit_rate + mean forwards vs v2 baseline  
+- **2026-08-12** smoke: score_version=4 rows appear  
+- **2026-08-17** (~7d): `crossposting-v4-like-volume.sql` keep/kill
 
 ---
 

--- a/experiments/HYPOTHESES.md
+++ b/experiments/HYPOTHESES.md
@@ -266,33 +266,46 @@ week CS3 band.
 
 | Field | Value |
 |-------|--------|
-| **ID** | `crosspost_meme_level_v1` |
-| **Status** | **offline PASS (partial)** — not in cron yet |
-| **Readout** | `docs/analyst/readouts/2026-08-09-crosspost-meme-level-offline.md` |
-| **n** | 611 RU image posts / 120d |
+| **ID** | `crosspost_meme_level_v1` / **score_version=4** |
+| **Status** | **SHIPPING** (RU scheduled ranker default ON) |
+| **Kill switch** | `CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED=false` → v2 |
+| **Readout offline** | `docs/analyst/readouts/2026-08-09-crosspost-meme-level-offline.md` |
+| **Readout online** | `docs/analyst/crossposting-v4-like-volume.sql` |
+| **n offline** | 611 RU image posts / 120d |
 
 ### Hypothesis
 
-Among channel candidates, **timestamp-safe pre-post like volume** (and engaged likes)
-improves 24h channel forwards **beyond source prior**. Bot **like rate** does not.
+Among channel candidates, **like volume** (`ln(nlikes+1)` via `meme_stats`) improves
+24h channel forwards beyond source prior. Bot **like rate** does not.
 
 ### Offline result (2026-08-09)
 
 - pre_lr vs channel: ~0 (reject LR feature)
-- pre_likes / engaged_likes residual Spearman ~**0.16–0.20**
+- pre_likes residual Spearman ~**0.16–0.20**
 - top-20% **src × log1p(pre_likes)** lift **1.14×** forwards (time-split test too)
-- pre_share coverage **2.6%** only
-- HIT threshold: f1k ≥ **~31** (p75) OR forwards ≥ **12**
+- HIT: f1k ≥ **~31** OR forwards ≥ **12**
 
-### Next
+### Production formula (score_version=4)
 
-1. Shadow-log meme score in `crossposting_decision_log` (no post change)
-2. RU canary / score_version bump only after shadow confirms ranking flip quality
-3. Optional ML only if beats `src × log1p(likes)` by ≥5% lift
+```text
+v2_score * LN(COALESCE(nlikes,0) + 1)
+```
+
+Logged in decision candidates: `like_volume_factor`, `like_volume_enabled`.
+
+### Online success (7–14d after deploy)
+
+Compare v4 mature posts vs last 30d v2 baseline:
+
+- hit_rate_pct not down; preferably **+3pp**
+- avg forwards_24h ≥ v2 baseline
+- avg views_24h not &lt; v2 − 15%
+- Kill if hit_rate collapses or empty slots spike
 
 ### Next check
 
-- After shadow deploy: weekly hit_rate + mean forwards vs v2 baseline  
+- **2026-08-12** smoke: score_version=4 rows appear  
+- **2026-08-17** (~7d): `crossposting-v4-like-volume.sql` keep/kill
 
 ---
 

--- a/src/config.py
+++ b/src/config.py
@@ -77,6 +77,10 @@ class Config(BaseSettings):
     # Retention broadcasts: pick high-confidence meme (affinity + LR) instead of
     # blind Redis queue pop. Kill switch rolls back to queue path.
     BROADCAST_HIGH_QUALITY_PICK_ENABLED: bool = True
+    # RU crosspost ranker: multiply score by ln(nlikes+1) (meme volume, not LR).
+    # Offline 2026-08-09: src×log1p(likes) top-20% lift ~1.14 on time-split.
+    # Kill switch reverts @fastfoodmemes to score_version=2 behavior.
+    CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED: bool = True
 
     PREFECT_API_URL: str | None = None
     PREFECT_AUTH_STRING: str | None = None

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -1,8 +1,10 @@
+import math
 from typing import Any
 
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert
 
+from src.config import settings
 from src.crossposting.constants import Channel
 from src.database import (
     crossposting,
@@ -10,6 +12,12 @@ from src.database import (
     execute,
     fetch_all,
 )
+
+# score_version in crossposting + decision_log
+SCORE_VERSION_V2 = 2
+SCORE_VERSION_SHARE_MAX = 3
+# RU: v2 factors × ln(nlikes+1) — meme-level like volume (docs/analyst/readouts/2026-08-09-…)
+SCORE_VERSION_MEME_LIKE_VOLUME = 4
 
 
 async def log_meme_sent(
@@ -46,7 +54,12 @@ _CHANNEL_PARAMS: dict[str, dict[str, Any]] = {
 }
 
 
-def _compute_score_breakdown(row: dict[str, Any], channel: str) -> dict[str, Any]:
+def _compute_score_breakdown(
+    row: dict[str, Any],
+    channel: str,
+    *,
+    like_volume_enabled: bool = False,
+) -> dict[str, Any]:
     """Reproduce the SQL ORDER BY in Python so each candidate gets a logged score
     breakdown. Must stay in sync with the ORDER BY in the SQL queries below."""
     params = _CHANNEL_PARAMS[channel]
@@ -76,6 +89,8 @@ def _compute_score_breakdown(row: dict[str, Any], channel: str) -> dict[str, Any
         src_quality_mult = 1.0
 
     invited_boost = 1.0 + min(invited_count, 10) * 0.1
+    # Meme-level volume (not LR): prefers "well tested in bot" over high-LR sparse.
+    like_volume_factor = math.log(float(nlikes) + 1.0) if like_volume_enabled else 1.0
 
     final_score = (
         lr_factor
@@ -85,9 +100,10 @@ def _compute_score_breakdown(row: dict[str, Any], channel: str) -> dict[str, Any
         * sent_factor
         * src_quality_mult
         * invited_boost
+        * like_volume_factor
     )
 
-    return {
+    out = {
         "lr_factor": round(lr_factor, 4),
         "impr_factor": round(impr_factor, 4),
         "age_factor": round(age_factor, 4),
@@ -95,14 +111,19 @@ def _compute_score_breakdown(row: dict[str, Any], channel: str) -> dict[str, Any
         "sent_factor": round(sent_factor, 4),
         "src_quality_mult": round(src_quality_mult, 4),
         "invited_boost": round(invited_boost, 4),
+        "like_volume_factor": round(like_volume_factor, 4),
+        "like_volume_enabled": like_volume_enabled,
         "final_score": round(final_score, 6),
     }
+    return out
 
 
 def _build_decision_log(
     channel: str,
     score_version: int,
     candidates: list[dict[str, Any]],
+    *,
+    like_volume_enabled: bool = False,
 ) -> dict[str, Any] | None:
     """Build the kwargs dict for log_ranker_decision from a top-N candidate list.
     Returns None if candidates is empty."""
@@ -111,7 +132,7 @@ def _build_decision_log(
     picked = candidates[0]
     log_candidates = []
     for i, row in enumerate(candidates):
-        breakdown = _compute_score_breakdown(row, channel)
+        breakdown = _compute_score_breakdown(row, channel, like_volume_enabled=like_volume_enabled)
         log_candidate = {
             "rank": i + 1,
             "meme_id": row["id"],
@@ -242,7 +263,12 @@ _STANDARD_RANKER_QUERY = """
                         )),
                         1.0
                       )
-                    * (1.0 + LEAST(MS.invited_count, 10) * 0.1),
+                    * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
+                    -- meme-level volume (score_version=4): ln(nlikes+1); weight 0 → 1.0
+                    * CASE
+                        WHEN :like_volume_enabled THEN LN(COALESCE(MS.nlikes, 0) + 1.0)
+                        ELSE 1.0
+                      END,
                     M.id
             ) AS candidate_rank
         FROM meme M
@@ -271,7 +297,11 @@ _STANDARD_RANKER_QUERY = """
                 )),
                 1.0
               )
-            * (1.0 + LEAST(MS.invited_count, 10) * 0.1),
+            * (1.0 + LEAST(MS.invited_count, 10) * 0.1)
+            * CASE
+                WHEN :like_volume_enabled THEN LN(COALESCE(MS.nlikes, 0) + 1.0)
+                ELSE 1.0
+              END,
             M.id
         LIMIT :limit
     )
@@ -505,16 +535,30 @@ async def _get_next_meme_for_channel(
     *,
     log_top_n: int,
     score_version: int,
+    like_volume_enabled: bool = False,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
     params = {
         **_CHANNEL_PARAMS[channel],
         "channel": channel,
         "limit": log_top_n,
+        "like_volume_enabled": like_volume_enabled,
     }
     rows = await fetch_all(text(_STANDARD_RANKER_QUERY), params)
     if not rows:
         return None, None
-    return _picked_meme_dict(rows[0]), _build_decision_log(channel, score_version, rows)
+    return (
+        _picked_meme_dict(rows[0]),
+        _build_decision_log(
+            channel,
+            score_version,
+            rows,
+            like_volume_enabled=like_volume_enabled,
+        ),
+    )
+
+
+def _ru_like_volume_ranker_enabled() -> bool:
+    return bool(settings.CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED)
 
 
 async def get_next_meme_for_tgchannelru(
@@ -529,22 +573,32 @@ async def get_next_meme_for_tgchannelru(
       filters.
     - ``decision_log`` — kwargs dict for ``log_ranker_decision``, with the top-N
       candidates and per-candidate score breakdown. ``None`` when no candidates.
+
+    When ``CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED`` (default ON), uses
+    ``score_version=4``: v2 factors × ``ln(nlikes+1)`` so high bot-exposure
+    memes win within source prior (offline H6). Kill switch → v2.
     """
+    like_vol = _ru_like_volume_ranker_enabled()
     return await _get_next_meme_for_channel(
         "tgchannelru",
         log_top_n=log_top_n,
-        score_version=2,
+        score_version=(SCORE_VERSION_MEME_LIKE_VOLUME if like_vol else SCORE_VERSION_V2),
+        like_volume_enabled=like_vol,
     )
 
 
 async def get_next_meme_for_tgchannelen(
     log_top_n: int = 5,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-    """Same as :func:`get_next_meme_for_tgchannelru` but for @fast_food_memes (EN)."""
+    """Same as :func:`get_next_meme_for_tgchannelru` but for @fast_food_memes (EN).
+
+    EN stays on score_version=2 (no like-volume factor) until offline gate passes.
+    """
     return await _get_next_meme_for_channel(
         "tgchannelen",
         log_top_n=log_top_n,
-        score_version=2,
+        score_version=SCORE_VERSION_V2,
+        like_volume_enabled=False,
     )
 
 
@@ -571,7 +625,9 @@ async def get_next_share_max_meme_for_tgchannelru(
     rows = await fetch_all(text(_SHARE_MAX_QUERY), params)
     if not rows:
         return None, None
-    return _picked_meme_dict(rows[0]), _build_decision_log("tgchannelru", 3, rows)
+    return _picked_meme_dict(rows[0]), _build_decision_log(
+        "tgchannelru", SCORE_VERSION_SHARE_MAX, rows
+    )
 
 
 async def get_next_share_max_meme_for_tgchannelen(
@@ -595,4 +651,6 @@ async def get_next_share_max_meme_for_tgchannelen(
     rows = await fetch_all(text(_SHARE_MAX_QUERY), params)
     if not rows:
         return None, None
-    return _picked_meme_dict(rows[0]), _build_decision_log("tgchannelen", 3, rows)
+    return _picked_meme_dict(rows[0]), _build_decision_log(
+        "tgchannelen", SCORE_VERSION_SHARE_MAX, rows
+    )

--- a/src/flows/crossposting/meme.py
+++ b/src/flows/crossposting/meme.py
@@ -5,8 +5,11 @@ from html import escape
 from prefect import flow, get_run_logger
 from telegram.constants import ParseMode
 
+from src.config import settings
 from src.crossposting.constants import Channel
 from src.crossposting.service import (
+    SCORE_VERSION_MEME_LIKE_VOLUME,
+    SCORE_VERSION_V2,
     get_next_meme_for_tgchannelen,
     get_next_meme_for_tgchannelru,
     get_next_share_max_meme_for_tgchannelen,
@@ -220,7 +223,7 @@ async def post_meme_to_tgchannelen():
         Channel.TG_CHANNEL_EN,
         telegram_message_id=msg.message_id,
         caption_text=caption_text,
-        score_version=2,
+        score_version=SCORE_VERSION_V2,
     )
     await update_meme(next_meme.id, status=MemeStatus.PUBLISHED)
 
@@ -270,12 +273,17 @@ async def post_meme_to_tgchannelru():
         bot, TELEGRAM_CHANNEL_RU_CHAT_ID, next_meme, reply_markup=None
     )
 
+    ru_score_version = (
+        SCORE_VERSION_MEME_LIKE_VOLUME
+        if settings.CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED
+        else SCORE_VERSION_V2
+    )
     await log_meme_sent(
         next_meme.id,
         Channel.TG_CHANNEL_RU,
         telegram_message_id=msg.message_id,
         caption_text=caption_text,
-        score_version=2,
+        score_version=ru_score_version,
     )
     await update_meme(next_meme.id, status=MemeStatus.PUBLISHED)
 

--- a/tests/test_crossposting_meme.py
+++ b/tests/test_crossposting_meme.py
@@ -6,6 +6,9 @@ from sqlalchemy import delete, text
 from sqlalchemy.dialects.postgresql import insert
 
 from src.crossposting.service import (
+    SCORE_VERSION_MEME_LIKE_VOLUME,
+    SCORE_VERSION_V2,
+    _compute_score_breakdown,
     get_next_meme_for_tgchannelen,
     get_next_meme_for_tgchannelru,
     get_next_share_max_meme_for_tgchannelen,
@@ -61,6 +64,26 @@ def test_empty_string():
 
 def test_whitespace_only():
     assert _clean_caption("  \n  ") == ""
+
+
+def test_like_volume_factor_raises_score_for_more_likes():
+    base = {
+        "nlikes": 10,
+        "ndislikes": 10,
+        "nmemes_sent": 40,
+        "raw_impr_rank": 0,
+        "age_days": 3,
+        "invited_count": 0,
+        "src_signal": 10.0,
+        "median_signal": 10.0,
+        "caption": None,
+    }
+    low = _compute_score_breakdown({**base, "nlikes": 10}, "tgchannelru", like_volume_enabled=True)
+    high = _compute_score_breakdown({**base, "nlikes": 80}, "tgchannelru", like_volume_enabled=True)
+    off = _compute_score_breakdown({**base, "nlikes": 80}, "tgchannelru", like_volume_enabled=False)
+    assert high["like_volume_factor"] > low["like_volume_factor"]
+    assert high["final_score"] > low["final_score"]
+    assert off["like_volume_factor"] == 1.0
 
 
 # ── Integration tests for get_next_meme_for_tgchannelru ranker ───────────
@@ -152,6 +175,58 @@ async def test_select_excludes_source_posted_within_24h(clean_xpost):
     assert decision is not None
     assert decision["picked_meme_id"] == 10004
     assert decision["candidates"][0]["meme_id"] == 10004
+    assert decision["score_version"] == SCORE_VERSION_MEME_LIKE_VOLUME
+
+
+@pytest.mark.asyncio
+async def test_like_volume_prefers_higher_nlikes_same_source(clean_xpost, monkeypatch):
+    """score_version=4: ln(nlikes+1) re-ranks within equal quality."""
+    monkeypatch.setattr(
+        "src.crossposting.service.settings.CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED",
+        True,
+    )
+    async with engine.connect() as conn:
+        await create_meme_source(conn, id=10500, language_code="ru")
+        await create_meme(
+            conn, id=10501, meme_source_id=10500, language_code="ru", type="image", status="ok"
+        )
+        await create_meme(
+            conn, id=10502, meme_source_id=10500, language_code="ru", type="image", status="ok"
+        )
+        # Same LR ~0.8; volume differs
+        await create_meme_stats(conn, meme_id=10501, nlikes=8, ndislikes=2, nmemes_sent=20)
+        await create_meme_stats(conn, meme_id=10502, nlikes=80, ndislikes=20, nmemes_sent=200)
+        await conn.commit()
+
+    picked, decision = await get_next_meme_for_tgchannelru()
+    assert picked is not None
+    assert picked["id"] == 10502
+    assert decision["score_version"] == SCORE_VERSION_MEME_LIKE_VOLUME
+    assert (
+        decision["candidates"][0]["like_volume_factor"]
+        > decision["candidates"][1]["like_volume_factor"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_ru_kill_switch_falls_back_to_v2(clean_xpost, monkeypatch):
+    monkeypatch.setattr(
+        "src.crossposting.service.settings.CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED",
+        False,
+    )
+    async with engine.connect() as conn:
+        await create_meme_source(conn, id=10510, language_code="ru")
+        await create_meme(
+            conn, id=10511, meme_source_id=10510, language_code="ru", type="image", status="ok"
+        )
+        await create_meme_stats(conn, meme_id=10511, nlikes=20, ndislikes=5)
+        await conn.commit()
+
+    picked, decision = await get_next_meme_for_tgchannelru()
+    assert picked is not None
+    assert decision["score_version"] == SCORE_VERSION_V2
+    assert decision["candidates"][0]["like_volume_enabled"] is False
+    assert decision["candidates"][0]["like_volume_factor"] == 1.0
 
 
 @pytest.mark.asyncio
@@ -578,7 +653,7 @@ async def test_ranker_decision_log_records_top5(clean_xpost):
     row = rows[0]
     assert row["channel"] == "tgchannelru"
     assert row["picked_meme_id"] == picked["id"]
-    assert row["score_version"] == 2
+    assert row["score_version"] == SCORE_VERSION_MEME_LIKE_VOLUME
     assert row["candidate_pool_size"] == 7  # 7 eligible memes
     assert len(row["candidates"]) == 5  # top-5 logged (LIMIT 5)
     # Each entry has the documented score breakdown keys
@@ -603,9 +678,13 @@ async def test_ranker_decision_log_records_top5(clean_xpost):
         "caption_factor",
         "sent_factor",
         "invited_boost",
+        "like_volume_factor",
+        "like_volume_enabled",
         "final_score",
     }
     assert required_keys.issubset(row["candidates"][0].keys())
+    assert row["candidates"][0]["like_volume_enabled"] is True
+    assert row["candidates"][0]["like_volume_factor"] > 1.0
     # Rank order matches list order
     ranks = [c["rank"] for c in row["candidates"]]
     assert ranks == [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Summary

Ships **score_version=4** for scheduled RU channel posts (`@fastfoodmemes`):

```text
score = v2_factors * ln(nlikes + 1)
```

From offline H6 (n=611, 120d): bot **like rate** does not predict channel forwards; **like volume** does (residual + hybrid top-20% lift **1.14×** on time-split).

| | |
|--|--|
| Kill switch | `CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED` (default **true**) |
| EN | unchanged (v2) |
| Decision log | `like_volume_factor`, `like_volume_enabled` |
| Online SQL | `docs/analyst/crossposting-v4-like-volume.sql` |

HIT metric: `f1k ≥ ~31` OR `forwards ≥ 12`.

## Test plan
- [x] Unit: like_volume_factor increases score
- [x] Integration: higher nlikes preferred; kill switch → v2
- [ ] Post-deploy: `score_version=4` on new RU posts; 7d hit_rate vs v2 baseline

## Rollback
`CROSSPOST_RU_MEME_LIKE_VOLUME_ENABLED=false` (no code revert required).