### PR TITLE
feat(crosspost): post-hook + hourly young stats collector

### DIFF
--- a/scripts/serve_flows.py
+++ b/scripts/serve_flows.py
@@ -31,7 +31,10 @@ from src.flows.crossposting.meme import (
     post_share_max_meme_to_tgchannelen,
     post_share_max_meme_to_tgchannelru,
 )
-from src.flows.crossposting.stats_collector import collect_channel_stats
+from src.flows.crossposting.stats_collector import (
+    collect_channel_stats,
+    collect_young_channel_stats,
+)
 from src.flows.crossposting.weekly_report import post_weekly_burger_report
 from src.flows.moderator.source_voting import daily_moderator_source_voting
 
@@ -168,10 +171,17 @@ if __name__ == "__main__":
         post_share_max_meme_to_tgchannelen.to_deployment(
             name="Post Share Max Meme to TG Channel EN",
         ),
-        # ── Channel Stats (every 6h) ──
+        # ── Channel Stats ──
+        # Full sweep: mature 24h labels + subscribers + lifecycle.
         collect_channel_stats.to_deployment(
             name="Collect Channel Stats",
             schedules=[CronSchedule(cron="0 */6 * * *", timezone=LON)],
+        ),
+        # Dense early samples for posts <48h (canary / score_version reads).
+        # Offset :30 so we don't stack with the full :00 sweep.
+        collect_young_channel_stats.to_deployment(
+            name="Collect Young Channel Stats",
+            schedules=[CronSchedule(cron="30 * * * *", timezone=LON)],
         ),
         # ── Editorial (on-demand + weekly report + daily stats digest) ──
         post_editorial_to_channel.to_deployment(

--- a/specs/crossposting-share-optimization-2026-05-18.md
+++ b/specs/crossposting-share-optimization-2026-05-18.md
@@ -142,6 +142,21 @@ Minimum next experiment: RU-only offline evaluator for a timestamp-safe
 prior-share feature, with superuser features measured but coefficient fixed at
 zero. EN stays report-only until it shows a positive offline signal.
 
+## Stats collector (2026-08-10)
+
+`collect_channel_stats` (Telethon) is healthy in prod: ~6h cadence, p50 time to
+first snapshot ~4.7h. Gaps for early canary reads:
+
+| Path | Schedule | Purpose |
+|------|----------|---------|
+| Full sweep | `0 */6` LON | 30d messages + subs + lifecycle |
+| Young posts | `30 * * * *` LON | posts &lt;48h only (dense early curve) |
+| Post-hook | after each TG crosspost | first sample within seconds |
+
+Shared write path: `_persist_crosspost_metrics` → `crossposting_snapshots` +
+live `crossposting.views/forwards`. Single-msg API:
+`refresh_crosspost_message_stats(channel, message_id, meme_id)`.
+
 ## Architecture follow-up
 
 The current ranker SQL and analysis queries are too expensive to rediscover and

--- a/src/flows/crossposting/meme.py
+++ b/src/flows/crossposting/meme.py
@@ -18,6 +18,7 @@ from src.crossposting.service import (
     log_ranker_decision,
 )
 from src.crossposting.vk import post_photo_to_group
+from src.flows.crossposting.stats_collector import refresh_crosspost_message_stats
 from src.flows.hooks import notify_telegram_on_failure
 from src.storage.constants import MemeStatus, MemeType
 from src.storage.schemas import MemeData
@@ -188,6 +189,29 @@ def _get_en_caption_for_crossposting_meme(meme: MemeData, channel: Channel) -> s
     return text
 
 
+async def _safe_refresh_crosspost_stats(
+    channel: Channel,
+    meme_id: int,
+    telegram_message_id: int | None,
+    logger,
+) -> None:
+    """Best-effort first snapshot right after post (does not fail the post flow)."""
+    if telegram_message_id is None:
+        return
+    if channel.value not in ("tgchannelru", "tgchannelen"):
+        return
+    try:
+        await refresh_crosspost_message_stats(channel.value, int(telegram_message_id), meme_id)
+    except Exception as e:
+        logger.warning(
+            "Post-hook stats refresh failed channel=%s meme=%s msg=%s: %s",
+            channel.value,
+            meme_id,
+            telegram_message_id,
+            e,
+        )
+
+
 @flow(
     retries=2,
     retry_delay_seconds=30,
@@ -226,6 +250,7 @@ async def post_meme_to_tgchannelen():
         score_version=SCORE_VERSION_V2,
     )
     await update_meme(next_meme.id, status=MemeStatus.PUBLISHED)
+    await _safe_refresh_crosspost_stats(Channel.TG_CHANNEL_EN, next_meme.id, msg.message_id, logger)
 
     uploader_user_id = await get_meme_uploader_user_id(next_meme.id)
     if uploader_user_id:
@@ -286,6 +311,7 @@ async def post_meme_to_tgchannelru():
         score_version=ru_score_version,
     )
     await update_meme(next_meme.id, status=MemeStatus.PUBLISHED)
+    await _safe_refresh_crosspost_stats(Channel.TG_CHANNEL_RU, next_meme.id, msg.message_id, logger)
 
     if next_meme.type == MemeType.IMAGE:
         try:
@@ -358,6 +384,7 @@ async def post_share_max_meme_to_tgchannelen():
         score_version=3,
     )
     await update_meme(next_meme.id, status=MemeStatus.PUBLISHED)
+    await _safe_refresh_crosspost_stats(Channel.TG_CHANNEL_EN, next_meme.id, msg.message_id, logger)
 
     uploader_user_id = await get_meme_uploader_user_id(next_meme.id)
     if uploader_user_id:
@@ -416,6 +443,7 @@ async def post_share_max_meme_to_tgchannelru():
         score_version=3,
     )
     await update_meme(next_meme.id, status=MemeStatus.PUBLISHED)
+    await _safe_refresh_crosspost_stats(Channel.TG_CHANNEL_RU, next_meme.id, msg.message_id, logger)
 
     uploader_user_id = await get_meme_uploader_user_id(next_meme.id)
     if uploader_user_id:

--- a/src/flows/crossposting/stats_collector.py
+++ b/src/flows/crossposting/stats_collector.py
@@ -4,15 +4,21 @@ Channel post stats collector via Telethon.
 Reads views, forwards, reactions from @ffmemes, @fastfoodmemes, and
 @fast_food_memes channel posts. Stores time-series snapshots for analysis.
 
-Runs every 6 hours via Prefect cron (registered in serve_flows.py).
+Schedules (serve_flows.py):
+- Full sweep every 6h (all recent messages + subscribers + lifecycle)
+- Young-posts hourly (<48h) for early canary / score_version reads
+- Single-message refresh after each crosspost (post-hook)
 
 Uses the same Telethon session string as e2e_smoke.py (TELEGRAM_API_ID,
 TELEGRAM_API_HASH, TELEGRAM_SESSION_STRING env vars).
 """
 
+from __future__ import annotations
+
 import json
 import logging
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from prefect import flow, get_run_logger
 from sqlalchemy import text
@@ -46,6 +52,15 @@ CHANNELS = {
     "tgchannelru": "fastfoodmemes",
     "tgchannelen": "fast_food_memes",
 }
+
+# Crosspost keys that receive post-hook + young-post refresh (not @ffmemes editorial-only).
+CROSSPOST_CHANNEL_KEYS = frozenset({"tgchannelru", "tgchannelen"})
+
+# How long after posting we care about dense early samples.
+YOUNG_POST_MAX_AGE = timedelta(hours=48)
+# Full sweep still refreshes a wider window for mature 24h labels.
+FULL_SWEEP_MESSAGE_LIMIT = 200
+FULL_SWEEP_MAX_AGE = timedelta(days=30)
 
 
 def _get_telethon_client() -> TelegramClient | None:
@@ -236,8 +251,207 @@ async def get_channel_lifecycle_readout(days: int = 7) -> list[dict]:
     )
 
 
+async def _persist_crosspost_metrics(
+    *,
+    channel_key: str,
+    meme_id: int,
+    telegram_message_id: int,
+    views: int,
+    forwards: int,
+    reactions: int,
+    comments: int,
+    reactions_detail: dict[str, int],
+    message_text: str | None = None,
+) -> None:
+    """Write one snapshot row + update live columns on ``crossposting``."""
+    await execute(
+        insert(crossposting_snapshots).values(
+            channel=channel_key,
+            meme_id=meme_id,
+            telegram_message_id=telegram_message_id,
+            views=views,
+            forwards=forwards,
+            reactions=reactions,
+            comments=comments,
+            reactions_detail=reactions_detail or None,
+            message_text=(message_text or "")[:500] if message_text is not None else None,
+        )
+    )
+    await execute(
+        text(
+            "UPDATE crossposting SET views = :views, forwards = :fwd, "
+            "reactions = :react, comments = :comments, "
+            "reactions_detail = :rdetail, stats_updated_at = NOW() "
+            "WHERE channel = :ch AND telegram_message_id = :msg_id"
+        ),
+        {
+            "views": views,
+            "fwd": forwards,
+            "react": reactions,
+            "comments": comments,
+            "rdetail": json.dumps(reactions_detail) if reactions_detail else None,
+            "ch": channel_key,
+            "msg_id": telegram_message_id,
+        },
+    )
+
+
+async def _persist_editorial_metrics(
+    *,
+    channel_key: str,
+    editorial_post_id: int,
+    telegram_message_id: int,
+    views: int,
+    forwards: int,
+    reactions: int,
+    comments: int,
+    reactions_detail: dict[str, int],
+) -> None:
+    await execute(
+        insert(editorial_post_snapshots).values(
+            channel=channel_key,
+            editorial_post_id=editorial_post_id,
+            telegram_message_id=telegram_message_id,
+            views=views,
+            forwards=forwards,
+            reactions=reactions,
+            comments=comments,
+            reactions_detail=reactions_detail or None,
+        )
+    )
+    await execute(
+        text(
+            "UPDATE editorial_posts SET views = :views, forwards = :fwd, "
+            "reactions = :react, comments = :comments, "
+            "reactions_detail = :rdetail, stats_updated_at = NOW() "
+            "WHERE channel = :ch AND telegram_message_id = :msg_id"
+        ),
+        {
+            "views": views,
+            "fwd": forwards,
+            "react": reactions,
+            "comments": comments,
+            "rdetail": json.dumps(reactions_detail) if reactions_detail else None,
+            "ch": channel_key,
+            "msg_id": telegram_message_id,
+        },
+    )
+
+
+async def _with_telethon_client():
+    """Async context-style connect. Caller must disconnect.
+
+    Returns client or None if misconfigured / unauthorized.
+    """
+    log = get_run_logger()
+    client = _get_telethon_client()
+    if client is None:
+        log.warning(
+            "Telethon not configured — set TELEGRAM_API_ID, TELEGRAM_API_HASH, "
+            "TELEGRAM_SESSION_STRING to enable channel stats collection"
+        )
+        return None
+    await client.connect()
+    if not await client.is_user_authorized():
+        log.error(
+            "Telethon session expired. Regenerate with: python scripts/generate_session_string.py"
+        )
+        await client.disconnect()
+        return None
+    return client
+
+
+async def refresh_crosspost_message_stats(
+    channel_key: str,
+    telegram_message_id: int,
+    meme_id: int,
+) -> dict[str, Any] | None:
+    """Fetch stats for one channel message and persist snapshot + live columns.
+
+    Safe to call from post-hooks: returns None and logs on soft failures
+    (no Telethon, private channel, missing message). Does not raise FloodWait
+    to the caller — logs and returns None.
+    """
+    log = get_run_logger()
+    if channel_key not in CHANNELS:
+        log.warning("Unknown channel_key=%s for stats refresh", channel_key)
+        return None
+    if channel_key not in CROSSPOST_CHANNEL_KEYS:
+        log.warning("channel_key=%s is not a crosspost channel; skip", channel_key)
+        return None
+
+    username = CHANNELS[channel_key]
+    client = await _with_telethon_client()
+    if client is None:
+        return None
+
+    try:
+        try:
+            entity = await client.get_entity(username)
+        except ChannelPrivateError:
+            log.error("Cannot access @%s — private or no access", username)
+            return None
+
+        messages = await client.get_messages(entity, ids=telegram_message_id)
+        msg = messages if not isinstance(messages, list) else (messages[0] if messages else None)
+        if msg is None:
+            log.warning(
+                "No Telegram message id=%s on @%s (meme_id=%s)",
+                telegram_message_id,
+                username,
+                meme_id,
+            )
+            return None
+
+        views, forwards, reaction_count, reactions_detail, comments = _extract_metrics(msg)
+        await _persist_crosspost_metrics(
+            channel_key=channel_key,
+            meme_id=meme_id,
+            telegram_message_id=telegram_message_id,
+            views=views,
+            forwards=forwards,
+            reactions=reaction_count,
+            comments=comments,
+            reactions_detail=reactions_detail,
+            message_text=msg.text or "",
+        )
+        log.info(
+            "Refreshed stats @%s msg=%s meme=%s views=%s forwards=%s",
+            username,
+            telegram_message_id,
+            meme_id,
+            views,
+            forwards,
+        )
+        return {
+            "channel": channel_key,
+            "meme_id": meme_id,
+            "telegram_message_id": telegram_message_id,
+            "views": views,
+            "forwards": forwards,
+            "reactions": reaction_count,
+            "comments": comments,
+        }
+    except FloodWaitError as e:
+        log.warning("Telethon flood wait %ss on single-msg refresh @%s", e.seconds, username)
+        return None
+    except SessionExpiredError:
+        log.error("Telethon session expired during single-msg refresh")
+        return None
+    except Exception as e:
+        log.error(
+            "Single-msg stats refresh failed @%s msg=%s: %s",
+            username,
+            telegram_message_id,
+            e,
+        )
+        return None
+    finally:
+        await client.disconnect()
+
+
 async def _collect_post_stats(client: TelegramClient, channel_key: str, channel_username: str):
-    """Collect views/forwards/reactions for recent posts in a channel.
+    """Full sweep: views/forwards/reactions for recent posts in a channel.
 
     Posts may be tracked in two places: `crossposting` (meme cross-posts, high
     volume) or `editorial_posts` (agent-written updates, ~1/day). A single
@@ -251,12 +465,11 @@ async def _collect_post_stats(client: TelegramClient, channel_key: str, channel_
         log.error(f"Cannot access @{channel_username} — private or no access")
         return
 
-    # Fetch a wider window: editorial posts are low-volume (~1/day) so we want
-    # to keep refreshing them for ~30 days. Meme crossposts get most of their
-    # views in the first 48h, but re-updating is cheap.
-    messages = await client.get_messages(entity, limit=200)
+    # Editorial posts are low-volume (~1/day) so we keep refreshing ~30 days.
+    # Meme crossposts get most views in the first 48h; re-updating is cheap.
+    messages = await client.get_messages(entity, limit=FULL_SWEEP_MESSAGE_LIMIT)
 
-    cutoff = datetime.utcnow() - timedelta(days=30)
+    cutoff = datetime.utcnow() - FULL_SWEEP_MAX_AGE
     recent_messages = [m for m in messages if m.date and m.date.replace(tzinfo=None) > cutoff]
 
     log.info(f"@{channel_username}: {len(recent_messages)} posts in last 30d")
@@ -264,7 +477,6 @@ async def _collect_post_stats(client: TelegramClient, channel_key: str, channel_
     if not recent_messages:
         return
 
-    # Build two lookup maps so a single message update is routed correctly.
     crosspost_rows = await fetch_all(
         text(
             "SELECT meme_id, telegram_message_id FROM crossposting "
@@ -296,74 +508,107 @@ async def _collect_post_stats(client: TelegramClient, channel_key: str, channel_
         editorial_id = known_editorial.get(msg.id)
 
         if meme_id is not None:
-            await execute(
-                insert(crossposting_snapshots).values(
-                    channel=channel_key,
-                    meme_id=meme_id,
-                    telegram_message_id=msg.id,
-                    views=views,
-                    forwards=forwards,
-                    reactions=reaction_count,
-                    comments=comments,
-                    reactions_detail=reactions_detail or None,
-                    message_text=(msg.text or "")[:500],
-                )
+            await _persist_crosspost_metrics(
+                channel_key=channel_key,
+                meme_id=meme_id,
+                telegram_message_id=msg.id,
+                views=views,
+                forwards=forwards,
+                reactions=reaction_count,
+                comments=comments,
+                reactions_detail=reactions_detail,
+                message_text=msg.text or "",
             )
             crosspost_snapshots += 1
-            await execute(
-                text(
-                    "UPDATE crossposting SET views = :views, forwards = :fwd, "
-                    "reactions = :react, comments = :comments, "
-                    "reactions_detail = :rdetail, stats_updated_at = NOW() "
-                    "WHERE channel = :ch AND telegram_message_id = :msg_id"
-                ),
-                {
-                    "views": views,
-                    "fwd": forwards,
-                    "react": reaction_count,
-                    "comments": comments,
-                    "rdetail": json.dumps(reactions_detail) if reactions_detail else None,
-                    "ch": channel_key,
-                    "msg_id": msg.id,
-                },
-            )
 
         if editorial_id is not None:
-            await execute(
-                insert(editorial_post_snapshots).values(
-                    channel=channel_key,
-                    editorial_post_id=editorial_id,
-                    telegram_message_id=msg.id,
-                    views=views,
-                    forwards=forwards,
-                    reactions=reaction_count,
-                    comments=comments,
-                    reactions_detail=reactions_detail or None,
-                )
+            await _persist_editorial_metrics(
+                channel_key=channel_key,
+                editorial_post_id=editorial_id,
+                telegram_message_id=msg.id,
+                views=views,
+                forwards=forwards,
+                reactions=reaction_count,
+                comments=comments,
+                reactions_detail=reactions_detail,
             )
             editorial_snapshots += 1
-            await execute(
-                text(
-                    "UPDATE editorial_posts SET views = :views, forwards = :fwd, "
-                    "reactions = :react, comments = :comments, "
-                    "reactions_detail = :rdetail, stats_updated_at = NOW() "
-                    "WHERE channel = :ch AND telegram_message_id = :msg_id"
-                ),
-                {
-                    "views": views,
-                    "fwd": forwards,
-                    "react": reaction_count,
-                    "comments": comments,
-                    "rdetail": json.dumps(reactions_detail) if reactions_detail else None,
-                    "ch": channel_key,
-                    "msg_id": msg.id,
-                },
-            )
 
     log.info(
         f"@{channel_username}: {crosspost_snapshots} crosspost snapshots, "
         f"{editorial_snapshots} editorial snapshots"
     )
+
+
+async def _collect_young_crosspost_stats(
+    client: TelegramClient,
+    channel_key: str,
+    channel_username: str,
+    *,
+    max_age: timedelta = YOUNG_POST_MAX_AGE,
+) -> int:
+    """Refresh only young crossposts (dense early samples for canaries)."""
+    log = get_run_logger()
+    if channel_key not in CROSSPOST_CHANNEL_KEYS:
+        return 0
+
+    young = await fetch_all(
+        text(
+            """
+            SELECT meme_id, telegram_message_id
+            FROM crossposting
+            WHERE channel = :channel
+              AND telegram_message_id IS NOT NULL
+              AND created_at > NOW() - make_interval(hours => :max_age_hours)
+            ORDER BY created_at DESC
+            """
+        ),
+        {
+            "channel": channel_key,
+            "max_age_hours": int(max_age.total_seconds() // 3600),
+        },
+    )
+    if not young:
+        log.info("@%s: no young crossposts to refresh", channel_username)
+        return 0
+
+    try:
+        entity = await client.get_entity(channel_username)
+    except ChannelPrivateError:
+        log.error("Cannot access @%s — private or no access", channel_username)
+        return 0
+
+    ids = [int(r["telegram_message_id"]) for r in young]
+    id_to_meme = {int(r["telegram_message_id"]): int(r["meme_id"]) for r in young}
+
+    # Telethon accepts a list of ids; may return list aligned with request.
+    messages = await client.get_messages(entity, ids=ids)
+    if not isinstance(messages, list):
+        messages = [messages]
+
+    refreshed = 0
+    for msg in messages:
+        if msg is None:
+            continue
+        meme_id = id_to_meme.get(msg.id)
+        if meme_id is None:
+            continue
+        views, forwards, reaction_count, reactions_detail, comments = _extract_metrics(msg)
+        await _persist_crosspost_metrics(
+            channel_key=channel_key,
+            meme_id=meme_id,
+            telegram_message_id=msg.id,
+            views=views,
+            forwards=forwards,
+            reactions=reaction_count,
+            comments=comments,
+            reactions_detail=reactions_detail,
+            message_text=msg.text or "",
+        )
+        refreshed += 1
+
+    log.info("@%s: refreshed %s/%s young crossposts", channel_username, refreshed, len(young))
+    return refreshed
 
 
 async def _collect_subscriber_count(
@@ -409,26 +654,14 @@ async def _collect_subscriber_count(
     on_failure=[notify_telegram_on_failure],
 )
 async def collect_channel_stats():
-    """Collect post stats and subscriber counts for all crossposting channels."""
+    """Full sweep: post stats + subscriber counts + lifecycle for all channels."""
     log = get_run_logger()
 
-    client = _get_telethon_client()
+    client = await _with_telethon_client()
     if client is None:
-        log.warning(
-            "Telethon not configured — set TELEGRAM_API_ID, TELEGRAM_API_HASH, "
-            "TELEGRAM_SESSION_STRING to enable channel stats collection"
-        )
         return
 
     try:
-        await client.connect()
-        if not await client.is_user_authorized():
-            log.error(
-                "Telethon session expired. Regenerate with: "
-                "python scripts/generate_session_string.py"
-            )
-            return
-
         for channel_key, channel_username in CHANNELS.items():
             try:
                 await _collect_post_stats(client, channel_key, channel_username)
@@ -446,3 +679,40 @@ async def collect_channel_stats():
         await client.disconnect()
 
     log.info("Channel stats collection complete")
+
+
+@flow(
+    name="Collect Young Channel Stats",
+    retries=1,
+    retry_delay_seconds=30,
+    timeout_seconds=180,
+    on_failure=[notify_telegram_on_failure],
+)
+async def collect_young_channel_stats():
+    """Hourly dense refresh for crossposts younger than 48h (early fwd/views).
+
+    Complements the 6h full sweep so canaries (e.g. score_version=4) get
+    1h/3h/6h samples instead of waiting up to a full 6h cycle.
+    """
+    log = get_run_logger()
+    client = await _with_telethon_client()
+    if client is None:
+        return
+
+    total = 0
+    try:
+        for channel_key in CROSSPOST_CHANNEL_KEYS:
+            username = CHANNELS[channel_key]
+            try:
+                total += await _collect_young_crosspost_stats(client, channel_key, username)
+            except FloodWaitError as e:
+                log.warning("Telethon flood wait: %ss — skipping @%s", e.seconds, username)
+            except SessionExpiredError:
+                log.error("Telethon session expired mid young-post collection")
+                return
+            except Exception as e:
+                log.error("Young-post stats error @%s: %s", username, e)
+    finally:
+        await client.disconnect()
+
+    log.info("Young channel stats complete: %s messages refreshed", total)

--- a/tests/flows/crossposting/test_stats_refresh.py
+++ b/tests/flows/crossposting/test_stats_refresh.py
@@ -1,0 +1,161 @@
+"""Unit tests for crosspost stats persistence + single-msg / young refresh."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.flows.crossposting import stats_collector
+
+
+class _FakeLog:
+    def info(self, *a, **k):
+        pass
+
+    def warning(self, *a, **k):
+        pass
+
+    def error(self, *a, **k):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_persist_crosspost_metrics_writes_snapshot_and_live(monkeypatch):
+    calls = []
+
+    async def fake_execute(stmt, params=None):
+        calls.append((str(stmt), params))
+        return MagicMock(rowcount=1)
+
+    monkeypatch.setattr(stats_collector, "execute", fake_execute)
+
+    await stats_collector._persist_crosspost_metrics(
+        channel_key="tgchannelru",
+        meme_id=42,
+        telegram_message_id=100,
+        views=50,
+        forwards=3,
+        reactions=2,
+        comments=0,
+        reactions_detail={"❤": 2},
+        message_text="hi",
+    )
+
+    assert len(calls) == 2
+    # second call is the UPDATE with live columns
+    _, params = calls[1]
+    assert params["views"] == 50
+    assert params["fwd"] == 3
+    assert params["msg_id"] == 100
+    assert params["ch"] == "tgchannelru"
+
+
+@pytest.mark.asyncio
+async def test_refresh_single_message_happy_path(monkeypatch):
+    msg = SimpleNamespace(
+        id=777,
+        views=12,
+        forwards=2,
+        reactions=SimpleNamespace(results=[]),
+        replies=None,
+        text="cta",
+    )
+
+    class Client:
+        async def connect(self):
+            pass
+
+        async def disconnect(self):
+            pass
+
+        async def is_user_authorized(self):
+            return True
+
+        async def get_entity(self, name):
+            return SimpleNamespace(username=name)
+
+        async def get_messages(self, entity, ids=None):
+            assert ids == 777
+            return msg
+
+    monkeypatch.setattr(stats_collector, "_get_telethon_client", lambda: Client())
+    monkeypatch.setattr(stats_collector, "get_run_logger", lambda: _FakeLog())
+    persist = AsyncMock()
+    monkeypatch.setattr(stats_collector, "_persist_crosspost_metrics", persist)
+
+    result = await stats_collector.refresh_crosspost_message_stats("tgchannelru", 777, meme_id=999)
+
+    assert result is not None
+    assert result["views"] == 12
+    assert result["forwards"] == 2
+    persist.assert_awaited_once()
+    kwargs = persist.await_args.kwargs
+    assert kwargs["meme_id"] == 999
+    assert kwargs["telegram_message_id"] == 777
+
+
+@pytest.mark.asyncio
+async def test_refresh_skips_unknown_channel(monkeypatch):
+    monkeypatch.setattr(stats_collector, "get_run_logger", lambda: _FakeLog())
+    result = await stats_collector.refresh_crosspost_message_stats("nope", 1, 2)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_young_collect_uses_id_list(monkeypatch):
+    young_rows = [
+        {"meme_id": 1, "telegram_message_id": 10},
+        {"meme_id": 2, "telegram_message_id": 20},
+    ]
+    msgs = [
+        SimpleNamespace(
+            id=10,
+            views=1,
+            forwards=0,
+            reactions=None,
+            replies=None,
+            text="",
+        ),
+        SimpleNamespace(
+            id=20,
+            views=5,
+            forwards=1,
+            reactions=None,
+            replies=None,
+            text="",
+        ),
+    ]
+
+    class Client:
+        async def get_entity(self, name):
+            return SimpleNamespace(username=name)
+
+        async def get_messages(self, entity, ids=None):
+            assert ids == [10, 20]
+            return msgs
+
+    monkeypatch.setattr(stats_collector, "fetch_all", AsyncMock(return_value=young_rows))
+    monkeypatch.setattr(stats_collector, "get_run_logger", lambda: _FakeLog())
+    persist = AsyncMock()
+    monkeypatch.setattr(stats_collector, "_persist_crosspost_metrics", persist)
+
+    n = await stats_collector._collect_young_crosspost_stats(
+        Client(), "tgchannelru", "fastfoodmemes"
+    )
+    assert n == 2
+    assert persist.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_swallows_errors(monkeypatch):
+    from src.crossposting.constants import Channel
+    from src.flows.crossposting import meme as meme_flow
+
+    monkeypatch.setattr(
+        meme_flow,
+        "refresh_crosspost_message_stats",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    )
+    log = MagicMock()
+    await meme_flow._safe_refresh_crosspost_stats(Channel.TG_CHANNEL_RU, 1, 2, log)
+    log.warning.assert_called()


### PR DESCRIPTION
## Summary

Channel stats collector was healthy but **blind for up to ~6h** after a post (batch `0 */6` LON). That made early v4 share checks useless (NULL views/forwards).

### Changes
1. **Shared write path** `_persist_crosspost_metrics` (snapshot + live `crossposting` columns)
2. **`refresh_crosspost_message_stats`** — Telethon fetch one message; used as **post-hook** after RU/EN (and share-max) posts
3. **`collect_young_channel_stats`** — hourly (`30 * * * *` LON), only posts **&lt;48h**
4. Full 6h sweep unchanged for 24h labels / subs / lifecycle

### Ops
After deploy: restart Prefect `serve_flows` process so the new hourly deployment is registered.

## Test plan
- [x] Unit: persist, single-msg refresh, young collect, post-hook swallows errors
- [x] Lifecycle tests still pass
- [ ] Post-deploy: next RU post has views/forwards within minutes; young flow in Prefect UI

## Rollback
Remove young deployment / post-hook calls; 6h sweep alone still works.