### PR TITLE
feat(tgbot): /last, help menu, private DM message_tg logging

### DIFF
--- a/docs/analyst/README.md
+++ b/docs/analyst/README.md
@@ -10,6 +10,7 @@ The Analyst agent monitors product health, tracks experiments, and produces dail
 
 ## Key Files
 - `docs/analyst/metrics.sql` — SQL queries organized by section (health, north star, engines, retention, etc.)
+- `docs/analyst/command-surface-proxies.sql` — private slash commands from `message_tg` (`chat_id > 0`) + secondary feature proxies. Notes: [`docs/product/surface-and-commands.md`](../product/surface-and-commands.md).
 - `docs/analyst/viral-shares-blender-v1.sql` — readout for `viral_shares_blender_v1` (share clickers + invites vs control + session guardrail).
 - `docs/analyst/dwell-feed-vs-broadcast.sql` — `sec_to_react` percentiles: like vs skip × feed vs broadcast; dwell buckets; demote inventory risk.
 - `docs/analyst/source-affinity-demote-guardrails.sql` — post-deploy volume / LR checks for soft-demote (#340).
@@ -40,7 +41,7 @@ Key tables for analytics:
 | `user_deep_link_log` | Share click tracking (growth proxy) | user_id, deep_link, created_at |
 | `chat_agent_usage` | AI agent calls in group chats | chat_id, user_id, prompt_tokens, completion_tokens, tool_calls, response_time_ms, trigger_type |
 | `chat_meme_reaction` | Like/dislike votes on memes in group chats | chat_id, meme_id, user_id, reaction (1=like, 2=dislike) |
-| `message_tg` | All group messages (AI context) | chat_id, message_id, user_id, text, date |
+| `message_tg` | Group messages (AI context) **and private inbound DMs** (commands/text/media) | chat_id (>0 private), message_id, user_id, text, date |
 
 ## Reaction ID Mapping
 - `reaction_id = 1` → Like (👍)

--- a/docs/analyst/command-surface-proxies.sql
+++ b/docs/analyst/command-surface-proxies.sql
@@ -1,0 +1,88 @@
+-- Command / product-surface proxies
+-- Private DMs (incl. slash commands) land in message_tg with chat_id > 0.
+-- Companion notes: docs/product/surface-and-commands.md
+
+-- 1) Core feed
+SELECT
+  COUNT(*) FILTER (WHERE reacted_at > now() - interval '7 days') AS reactions_7d,
+  COUNT(DISTINCT user_id) FILTER (WHERE reacted_at > now() - interval '7 days') AS users_7d,
+  COUNT(*) FILTER (WHERE reacted_at > now() - interval '30 days') AS reactions_30d,
+  COUNT(DISTINCT user_id) FILTER (WHERE reacted_at > now() - interval '30 days') AS users_30d,
+  ROUND(
+    100.0 * COUNT(*) FILTER (
+      WHERE reacted_at > now() - interval '7 days' AND reaction_id = 2
+    ) / NULLIF(
+      COUNT(*) FILTER (
+        WHERE reacted_at > now() - interval '7 days' AND reaction_id IS NOT NULL
+      ),
+      0
+    ),
+    1
+  ) AS skip_pct_7d
+FROM user_meme_reaction
+WHERE reacted_at > now() - interval '30 days';
+
+-- 2) Deep-link buckets
+SELECT
+  CASE
+    WHEN deep_link IS NULL OR deep_link = '' THEN '(empty)'
+    WHEN deep_link ~ '^(m|s)_' THEN 'share_meme'
+    WHEN deep_link ~ '^sc_' THEN 'channel_share'
+    WHEN deep_link = 'kitchen' THEN 'kitchen'
+    WHEN deep_link LIKE 'giveaway%' THEN 'giveaway'
+    WHEN deep_link = 'wrapped' THEN 'wrapped'
+    WHEN deep_link = 'inline_search_request' THEN 'inline_search_request'
+    ELSE 'other'
+  END AS bucket,
+  COUNT(*) AS events,
+  COUNT(DISTINCT user_id) AS users
+FROM user_deep_link_log
+WHERE created_at > now() - interval '30 days'
+GROUP BY 1
+ORDER BY events DESC;
+
+-- 3) Economy / treasury
+SELECT type, COUNT(*) AS n, COUNT(DISTINCT user_id) AS users, SUM(amount) AS sum_amount
+FROM treasury_trx
+WHERE created_at > now() - interval '30 days'
+GROUP BY type
+ORDER BY n DESC;
+
+-- 4) Secondary surfaces (unique users 30d)
+SELECT 'feed_reactors' AS feature, COUNT(DISTINCT user_id) AS users
+FROM user_meme_reaction
+WHERE reacted_at > now() - interval '30 days'
+UNION ALL
+SELECT 'uploaders', COUNT(DISTINCT user_id)
+FROM meme_raw_upload
+WHERE created_at > now() - interval '30 days'
+UNION ALL
+SELECT 'inline_searchers', COUNT(DISTINCT user_id)
+FROM inline_search_logs
+WHERE searched_at > now() - interval '30 days'
+UNION ALL
+SELECT 'bot_chat_payers', COUNT(DISTINCT user_id)
+FROM treasury_trx
+WHERE type = 'bot_reply_payment' AND created_at > now() - interval '30 days'
+ORDER BY users DESC;
+
+-- 5) Private slash commands from message_tg (chat_id > 0 = private DMs)
+SELECT
+  lower(split_part(split_part(trim(text), ' ', 1), '@', 1)) AS command,
+  COUNT(*) AS n,
+  COUNT(DISTINCT user_id) AS users
+FROM message_tg
+WHERE date > now() - interval '30 days'
+  AND chat_id > 0
+  AND text LIKE '/%'
+GROUP BY 1
+ORDER BY n DESC;
+
+-- 6) Private DM volume vs groups
+SELECT
+  CASE WHEN chat_id > 0 THEN 'private' ELSE 'group_or_channel' END AS kind,
+  COUNT(*) AS messages,
+  COUNT(DISTINCT user_id) AS users
+FROM message_tg
+WHERE date > now() - interval '30 days'
+GROUP BY 1;

--- a/docs/product/surface-and-commands.md
+++ b/docs/product/surface-and-commands.md
@@ -1,0 +1,239 @@
+# Product surface & commands — living notes
+
+**Status:** living product notes (started 2026-08-11)  
+**Audience:** founder + agents prioritising what to build next  
+**Companion data SQL:** [`docs/analyst/command-surface-proxies.sql`](../analyst/command-surface-proxies.sql)
+
+This is **not** a full SPEC. It captures product nuance, what users actually do,
+and decisions about the bot command surface (`/help`, menu, `/last`).
+
+---
+
+## Core product (what actually matters)
+
+| Layer | Reality |
+|-------|---------|
+| **Primary loop** | Infinite meme feed. Like ❤️ / skip ⏬ on the keyboard. Session north star = memes per session. |
+| **`/start`** | Telegram platform default, not a “feature menu”. Delivers a meme + handles **deep links** (share `m_`/`s_`, channel `sc_`, `kitchen`, giveaways, acquisition refs). Do **not** sell `/start` in `/help` as a product capability unless it becomes a real hub. |
+| **Like / skip** | Visible on every meme keyboard. Do **not** document them as “commands”. Skip is closer to TikTok “next” than “hate this” (see growth notes / dwell). |
+| **Growth** | Organic via share deep links under memes + inline. See [`docs/growth/virality-loop.md`](../growth/virality-loop.md). |
+
+Everything else is secondary surface: economy, upload, lang, chat agent, wrapped, stats.
+
+---
+
+## Founder notes (2026-08-11)
+
+### Burgers 🍔
+
+- Internal currency earned for bot use (daily activity), uploads, share clicks, invites, weekly upload tops, etc.
+- **Spend today is weak:** mainly **1 🍔 per reply** when the bot is in a group and someone triggers the DeepSeek agent (`bot_reply_payment`).
+- Quality of group chat replies is **poor vs peers** (e.g. countdurovbot prompts feel better).
+- Original hope: people add the bot to chats so it **occasionally posts memes** with **low LLM cost** — not a full chat companion.
+- Open strategic question: is the economy a real product loop, a joke meta, or scaffolding for a future sink (meme drops in groups, boosts, cosmetics…)? Until there is a good sink, **don’t put burgers in the centre of the menu**.
+
+### Languages (`/lang`)
+
+- Current UI: multi-select picker of content languages.
+- **Not intuitive.** Telegram `language_code` is a weak signal (`en` often means nothing about meme taste).
+- Content language is really: **`meme_source.language_code` + OCR / describe_memes** on the meme.
+- Product intent for lang should be “what languages of memes do I want?”, not “what language is my Telegram app?”.
+- Refactor candidate (later): smarter default from TG + first share/source affinity; simplify picker to 1–2 primary languages; stop looking like a settings dump.
+
+### Command surface philosophy
+
+- Prefer **almost empty BotFather menu**: maybe **`/last`** (re-show previous meme) + **`/help`** (catalog of the rest).
+- Do not clutter help with base loop (like/skip) or platform `/start` unless deep links need explaining in one line.
+- Kitchen/balance/leaderboard are optional depth for people who care about 🍔 — discoverable from `/help`, not necessarily from ☰.
+
+### `/last` (aka `/previous` / `/prev`)
+
+- Real pain: after skip, the bot **replaces** the previous meme message → “brain hadn’t processed it, meme is gone”.
+- Multiple users have asked.
+- v1: **command only**, re-send last meme (no keyboard button, no multi-step history, no undo-dislike stats rewrite).
+- Name options: `/last` (short, clear) vs `/previous` / `/prev`. Prefer one public name + aliases.
+
+---
+
+## Instrumentation (commands)
+
+### What we already had (and what we didn't)
+
+| Store | Scope | Slash commands in private DM? |
+|-------|--------|-------------------------------|
+| `message_tg` | **Group/channel** messages (chat-agent context) | **No** — private `/kitchen` never landed here |
+| `user_deep_link_log` | `/start <payload>` deep links only | Only when args present |
+| `inline_search_logs` | Inline queries | N/A |
+| `treasury_trx` | Economy side effects | Indirect proxy only |
+
+So “логи всех сообщений” = **group AI context**, not a private command audit trail.
+
+### Now shipping
+
+- **Private DMs → `message_tg`**: inbound private messages (text, media, `/commands`) are saved via PTB group `-1` → `save_telegram_message`. Groups already used this path for the chat agent.
+- Command usage readout: `message_tg` where `chat_id > 0` and `text LIKE '/%'` (see analyst SQL).
+- **Not logged:** like/skip callbacks (still `user_meme_reaction`); bot outbound meme sends (same ledger).
+- Menu `set_my_commands`: **`/last` first**, then `/help` (localized ru/en/uk).
+- `/last` (`/previous`, `/prev`): re-send last delivered meme by `sent_at` (like or skip), with buttons; **re-reaction allowed**.
+
+Readout SQL: `docs/analyst/command-surface-proxies.sql`.
+
+### Domain tables still exist on purpose
+
+| Store | Job |
+|-------|-----|
+| `message_tg` | Transport: groups **and** private inbound DMs |
+| `user_deep_link_log` | Growth attribution |
+| `user_meme_reaction` | Core feed send + reaction |
+| `treasury_trx` / inline / agent | Economy, inline, LLM cost |
+
+Outbound bot messages and callbacks are not mirrored into `message_tg` (volume + PII). Product ledgers stay the source of truth for those.
+
+---
+
+---
+
+## Real usage snapshot (prod readonly, ~2026-08-11)
+
+Window: last **30 days** unless noted. Active ≈ `user.last_active_at`.
+
+### Core loop (orders of magnitude above everything)
+
+| Signal | 7d | 30d |
+|--------|----|-----|
+| Users who reacted | **390** | **626** |
+| Reactions | ~141k | ~609k |
+| Skip share of reactions (7d) | **66%** skip / 34% like | — |
+
+Skip is the majority action → **re-show last meme is high-leverage UX**, not a niche power-user toy.
+
+### Secondary features (unique users, 30d proxies)
+
+| Feature / proxy | Users 30d | Notes |
+|-----------------|-----------|--------|
+| Feed reactors | **626** | Core |
+| Daily reward earners | **494** | Auto from activity, not a command |
+| Nickname set (active users) | **127** | ~17% of 762 active-30d |
+| Uploaders | **40** | Strong UGC core of a small power group |
+| Non-self share clickers | **22** | Growth still thin |
+| Share-click rewards (`meme_shared`) | **13** | |
+| Inviters | **11** | |
+| Inline searchers | **12** (58 queries) | Historically larger (10k searches all-time); currently cold |
+| Bot chat payers (`bot_reply_payment`) | **12** | Spend sink barely used |
+| Kitchen **deep link** only | **10** | `/kitchen` command itself **unmeasured** |
+| Stars `purchase_token` | **3 ever** | Economy not monetising |
+| `user_wrapped` rows | **0** | Seasonal; dead outside campaigns |
+
+### Group chat agent (burgers sink)
+
+| Metric | Value |
+|--------|--------|
+| Agent calls 30d | **25** |
+| Distinct users 30d | **10** |
+| Distinct chats 30d | **2** |
+| All-time top chat | Moderator chat dominates volume |
+| Chats with `bot_status=member` | handful |
+
+**Read:** group-LLM companion is not a product people use. It burns product attention and LLM quality debt for ~dozens of calls/month. Aligns with founder gut: either **meme-in-chat with low cost**, or deprioritise agent quality work.
+
+### Languages
+
+| Signal | Value |
+|--------|--------|
+| Active 30d multi-lang (`≥2` codes) | **359 / 762** |
+| Lang rows added **after** first hour (90d) | **11 users** |
+
+**Read:** multi-lang is mostly **onboarding / auto-seed**, not deliberate multi-picker use. Investing in multi-select polish is low ROI vs smarter defaults + OCR/source language quality.
+
+### Deep links 30d (entry intents we *do* see)
+
+| Bucket | Events | Users |
+|--------|--------|-------|
+| empty `/start` | 566 | 190 |
+| share `m_`/`s_` | 258 | 105 |
+| channel `sc_` | 149 | 45 |
+| kitchen | 12 | 10 |
+| inline_search_request | 7 | 7 |
+| wrapped | 5 | 3 |
+
+Share/start still dominate intentional deep links. Kitchen/wrapped almost unused as links.
+
+---
+
+## What this implies for the menu
+
+### Evidence-based ranking of surfaces
+
+1. **Feed + skip/like** — the product. No command needed.
+2. **`/last`** — fills a hole created by our own replace-on-skip UX; skip is 66% of reactions.
+3. **`/help`** — needed because discoverability is oral + kitchen footer + popups; menu is not code-owned.
+4. **Upload** (send media, not a command) — small but real power-user loop; keep visible in help.
+5. **Share / inline** — strategic for growth; low current volume; don’t bury forever, but don’t centre menu on them until share loop improves.
+6. **🍔 economy commands** (`/balance`, `/kitchen`, `/leaderboard`, `/nickname`) — secondary. Nickname has some adoption; kitchen deep-link almost none; paid spend near zero.
+7. **`/lang`** — needed for wrong-language pain, but UX should be redesigned later; one line in help is enough.
+8. **Group agent** — do not promote in user menu until strategy is clear.
+9. **`/stats`, `/wrapped`, `/delete`, admin/mod** — help footnote or hidden.
+
+### Concrete menu (shipped)
+
+**Telegram ☰ (order matters):**
+
+1. `/last` — Предыдущий мем / Show previous meme  
+2. `/help` — Что умеет бот / What this bot can do
+
+**`/help` body (short):**
+
+- One line: лента = лайк/скип под мемом (not a command list item).
+- `/last` — вернуть прошлый мем.
+- Пришли мем боту — загрузка; `/uploads` если есть.
+- Поделиться — кнопка под мемом / `@ffmemesbot` inline.
+- Языки мемов — `/lang` (one line).
+- Бургеры — `/kitchen` (collapse detail there).
+- Написать нам — `/chat`.
+- Данные — `/delete`.
+- Do **not** lead with `/start`.
+
+Aliases: `/last` = `/previous` = `/prev` if cheap.
+
+### Shipping order
+
+| Step | Why |
+|------|-----|
+| 1. `user_command_log` (or equivalent) | Stop flying blind |
+| 2. `set_my_commands` + `/help` | Own the surface in code |
+| 3. `/last` re-show | Highest user-visible pain vs effort |
+| 4. Re-read command log after 2–4 weeks | Decide whether kitchen/lang deserve ☰ slots |
+| 5. Lang UX refactor | After defaults/OCR clarity |
+| 6. Burgers strategy | Separate product decision: meme-in-chat sink vs sunset promotion of agent |
+
+---
+
+## Open product bets (not decided)
+
+1. **Burgers:** joke points vs real economy. Needs a non-LLM sink people want (e.g. “send meme to this chat”, boosts, cosmetics) or honest de-emphasis.
+2. **Bot in groups:** meme poster on a schedule / on emoji trigger **without** chat-LLM — closer to original idea and to cost structure.
+3. **`/lang`:** reduce to primary language + optional “also show EN/RU”, driven by source+OCR quality.
+4. **Inline:** historically used, now cold — is that discovery, quality, or ranking? Separate investigation.
+5. **Share loop still tiny** (22 non-self clickers / 30d) vs 626 reactors — growth work still dominates long-term value; command cleanup is hygiene, not north star.
+
+---
+
+## Related code
+
+| Area | Where |
+|------|--------|
+| Handler registration | `src/tgbot/app.py` |
+| Feed keyboard | `src/tgbot/senders/keyboards.py` |
+| Replace-on-skip | `src/tgbot/senders/next_message.py` (`should_replace_previous`) |
+| Economy copy | `src/tgbot/handlers/treasury/commands.py` (`/kitchen`) |
+| Group agent charge | `src/tgbot/handlers/chat/chat.py` |
+| Deep links | `src/tgbot/handlers/start.py`, `user_deep_link_log` |
+| No `set_my_commands` today | (gap) |
+
+---
+
+## Changelog
+
+- **2026-08-11:** Initial notes from founder conversation + first prod proxy readout (no direct command telemetry).
+- **2026-08-11:** Private DMs → `message_tg` (no separate command table); `/last` + `/help` menu (`last` first); re-reaction allowed.
+

--- a/src/recommendations/service.py
+++ b/src/recommendations/service.py
@@ -41,18 +41,32 @@ async def update_user_meme_reaction(
     meme_id: int,
     reaction_id: int,
 ) -> bool:
+    """Persist a reaction.
+
+    Returns True when the stored reaction changed:
+    - first reaction (NULL → value), or
+    - re-reaction with a different value (e.g. accidental skip → like via /last).
+
+    Same-value double taps return False so the feed does not advance twice.
+    """
     update_query = (
         user_meme_reaction.update()
         .where(user_meme_reaction.c.user_id == user_id)
         .where(user_meme_reaction.c.meme_id == meme_id)
-        .where(user_meme_reaction.c.reaction_id.is_(None))  # not sure abot that
+        # NULL or a different reaction_id — allow corrections after /last re-show.
+        .where(user_meme_reaction.c.reaction_id.is_distinct_from(reaction_id))
         .values(reaction_id=reaction_id, reacted_at=datetime.utcnow())
     )
     res = await execute(update_query)
-    reaction_is_new = res.rowcount > 0
-    if not reaction_is_new:
-        logging.debug(f"User {user_id} already reacted to meme {meme_id}!")
-    return reaction_is_new  # I can filter double clicks
+    reaction_changed = res.rowcount > 0
+    if not reaction_changed:
+        logging.debug(
+            "User %s already has reaction %s on meme %s",
+            user_id,
+            reaction_id,
+            meme_id,
+        )
+    return reaction_changed
 
 
 async def update_user_last_active_at(

--- a/src/tgbot/app.py
+++ b/src/tgbot/app.py
@@ -17,6 +17,7 @@ from telegram.ext import (
 
 from src.config import settings
 from src.observability.sentry import telegram_update_scope
+from src.tgbot.commands_catalog import sync_bot_commands
 from src.tgbot.constants import (
     LANG_SETTINGS_END_CALLBACK_DATA,
     LANG_SETTINGS_LANG_CHANGE_CALLBACK_PATTERN,
@@ -66,6 +67,7 @@ from src.tgbot.handlers.chat.send_tokens import (
     reward_active_chat_users,
     send_tokens_to_reply,
 )
+from src.tgbot.handlers.help import handle_help, handle_last
 from src.tgbot.handlers.moderator.registry import add_moderator_handlers
 from src.tgbot.handlers.payments.purchase import (
     PURCHASE_TOKEN_CALLBACK_DATA_REGEXP,
@@ -74,6 +76,7 @@ from src.tgbot.handlers.payments.purchase import (
     refund_command,
     successful_payment_callback,
 )
+from src.tgbot.handlers.private_message_log import log_private_inbound_message
 from src.tgbot.handlers.stats.stats import handle_stats
 from src.tgbot.handlers.stats.wrapped import handle_wrapped, handle_wrapped_button
 from src.tgbot.handlers.treasury.commands import (
@@ -95,10 +98,38 @@ def _get_update_user_id(update: Update) -> int | None:
 
 
 def add_handlers(application: Application) -> None:
+    # Analytics: persist all private DMs (incl. slash commands) into message_tg.
+    # PTB runs each handler group independently; group -1 does not block group 0.
+    application.add_handler(
+        MessageHandler(
+            filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
+            log_private_inbound_message,
+        ),
+        group=-1,
+    )
+
     application.add_handler(
         CommandHandler(
             "start",
             start.handle_start,
+            filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
+        )
+    )
+
+    ###################
+    # re-show previous meme + help catalog
+    # /last is first in set_my_commands (see commands_catalog).
+    application.add_handler(
+        CommandHandler(
+            ["last", "previous", "prev"],
+            handle_last,
+            filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
+        )
+    )
+    application.add_handler(
+        CommandHandler(
+            "help",
+            handle_help,
             filters=filters.ChatType.PRIVATE & filters.UpdateType.MESSAGE,
         )
     )
@@ -497,9 +528,14 @@ async def setup_webhook(application: Application) -> None:
     await application.start()
 
 
+async def _post_init(application: Application) -> None:
+    await sync_bot_commands(application.bot)
+
+
 def setup_application(is_webhook: bool = False) -> Application:
     application_builder = Application.builder().token(settings.TELEGRAM_BOT_TOKEN)
     application_builder.rate_limiter(AIORateLimiter(max_retries=10))
+    application_builder.post_init(_post_init)
 
     if is_webhook:
         application_builder.updater(None)

--- a/src/tgbot/commands_catalog.py
+++ b/src/tgbot/commands_catalog.py
@@ -1,0 +1,57 @@
+"""User-facing bot command surface (menu + help).
+
+Keep the Telegram ☰ menu intentionally tiny. Secondary commands live in /help.
+See docs/product/surface-and-commands.md.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from telegram import Bot, BotCommand
+
+logger = logging.getLogger(__name__)
+
+# Default menu language + per-language overrides for set_my_commands.
+# /last is always first — the only high-frequency command we want in ☰.
+MENU_COMMANDS_DEFAULT: list[tuple[str, str]] = [
+    ("last", "Show previous meme"),
+    ("help", "What this bot can do"),
+]
+
+MENU_COMMANDS_BY_LANG: dict[str, list[tuple[str, str]]] = {
+    "ru": [
+        ("last", "Предыдущий мем"),
+        ("help", "Что умеет бот"),
+    ],
+    "en": MENU_COMMANDS_DEFAULT,
+    "uk": [
+        ("last", "Попередній мем"),
+        ("help", "Що вміє бот"),
+    ],
+}
+
+# Public command names for the last/help surface (typed or menu).
+PUBLIC_COMMANDS = frozenset(
+    {
+        "last",
+        "previous",
+        "prev",
+        "help",
+    }
+)
+
+
+def menu_bot_commands(language_code: str | None = None) -> list[BotCommand]:
+    pairs = MENU_COMMANDS_BY_LANG.get(language_code or "", MENU_COMMANDS_DEFAULT)
+    return [BotCommand(command=name, description=desc) for name, desc in pairs]
+
+
+async def sync_bot_commands(bot: Bot) -> None:
+    """Push the user menu to Telegram (default + a few language codes)."""
+    try:
+        await bot.set_my_commands(menu_bot_commands())
+        for lang in ("ru", "en", "uk"):
+            await bot.set_my_commands(menu_bot_commands(lang), language_code=lang)
+    except Exception:
+        logger.exception("Failed to sync Telegram bot commands menu")

--- a/src/tgbot/handlers/help.py
+++ b/src/tgbot/handlers/help.py
@@ -1,0 +1,82 @@
+"""User-facing /help and /last (re-show previous meme)."""
+
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.constants import ParseMode
+from telegram.ext import ContextTypes
+
+from src import localizer
+from src.storage.schemas import MemeData
+from src.tgbot.repo.memes import get_last_sent_meme_for_user
+from src.tgbot.senders.meme import send_meme_to_user
+from src.tgbot.user_info import get_user_info
+
+logger = logging.getLogger(__name__)
+
+
+def _interface_lang(user_info: dict | None) -> str | None:
+    if not user_info:
+        return None
+    return user_info.get("interface_lang")
+
+
+async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if update.effective_user is None or update.message is None:
+        return
+
+    try:
+        user_info = await get_user_info(update.effective_user.id)
+    except Exception:
+        logger.exception("help: failed to load user_info for %s", update.effective_user.id)
+        user_info = None
+
+    text = localizer.t("help.text", _interface_lang(user_info))
+    await update.message.reply_text(text, parse_mode=ParseMode.HTML)
+
+
+async def handle_last(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Re-send the user's most recently delivered meme (skip undo is out of scope)."""
+    if update.effective_user is None or update.message is None:
+        return
+
+    user_id = update.effective_user.id
+    try:
+        user_info = await get_user_info(user_id)
+    except Exception:
+        logger.exception("last: failed to load user_info for %s", user_id)
+        user_info = None
+
+    lang = _interface_lang(user_info)
+    row = await get_last_sent_meme_for_user(user_id)
+    if row is None:
+        await update.message.reply_text(localizer.t("last.none", lang))
+        return
+
+    try:
+        meme = MemeData(
+            id=row["id"],
+            type=row["type"],
+            telegram_file_id=row["telegram_file_id"],
+            caption=row.get("caption"),
+            language_code=row.get("language_code"),
+            recommended_by="last",
+            nlikes=int(row.get("nlikes") or 0),
+        )
+    except Exception:
+        logger.exception("last: invalid meme row for user %s: %s", user_id, row.get("id"))
+        await update.message.reply_text(localizer.t("last.unavailable", lang))
+        return
+
+    try:
+        await send_meme_to_user(
+            context.bot,
+            user_id,
+            meme,
+            recommended_by="last",
+        )
+    except Exception:
+        logger.exception("last: failed to re-send meme %s to user %s", meme.id, user_id)
+        await update.message.reply_text(localizer.t("last.unavailable", lang))

--- a/src/tgbot/handlers/private_message_log.py
+++ b/src/tgbot/handlers/private_message_log.py
@@ -1,0 +1,39 @@
+"""Persist private DM traffic into message_tg.
+
+Historically message_tg only stored group/channel messages for the chat agent.
+Private slash commands (/last, /kitchen, …) were invisible in analytics.
+
+Inbound private messages (text, media, commands) are now written with the same
+row shape. Outbound bot messages are still not mirrored here — product ledgers
+cover meme sends (user_meme_reaction) and other domains.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from src.tgbot.handlers.chat.service import save_telegram_message
+
+logger = logging.getLogger(__name__)
+
+
+async def log_private_inbound_message(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    """Best-effort: never block real command/upload handlers (PTB group -1)."""
+    msg = update.message
+    if msg is None:
+        return
+    try:
+        await save_telegram_message(msg)
+    except Exception:
+        logger.warning(
+            "Failed to log private message %s from user %s",
+            getattr(msg, "message_id", None),
+            getattr(update.effective_user, "id", None),
+            exc_info=True,
+        )

--- a/src/tgbot/repo/memes.py
+++ b/src/tgbot/repo/memes.py
@@ -33,6 +33,34 @@ async def get_shareable_meme_by_id(id: int) -> dict[str, Any] | None:
     return await fetch_one(text(query), {"id": id, "status": MemeStatus.OK.value})
 
 
+async def get_last_sent_meme_for_user(user_id: int) -> dict[str, Any] | None:
+    """Most recently delivered meme for this user that can still be re-sent."""
+    query = """
+        SELECT
+            M.id,
+            M.type,
+            M.telegram_file_id,
+            M.caption,
+            M.language_code,
+            'last' AS recommended_by,
+            COALESCE(MS.nlikes, 0) AS nlikes
+        FROM user_meme_reaction R
+        JOIN meme M
+            ON M.id = R.meme_id
+        LEFT JOIN meme_stats MS
+            ON MS.meme_id = M.id
+        WHERE R.user_id = :user_id
+            AND M.status = :status
+            AND M.telegram_file_id IS NOT NULL
+        ORDER BY R.sent_at DESC
+        LIMIT 1
+    """
+    return await fetch_one(
+        text(query),
+        {"user_id": user_id, "status": MemeStatus.OK.value},
+    )
+
+
 async def get_meme_stats(meme_id: int) -> dict[str, Any] | None:
     select_statement = select(meme_stats).where(meme_stats.c.meme_id == meme_id)
     return await fetch_one(select_statement)

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -33,6 +33,7 @@ from src.tgbot.repo.meme_sources import (
     update_meme_source,
 )
 from src.tgbot.repo.memes import (
+    get_last_sent_meme_for_user,
     get_meme_by_id,
     get_meme_stats,
     get_meme_stats_for_meme_ids,
@@ -72,6 +73,7 @@ __all__ = [
     "dismiss_source_candidate",
     "get_experiment_assignment",
     "get_experiment_variant",
+    "get_last_sent_meme_for_user",
     "get_meme_by_id",
     "get_meme_source_by_id",
     "get_meme_source_stats_by_id",

--- a/static/localization/service.yml
+++ b/static/localization/service.yml
@@ -1,3 +1,75 @@
+help.text:
+  en: |-
+    <b>Fast Food Memes</b>
+
+    Feed: like ❤️ / skip ⏬ under each meme.
+
+    /last — show the previous meme again (with buttons; you can change your reaction)
+
+    Upload — just send a meme to the bot
+    /uploads — your uploads
+
+    Share — button under the meme, or @ffmemesbot in any chat
+
+    /lang — meme languages
+    /kitchen — burgers 🍔
+    /balance · /leaderboard · /nickname
+
+    /chat — message us
+    /delete — delete your data
+  ru: |-
+    <b>Fast Food Memes</b>
+
+    Лента: лайк ❤️ / скип ⏬ под мемом.
+
+    /last — показать прошлый мем (с кнопками; реакцию можно поменять)
+
+    Загрузка — просто пришли мем боту
+    /uploads — твои загрузки
+
+    Поделиться — кнопка под мемом или @ffmemesbot в любом чате
+
+    /lang — языки мемов
+    /kitchen — бургеры 🍔
+    /balance · /leaderboard · /nickname
+
+    /chat — написать нам
+    /delete — удалить данные
+  uk: |-
+    <b>Fast Food Memes</b>
+
+    Стрічка: лайк ❤️ / скіп ⏬ під мемом.
+
+    /last — показати попередній мем (з кнопками; реакцію можна змінити)
+
+    Завантаження — просто надішли мем боту
+    /uploads — твої завантаження
+
+    Поділитися — кнопка під мемом або @ffmemesbot у будь-якому чаті
+
+    /lang — мови мемів
+    /kitchen — бургери 🍔
+    /balance · /leaderboard · /nickname
+
+    /chat — написати нам
+    /delete — видалити дані
+
+last.none:
+  en: |-
+    No previous meme yet — press /start and watch a few first.
+  ru: |-
+    Пока нечего возвращать — жми /start и посмотри пару мемов.
+  uk: |-
+    Поки немає попереднього мема — натисни /start і подивись кілька мемів.
+
+last.unavailable:
+  en: |-
+    Couldn't re-send that meme. Try /start for a new one.
+  ru: |-
+    Не получилось показать прошлый мем. Жми /start за новым.
+  uk: |-
+    Не вийшло показати попередній мем. Тисни /start за новим.
+
 service.out_of_memes:
   en: |-
     🚀 You've watched all the memes we've prepared for you! 

--- a/tests/recommendations/test_reaction_service.py
+++ b/tests/recommendations/test_reaction_service.py
@@ -92,10 +92,10 @@ async def test_update_reaction_returns_true_on_new(setup):
 
 
 @pytest.mark.asyncio
-async def test_update_reaction_returns_false_on_duplicate(setup):
+async def test_update_reaction_returns_false_on_same_value_double_tap(setup):
     await create_user_meme_reaction(10001, 10001, "test")
     await update_user_meme_reaction(10001, 10001, reaction_id=1)
-    result = await update_user_meme_reaction(10001, 10001, reaction_id=2)
+    result = await update_user_meme_reaction(10001, 10001, reaction_id=1)
     assert result is False
 
 
@@ -109,12 +109,13 @@ async def test_update_reaction_sets_reacted_at(setup):
 
 
 @pytest.mark.asyncio
-async def test_update_reaction_does_not_overwrite(setup):
+async def test_update_reaction_allows_change_skip_to_like(setup):
+    """Accidental skip can be corrected after /last re-shows the meme."""
     await create_user_meme_reaction(
-        10001, 10001, "test", reaction_id=1, reacted_at=datetime.utcnow()
+        10001, 10001, "test", reaction_id=2, reacted_at=datetime.utcnow()
     )
-    result = await update_user_meme_reaction(10001, 10001, reaction_id=2)
-    assert result is False
+    result = await update_user_meme_reaction(10001, 10001, reaction_id=1)
+    assert result is True
     row = await _get_reaction(10001, 10001)
     assert row["reaction_id"] == 1
 

--- a/tests/tgbot/test_help_and_last.py
+++ b/tests/tgbot/test_help_and_last.py
@@ -1,0 +1,149 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.storage.constants import MemeType
+from src.tgbot.commands_catalog import PUBLIC_COMMANDS, menu_bot_commands
+from src.tgbot.handlers import help as help_handlers
+from src.tgbot.handlers import private_message_log
+
+
+def _make_update(user_id: int = 10001):
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=user_id),
+        message=SimpleNamespace(reply_text=AsyncMock()),
+    )
+
+
+def _make_context():
+    return SimpleNamespace(bot=object())
+
+
+def test_menu_bot_commands_last_is_first():
+    for lang in (None, "ru", "en", "uk"):
+        cmds = menu_bot_commands(lang)
+        assert [c.command for c in cmds][0] == "last"
+        assert [c.command for c in cmds] == ["last", "help"]
+    assert menu_bot_commands("ru")[0].description == "Предыдущий мем"
+    assert "start" not in {c.command for c in menu_bot_commands()}
+    assert PUBLIC_COMMANDS >= {"last", "help", "previous", "prev"}
+
+
+@pytest.mark.asyncio
+async def test_help_uses_russian_when_interface_lang_ru(monkeypatch):
+    update = _make_update()
+    monkeypatch.setattr(
+        help_handlers,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "ru"}),
+    )
+
+    await help_handlers.handle_help(update, _make_context())
+
+    text = update.message.reply_text.call_args.args[0]
+    assert "/last" in text
+    assert "Лента" in text or "лайк" in text
+    assert "Как получить бургеры" not in text
+
+
+@pytest.mark.asyncio
+async def test_help_uses_english_fallback(monkeypatch):
+    update = _make_update()
+    monkeypatch.setattr(
+        help_handlers,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "de"}),
+    )
+
+    await help_handlers.handle_help(update, _make_context())
+
+    text = update.message.reply_text.call_args.args[0]
+    assert "Feed:" in text
+    assert "/last" in text
+
+
+@pytest.mark.asyncio
+async def test_last_replies_when_no_history(monkeypatch):
+    update = _make_update()
+    monkeypatch.setattr(
+        help_handlers,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "ru"}),
+    )
+    monkeypatch.setattr(
+        help_handlers,
+        "get_last_sent_meme_for_user",
+        AsyncMock(return_value=None),
+    )
+
+    await help_handlers.handle_last(update, _make_context())
+
+    text = update.message.reply_text.call_args.args[0]
+    assert "/start" in text
+
+
+@pytest.mark.asyncio
+async def test_last_resends_meme(monkeypatch):
+    update = _make_update(user_id=42)
+    send = AsyncMock()
+    monkeypatch.setattr(
+        help_handlers,
+        "get_user_info",
+        AsyncMock(return_value={"interface_lang": "en"}),
+    )
+    monkeypatch.setattr(
+        help_handlers,
+        "get_last_sent_meme_for_user",
+        AsyncMock(
+            return_value={
+                "id": 99,
+                "type": MemeType.IMAGE,
+                "telegram_file_id": "file-1",
+                "caption": "hi",
+                "language_code": "ru",
+                "recommended_by": "last",
+                "nlikes": 3,
+            }
+        ),
+    )
+    monkeypatch.setattr(help_handlers, "send_meme_to_user", send)
+
+    await help_handlers.handle_last(update, _make_context())
+
+    send.assert_awaited_once()
+    kwargs = send.call_args.kwargs
+    assert kwargs["recommended_by"] == "last"
+    meme = send.call_args.args[2]
+    assert meme.id == 99
+    update.message.reply_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_private_inbound_log_uses_message_tg(monkeypatch):
+    saved = AsyncMock()
+    monkeypatch.setattr(private_message_log, "save_telegram_message", saved)
+
+    msg = SimpleNamespace(message_id=7, text="/last")
+    update = SimpleNamespace(
+        message=msg,
+        effective_user=SimpleNamespace(id=42),
+    )
+    await private_message_log.log_private_inbound_message(update, SimpleNamespace())
+
+    saved.assert_awaited_once_with(msg)
+
+
+@pytest.mark.asyncio
+async def test_private_inbound_log_swallows_errors(monkeypatch):
+    monkeypatch.setattr(
+        private_message_log,
+        "save_telegram_message",
+        AsyncMock(side_effect=RuntimeError("db down")),
+    )
+    update = SimpleNamespace(
+        message=SimpleNamespace(message_id=1, text="/help"),
+        effective_user=SimpleNamespace(id=1),
+    )
+    # Must not raise
+    await private_message_log.log_private_inbound_message(update, SimpleNamespace())

--- a/tests/tgbot/test_reaction_handler.py
+++ b/tests/tgbot/test_reaction_handler.py
@@ -142,6 +142,28 @@ async def test_duplicate_reaction_skips_next_message(
 @patch(f"{HANDLER_MODULE}.update_user_last_active_at", new_callable=AsyncMock)
 @patch(f"{HANDLER_MODULE}.maybe_send_moderator_invite", new_callable=AsyncMock)
 @patch(f"{HANDLER_MODULE}.update_user_info_counters", new_callable=AsyncMock)
+async def test_re_reaction_skip_to_like_advances_feed(
+    mock_counters, mock_mod_invite, mock_active, mock_reward, mock_next, setup
+):
+    """After /last, user can flip accidental skip → like and get the next meme."""
+    from src.tgbot.handlers.reaction import handle_reaction
+
+    await create_user_meme_reaction(10001, 10001, "test", reaction_id=2)
+    mock_counters.return_value = {"nmemes_sent": 51, "memes_watched_today": 1}
+
+    update = _make_update(meme_id=10001, reaction_id=1)
+    context = _make_context()
+    await handle_reaction(update, context)
+
+    mock_next.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch(f"{HANDLER_MODULE}.next_message", new_callable=AsyncMock)
+@patch(f"{HANDLER_MODULE}.reward_user_for_daily_activity", new_callable=AsyncMock)
+@patch(f"{HANDLER_MODULE}.update_user_last_active_at", new_callable=AsyncMock)
+@patch(f"{HANDLER_MODULE}.maybe_send_moderator_invite", new_callable=AsyncMock)
+@patch(f"{HANDLER_MODULE}.update_user_info_counters", new_callable=AsyncMock)
 async def test_calls_update_user_info_counters(
     mock_counters, mock_mod_invite, mock_active, mock_reward, mock_next, setup
 ):


### PR DESCRIPTION
## Summary

- **`/last`** (aliases `/prev`, `/previous`): re-sends the user's most recently delivered meme (liked or skipped) with the normal like/skip/share keyboard.
- **Re-reaction**: changing skip→like (or the reverse) updates `user_meme_reaction` and advances the feed; same-value double-tap still no-ops.
- **Bot menu**: `set_my_commands` — **`/last` first**, then `/help` (localized ru/en/uk).
- **`/help`**: short product catalog (no treat-as-feature `/start` pitch; kitchen details stay on `/kitchen`).
- **Private DMs → `message_tg`**: all inbound private messages (text/media/commands) persist via the same `save_telegram_message` path groups already used, so slash usage is queryable with `chat_id > 0 AND text LIKE '/%'`. No separate `user_command_log` table.
- Docs: `docs/product/surface-and-commands.md`, `docs/analyst/command-surface-proxies.sql`.

## Why

Users asked to recover a meme after accidental skip. Discoverability of secondary commands was poor (no `set_my_commands`). Command analytics needed a transport path without inventing another ledger.

## Test plan

- [x] `pytest tests/tgbot/test_help_and_last.py tests/tgbot/test_reaction_handler.py tests/recommendations/test_reaction_service.py tests/tgbot/test_chat_service.py`
- [ ] Deploy: restart bot so `post_init` runs `set_my_commands`
- [ ] In prod bot DM: `/last` after a skip re-shows the meme; like works and next meme arrives
- [ ] After a few days: run analyst SQL section for private slash commands from `message_tg`