### PR TITLE
fix(tgbot): /last reacted, onboarding language, cold-start queue

### DIFF
--- a/docs/product/surface-and-commands.md
+++ b/docs/product/surface-and-commands.md
@@ -236,4 +236,5 @@ Aliases: `/last` = `/previous` = `/prev` if cheap.
 
 - **2026-08-11:** Initial notes from founder conversation + first prod proxy readout (no direct command telemetry).
 - **2026-08-11:** Private DMs → `message_tg` (no separate command table); `/last` + `/help` menu (`last` first); re-reaction allowed.
+- **2026-08-11:** `/last` = last *reacted* meme (not last sent/visible). Onboarding: single-language picker; auto-skip for ru/uk/CIS/cyrillic name; welcome only after language. Cold-start queue refill limit=5 while nmemes_sent<30 so adapt stage re-plans.
 

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -234,7 +234,13 @@ async def check_queue(user_id: int) -> bool:
         queue_length = await redis.get_meme_queue_length_by_key(queue_key)
 
         if queue_length <= 8:
-            await generate_recommendations(user_id, limit=15)
+            # Cold start: small batches so maturity stage re-plans as nmemes_sent
+            # grows (explore → adapt). A single limit=15 fill at nmemes_sent=0
+            # used to leave users stuck on explore_guarded for the whole queue.
+            user_info = await get_user_info(user_id)
+            nmemes_sent = int(user_info.get("nmemes_sent") or 0)
+            limit = 5 if nmemes_sent < 30 else 15
+            await generate_recommendations(user_id, limit=limit)
     except Exception:
         # DB connection errors (pool exhaustion, connection killed mid-query)
         # are expected under traffic spikes. Queue will refill on next attempt.

--- a/src/tgbot/app.py
+++ b/src/tgbot/app.py
@@ -23,6 +23,7 @@ from src.tgbot.constants import (
     LANG_SETTINGS_LANG_CHANGE_CALLBACK_PATTERN,
     MEME_BUTTON_CALLBACK_DATA_REGEXP,
     MEME_QUEUE_IS_EMPTY_ALERT_CALLBACK_DATA,
+    ONBOARDING_LANG_CALLBACK_REGEXP,
     POPUP_BUTTON_CALLBACK_DATA_REGEXP,
     TELEGRAM_CHANNEL_RU_CHAT_ID,
     TELEGRAM_FEEDBACK_CHAT_ID,
@@ -155,6 +156,14 @@ def add_handlers(application: Application) -> None:
         CallbackQueryHandler(
             language.handle_language_settings_end,
             pattern=LANG_SETTINGS_END_CALLBACK_DATA,
+        )
+    )
+
+    # New-user single-language onboarding picker
+    application.add_handler(
+        CallbackQueryHandler(
+            language.handle_onboarding_language_selected,
+            pattern=ONBOARDING_LANG_CALLBACK_REGEXP,
         )
     )
 

--- a/src/tgbot/constants.py
+++ b/src/tgbot/constants.py
@@ -97,9 +97,13 @@ INLINE_SEARCH_REQUEST_DEEPLINK = "inline_search_request"
 # deep link for adding bot to a group chat
 ADD_TO_GROUP_DEEPLINK = "https://t.me/ffmemesbot?startgroup=true"
 
-# /lang
+# /lang (multi-select settings for existing users)
 LANG_SETTINGS_LANG_CHANGE_CALLBACK_PATTERN = r"^l:\w+:(add|del)"
 LANG_SETTINGS_END_CALLBACK_DATA = "l:end"
+
+# Onboarding single-language picker (one primary language)
+ONBOARDING_LANG_CALLBACK_DATA_PATTERN = "ol:{lang}"
+ONBOARDING_LANG_CALLBACK_REGEXP = r"^ol:[\w-]{2,8}$"
 
 MESSAGE_REACTIONS = [
     "👍",

--- a/src/tgbot/handlers/help.py
+++ b/src/tgbot/handlers/help.py
@@ -10,7 +10,7 @@ from telegram.ext import ContextTypes
 
 from src import localizer
 from src.storage.schemas import MemeData
-from src.tgbot.repo.memes import get_last_sent_meme_for_user
+from src.tgbot.repo.memes import get_last_reacted_meme_for_user
 from src.tgbot.senders.meme import send_meme_to_user
 from src.tgbot.user_info import get_user_info
 
@@ -50,7 +50,7 @@ async def handle_last(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         user_info = None
 
     lang = _interface_lang(user_info)
-    row = await get_last_sent_meme_for_user(user_id)
+    row = await get_last_reacted_meme_for_user(user_id)
     if row is None:
         await update.message.reply_text(localizer.t("last.none", lang))
         return

--- a/src/tgbot/handlers/language.py
+++ b/src/tgbot/handlers/language.py
@@ -1,3 +1,5 @@
+import re
+
 import telegram
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, User
 from telegram.constants import ParseMode
@@ -10,13 +12,17 @@ from src.recommendations.meme_queue import (
     generate_recommendations,
 )
 from src.recommendations.service import get_user_reactions
-from src.tgbot.constants import LANG_SETTINGS_END_CALLBACK_DATA
+from src.tgbot.constants import (
+    LANG_SETTINGS_END_CALLBACK_DATA,
+    ONBOARDING_LANG_CALLBACK_DATA_PATTERN,
+)
 from src.tgbot.handlers.onboarding import onboarding_flow
 from src.tgbot.service import (
     add_user_language,
     add_user_languages,
     del_user_language,
     get_user_languages,
+    set_user_languages_exclusive,
 )
 from src.tgbot.user_info import get_user_info, update_user_info_cache
 
@@ -31,9 +37,17 @@ SUPPORTED_MEME_LANGUAGES = {
     "hi": "🇮🇳 हिन्दी",
 }
 
+# Telegram app language that is a reliable meme-content signal.
+# `en` is intentionally NOT auto-trusted (often default / VPN / US app store).
+_AUTO_CONTENT_LANG_FROM_TG = frozenset({"ru", "uk", "es", "fa", "hi"})
+
 
 async def init_user_languages_from_tg_user(tg_user: User):
-    """Initialize user languages based on Telegram user data."""
+    """Initialize user languages based on Telegram user data (legacy multi-seed).
+
+    Prefer :func:`resolve_onboarding_auto_language` for new-user onboarding.
+    Kept for orphans / existing users with empty ``user_language``.
+    """
     languages_to_add = set()
 
     if len(set(tg_user.full_name) & set(RUSSIAN_ALPHABET)) > 0:
@@ -45,6 +59,112 @@ async def init_user_languages_from_tg_user(tg_user: User):
         languages_to_add.add(tg_user.language_code)
 
     await add_user_languages(tg_user.id, languages_to_add)
+
+
+def _normalize_tg_lang(language_code: str | None) -> str | None:
+    if not language_code:
+        return None
+    return language_code.lower().replace("_", "-").split("-", 1)[0]
+
+
+def resolve_onboarding_auto_language(tg_user: User) -> str | None:
+    """Primary content language we can set without asking, or None to show picker.
+
+    - Cyrillic in display name → ``ru``
+    - Telegram CIS codes → ``ru`` (except explicit ``uk``)
+    - Strong non-EN app languages we serve → that code
+    - bare ``en`` / unknown → ask (EN is a weak signal)
+    """
+    full_name = tg_user.full_name or ""
+    if len(set(full_name) & set(RUSSIAN_ALPHABET)) > 0:
+        return "ru"
+
+    base = _normalize_tg_lang(tg_user.language_code)
+    if not base:
+        return None
+    if base == "uk":
+        return "uk"
+    if base in localizer.ALMOST_CIS_LANGUAGES or base == "ru":
+        return "ru"
+    if base in _AUTO_CONTENT_LANG_FROM_TG and base in SUPPORTED_MEME_LANGUAGES:
+        return base
+    return None
+
+
+def _picker_interface_lang(tg_user: User) -> str:
+    base = _normalize_tg_lang(tg_user.language_code) or "en"
+    if base in localizer.ALMOST_CIS_LANGUAGES or base == "ru":
+        return "ru"
+    return base if base in ("en", "uk", "es") else "en"
+
+
+def create_onboarding_language_keyboard() -> InlineKeyboardMarkup:
+    """One primary language per tap — not multi-select."""
+    rows = [
+        [
+            InlineKeyboardButton(
+                label,
+                callback_data=ONBOARDING_LANG_CALLBACK_DATA_PATTERN.format(lang=code),
+            )
+        ]
+        for code, label in SUPPORTED_MEME_LANGUAGES.items()
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
+async def send_onboarding_language_picker(
+    update: telegram.Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    """Show single-choice language picker; onboarding continues after a tap."""
+    interface_lang = _picker_interface_lang(update.effective_user)
+    text = localizer.t("onboarding.pick_language", interface_lang)
+    kwargs = {
+        "text": text,
+        "parse_mode": ParseMode.HTML,
+        "reply_markup": create_onboarding_language_keyboard(),
+    }
+    try:
+        if update.message:
+            await update.message.reply_text(**kwargs)
+        else:
+            await update.effective_chat.send_message(**kwargs)
+    except Forbidden:
+        pass
+
+
+async def handle_onboarding_language_selected(
+    update: telegram.Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    """Single-language onboarding choice → set language → welcome + first meme."""
+    query = update.callback_query
+    if query is None or not query.data:
+        return
+
+    match = re.fullmatch(r"ol:([\w-]{2,8})", query.data)
+    if not match:
+        await query.answer()
+        return
+
+    lang = match.group(1)
+    if lang not in SUPPORTED_MEME_LANGUAGES:
+        await query.answer()
+        return
+
+    user_id = update.effective_user.id
+    await query.answer()
+    await set_user_languages_exclusive(user_id, [lang])
+    await update_user_info_cache(user_id)
+    await clear_meme_queue_for_user(user_id)
+    await generate_recommendations(user_id, limit=5)
+
+    try:
+        await query.message.delete()
+    except BadRequest:
+        pass
+
+    return await onboarding_flow(update, context.bot)
 
 
 def create_language_button(lang: str, lang_text: str, is_selected: bool) -> InlineKeyboardButton:
@@ -138,7 +258,7 @@ async def handle_language_settings_end(
 
     user_id = update.effective_user.id
     await clear_meme_queue_for_user(user_id)
-    await generate_recommendations(user_id, limit=15)
+    await generate_recommendations(user_id, limit=5)
 
     if await get_user_reactions(user_id):
         return None

--- a/src/tgbot/handlers/start.py
+++ b/src/tgbot/handlers/start.py
@@ -7,8 +7,9 @@ from src.recommendations.meme_queue import clear_meme_queue_for_user
 from src.storage.schemas import MemeData
 from src.tgbot.handlers.deep_link import handle_invited_user, handle_shared_meme_reward
 from src.tgbot.handlers.language import (
-    handle_language_settings,
     init_user_languages_from_tg_user,
+    resolve_onboarding_auto_language,
+    send_onboarding_language_picker,
 )
 from src.tgbot.handlers.onboarding import onboarding_flow
 from src.tgbot.handlers.treasury.commands import (
@@ -25,6 +26,7 @@ from src.tgbot.service import (
     get_user_languages,
     log_user_deep_link,
     save_tg_user,
+    set_user_languages_exclusive,
 )
 from src.tgbot.sharing import (
     MEME_REACTION_CONTEXT_ONBOARD,
@@ -159,15 +161,18 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         created,
     )
 
-    # Lazy language init. Covers: new users on every deep_link path
-    # (kitchen used to skip this), and historical orphans whose init
-    # was never run — they were stuck on "memes ended" because
-    # recommendations filter by user_language. Idempotent:
-    # add_user_languages uses ON CONFLICT DO NOTHING.
-    if not await get_user_languages(user_id):
+    # Language seeding. New users get a single primary language (auto or picker).
+    # Existing orphans without user_language still use multi-seed init.
+    has_languages = bool(await get_user_languages(user_id))
+    if not has_languages and not created:
         await init_user_languages_from_tg_user(update.effective_user)
+        has_languages = bool(await get_user_languages(user_id))
 
     if deep_link == "kitchen":
+        if not has_languages:
+            auto = resolve_onboarding_auto_language(update.effective_user) or "en"
+            await set_user_languages_exclusive(user_id, [auto])
+            await update_user_info_cache(user_id)
         return await handle_show_kitchen(update, context)
 
     if deep_link == "wrapped":
@@ -193,13 +198,24 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         if shared_meme_sent:
             return
 
-        await handle_language_settings(update, context)
-
-        # handle giveaway after onboarding so user_language rows exist
+        # handle giveaway after languages exist
         if deep_link and deep_link.startswith("giveaway_"):
+            if not await get_user_languages(user_id):
+                auto = resolve_onboarding_auto_language(update.effective_user) or "en"
+                await set_user_languages_exclusive(user_id, [auto])
+                await update_user_info_cache(user_id)
             from src.tgbot.handlers.treasury.giveaway import handle_giveaway
 
             return await handle_giveaway(update, context, deep_link)
+
+        # Primary language first; welcome + first meme only after language is set.
+        if not await get_user_languages(user_id):
+            auto = resolve_onboarding_auto_language(update.effective_user)
+            if auto:
+                await set_user_languages_exclusive(user_id, [auto])
+                await update_user_info_cache(user_id)
+            else:
+                return await send_onboarding_language_picker(update, context)
 
         return await onboarding_flow(update, context.bot)
     else:  # existing user:

--- a/src/tgbot/repo/languages.py
+++ b/src/tgbot/repo/languages.py
@@ -61,3 +61,18 @@ async def del_user_language(
     )
 
     await execute(delete_language_query)
+
+
+async def clear_user_languages(user_id: int) -> None:
+    await execute(user_language.delete().where(user_language.c.user_id == user_id))
+
+
+async def set_user_languages_exclusive(
+    user_id: int,
+    language_codes: Sequence[str],
+) -> None:
+    """Replace the user's content languages with exactly this set."""
+    codes = [code for code in language_codes if code]
+    await clear_user_languages(user_id)
+    if codes:
+        await add_user_languages(user_id, codes)

--- a/src/tgbot/repo/memes.py
+++ b/src/tgbot/repo/memes.py
@@ -33,8 +33,12 @@ async def get_shareable_meme_by_id(id: int) -> dict[str, Any] | None:
     return await fetch_one(text(query), {"id": id, "status": MemeStatus.OK.value})
 
 
-async def get_last_sent_meme_for_user(user_id: int) -> dict[str, Any] | None:
-    """Most recently delivered meme for this user that can still be re-sent."""
+async def get_last_reacted_meme_for_user(user_id: int) -> dict[str, Any] | None:
+    """Most recently *reacted* meme (like or skip) that can still be re-sent.
+
+    /last exists so users can fix an accidental reaction. The latest *sent*
+    meme is often still on screen (no reaction yet) — that is not useful.
+    """
     query = """
         SELECT
             M.id,
@@ -50,15 +54,20 @@ async def get_last_sent_meme_for_user(user_id: int) -> dict[str, Any] | None:
         LEFT JOIN meme_stats MS
             ON MS.meme_id = M.id
         WHERE R.user_id = :user_id
+            AND R.reaction_id IS NOT NULL
             AND M.status = :status
             AND M.telegram_file_id IS NOT NULL
-        ORDER BY R.sent_at DESC
+        ORDER BY R.reacted_at DESC NULLS LAST, R.sent_at DESC
         LIMIT 1
     """
     return await fetch_one(
         text(query),
         {"user_id": user_id, "status": MemeStatus.OK.value},
     )
+
+
+# Back-compat alias for older imports/tests.
+get_last_sent_meme_for_user = get_last_reacted_meme_for_user
 
 
 async def get_meme_stats(meme_id: int) -> dict[str, Any] | None:

--- a/src/tgbot/service.py
+++ b/src/tgbot/service.py
@@ -19,8 +19,10 @@ from src.tgbot.repo.inline_search import (
 from src.tgbot.repo.languages import (
     add_user_language,
     add_user_languages,
+    clear_user_languages,
     del_user_language,
     get_user_languages,
+    set_user_languages_exclusive,
 )
 from src.tgbot.repo.meme_sources import (
     dismiss_source_candidate,
@@ -33,6 +35,7 @@ from src.tgbot.repo.meme_sources import (
     update_meme_source,
 )
 from src.tgbot.repo.memes import (
+    get_last_reacted_meme_for_user,
     get_last_sent_meme_for_user,
     get_meme_by_id,
     get_meme_stats,
@@ -64,6 +67,7 @@ __all__ = [
     "add_user_languages",
     "add_user_tg_chat_membership",
     "assign_experiment",
+    "clear_user_languages",
     "create_inline_chosen_result_log",
     "create_inline_search_log",
     "create_or_update_user",
@@ -73,6 +77,7 @@ __all__ = [
     "dismiss_source_candidate",
     "get_experiment_assignment",
     "get_experiment_variant",
+    "get_last_reacted_meme_for_user",
     "get_last_sent_meme_for_user",
     "get_meme_by_id",
     "get_meme_source_by_id",
@@ -93,6 +98,7 @@ __all__ = [
     "promote_source_candidate",
     "save_tg_user",
     "search_memes_for_inline_query",
+    "set_user_languages_exclusive",
     "update_meme_source",
     "update_user",
     "update_user_popup_log",

--- a/static/localization/onboarding.yml
+++ b/static/localization/onboarding.yml
@@ -138,6 +138,30 @@ onboarding.invited_by_admin:
     💎 नमस्ते! अब आपके पास भी पहुंच है। ➡️ /start पर क्लिक करें
 
 
+onboarding.pick_language:
+  ru: |-
+    Выбери язык мемов 👇
+  en: |-
+    Pick your meme language 👇
+  uk: |-
+    Обери мову мемів 👇
+  es: |-
+    Elige el idioma de los memes 👇
+  pt-br: |-
+    Escolha o idioma dos memes 👇
+  fr: |-
+    Choisis la langue des memes 👇
+  it: |-
+    Scegli la lingua dei meme 👇
+  de: |-
+    Wähle die Meme-Sprache 👇
+  fa: |-
+    زبان میم‌ها را انتخاب کن 👇
+  hi: |-
+    मीम्स की भाषा चुनें 👇
+  tr: |-
+    Meme dilini seç 👇
+
 onboarding.language_settings:
   ru: |-
     Выбери ВСЕ языки, на которых ты хочешь получать мемы

--- a/static/localization/service.yml
+++ b/static/localization/service.yml
@@ -56,11 +56,11 @@ help.text:
 
 last.none:
   en: |-
-    No previous meme yet — press /start and watch a few first.
+    No reaction to undo yet — like or skip a meme first, then /last.
   ru: |-
-    Пока нечего возвращать — жми /start и посмотри пару мемов.
+    Пока нечего исправлять — сначала лайкни или скипни мем, потом /last.
   uk: |-
-    Поки немає попереднього мема — натисни /start і подивись кілька мемів.
+    Поки немає що виправляти — спочатку лайкни або скіпни мем, потім /last.
 
 last.unavailable:
   en: |-

--- a/tests/tgbot/test_help_and_last.py
+++ b/tests/tgbot/test_help_and_last.py
@@ -73,14 +73,14 @@ async def test_last_replies_when_no_history(monkeypatch):
     )
     monkeypatch.setattr(
         help_handlers,
-        "get_last_sent_meme_for_user",
+        "get_last_reacted_meme_for_user",
         AsyncMock(return_value=None),
     )
 
     await help_handlers.handle_last(update, _make_context())
 
     text = update.message.reply_text.call_args.args[0]
-    assert "/start" in text
+    assert "/last" in text or "исправлять" in text or "undo" in text.lower() or "скип" in text
 
 
 @pytest.mark.asyncio
@@ -94,7 +94,7 @@ async def test_last_resends_meme(monkeypatch):
     )
     monkeypatch.setattr(
         help_handlers,
-        "get_last_sent_meme_for_user",
+        "get_last_reacted_meme_for_user",
         AsyncMock(
             return_value={
                 "id": 99,

--- a/tests/tgbot/test_onboarding_language.py
+++ b/tests/tgbot/test_onboarding_language.py
@@ -1,0 +1,38 @@
+from telegram import User
+
+from src.tgbot.handlers.language import (
+    resolve_onboarding_auto_language,
+)
+
+
+def _user(**kwargs) -> User:
+    defaults = dict(
+        id=1,
+        first_name="Alex",
+        last_name="Smith",
+        is_bot=False,
+        language_code="en",
+    )
+    defaults.update(kwargs)
+    return User(**defaults)
+
+
+def test_cyrillic_name_auto_ru_even_if_tg_en():
+    user = _user(first_name="Бот", last_name="Test", language_code="en")
+    assert resolve_onboarding_auto_language(user) == "ru"
+
+
+def test_tg_ru_auto_ru():
+    assert resolve_onboarding_auto_language(_user(language_code="ru")) == "ru"
+
+
+def test_tg_uk_auto_uk():
+    assert resolve_onboarding_auto_language(_user(language_code="uk")) == "uk"
+
+
+def test_tg_en_asks():
+    assert resolve_onboarding_auto_language(_user(language_code="en")) is None
+
+
+def test_tg_es_auto():
+    assert resolve_onboarding_auto_language(_user(language_code="es")) == "es"

--- a/tests/tgbot/test_start.py
+++ b/tests/tgbot/test_start.py
@@ -99,7 +99,10 @@ def _patch_handlers(shared_meme_sent: bool = False):
     """Patch every downstream handler so we test orchestration only."""
     return [
         patch(f"{HANDLER_MODULE}.handle_show_kitchen", new_callable=AsyncMock),
-        patch(f"{HANDLER_MODULE}.handle_language_settings", new_callable=AsyncMock),
+        patch(
+            f"{HANDLER_MODULE}.send_onboarding_language_picker",
+            new_callable=AsyncMock,
+        ),
         patch(f"{HANDLER_MODULE}.handle_invited_user", new_callable=AsyncMock),
         patch(f"{HANDLER_MODULE}.handle_shared_meme_reward", new_callable=AsyncMock),
         patch(
@@ -118,7 +121,12 @@ def _patch_handlers(shared_meme_sent: bool = False):
     ]
 
 
-async def _assert_universal_side_effects(user_id: int, expected_deep_link: str | None) -> None:
+async def _assert_universal_side_effects(
+    user_id: int,
+    expected_deep_link: str | None,
+    *,
+    require_languages: bool = True,
+) -> None:
     """Side effects every /start MUST run for created=True, all branches."""
     async with engine.connect() as conn:
         tg_row = (await conn.execute(select(user_tg).where(user_tg.c.id == user_id))).first()
@@ -134,7 +142,8 @@ async def _assert_universal_side_effects(user_id: int, expected_deep_link: str |
 
     assert tg_row is not None, "user_tg row missing"
     assert u_row is not None, "user row missing"
-    assert len(lang_rows) >= 1, "user_language rows missing — onboarding leak!"
+    if require_languages:
+        assert len(lang_rows) >= 1, "user_language rows missing — onboarding leak!"
     assert len(dl_rows) == 1, "user_deep_link_log row missing"
     assert dl_rows[0]._asdict()["deep_link"] == expected_deep_link
 
@@ -160,7 +169,7 @@ async def _run_handle_start(
         zip(
             [
                 "kitchen",
-                "lang_settings",
+                "lang_picker",
                 "invited",
                 "shared_reward",
                 "shared_meme",
@@ -176,7 +185,7 @@ async def _run_handle_start(
 
 
 @pytest.mark.asyncio
-async def test_new_user_no_deep_link_enters_onboarding_without_db():
+async def test_new_user_en_shows_language_picker_not_welcome():
     from src.tgbot.handlers.start import handle_start
 
     update = _make_update(deep_link=None)
@@ -194,16 +203,67 @@ async def test_new_user_no_deep_link_enters_onboarding_without_db():
             return_value=False,
         ),
         patch(f"{HANDLER_MODULE}.handle_invited_user", new_callable=AsyncMock),
-        patch(f"{HANDLER_MODULE}.handle_language_settings", new_callable=AsyncMock) as settings,
+        patch(
+            f"{HANDLER_MODULE}.send_onboarding_language_picker",
+            new_callable=AsyncMock,
+        ) as picker,
         patch(f"{HANDLER_MODULE}.onboarding_flow", new_callable=AsyncMock) as onboarding,
+        patch(
+            f"{HANDLER_MODULE}.resolve_onboarding_auto_language",
+            return_value=None,
+        ),
     ):
         save_user.return_value = ({"id": NEW_USER_ID}, True)
         user_info.return_value = {"type": "user", "interface_lang": "en"}
-        languages.return_value = {"en"}
+        languages.return_value = set()
 
         await handle_start(update, context)
 
-    settings.assert_awaited_once_with(update, context)
+    picker.assert_awaited_once_with(update, context)
+    onboarding.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_new_user_ru_auto_language_skips_picker():
+    from src.tgbot.handlers.start import handle_start
+
+    update = _make_update(deep_link=None)
+    context = _make_context(deep_link=None)
+
+    with (
+        patch(f"{HANDLER_MODULE}.save_user_data", new_callable=AsyncMock) as save_user,
+        patch(f"{HANDLER_MODULE}.update_user_info_cache", new_callable=AsyncMock) as user_info,
+        patch(f"{HANDLER_MODULE}.log_user_deep_link", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.log_start_event", new_callable=AsyncMock),
+        patch(f"{HANDLER_MODULE}.get_user_languages", new_callable=AsyncMock) as languages,
+        patch(
+            f"{HANDLER_MODULE}._send_shared_meme_from_deep_link",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(f"{HANDLER_MODULE}.handle_invited_user", new_callable=AsyncMock),
+        patch(
+            f"{HANDLER_MODULE}.send_onboarding_language_picker",
+            new_callable=AsyncMock,
+        ) as picker,
+        patch(f"{HANDLER_MODULE}.onboarding_flow", new_callable=AsyncMock) as onboarding,
+        patch(
+            f"{HANDLER_MODULE}.resolve_onboarding_auto_language",
+            return_value="ru",
+        ),
+        patch(
+            f"{HANDLER_MODULE}.set_user_languages_exclusive",
+            new_callable=AsyncMock,
+        ) as set_langs,
+    ):
+        save_user.return_value = ({"id": NEW_USER_ID}, True)
+        user_info.return_value = {"type": "user", "interface_lang": "ru"}
+        languages.return_value = set()
+
+        await handle_start(update, context)
+
+    set_langs.assert_awaited_once_with(NEW_USER_ID, ["ru"])
+    picker.assert_not_called()
     onboarding.assert_awaited_once_with(update, context.bot)
 
 
@@ -238,10 +298,22 @@ async def test_language_settings_done_does_not_replay_onboarding_after_meme_sent
 @pytest.mark.asyncio
 async def test_new_user_no_deep_link_runs_universal_side_effects(cleanup):
     mocks = await _run_handle_start(deep_link=None)
-    await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link=None)
-    mocks["lang_settings"].assert_called_once()
+    # EN Test User has no auto language → picker before welcome.
+    # user_language rows are created when auto-lang or picker fires, not on bare EN start.
+    async with engine.connect() as conn:
+        tg_row = (await conn.execute(select(user_tg).where(user_tg.c.id == NEW_USER_ID))).first()
+        u_row = (await conn.execute(select(user).where(user.c.id == NEW_USER_ID))).first()
+        dl_rows = (
+            await conn.execute(
+                select(user_deep_link_log).where(user_deep_link_log.c.user_id == NEW_USER_ID)
+            )
+        ).fetchall()
+    assert tg_row is not None, "user_tg row missing"
+    assert u_row is not None, "user row missing"
+    assert len(dl_rows) == 1, "user_deep_link_log row missing"
+    mocks["lang_picker"].assert_called_once()
     mocks["invited"].assert_called_once()
-    mocks["onboarding"].assert_called_once()
+    mocks["onboarding"].assert_not_called()
     mocks["next_message"].assert_not_called()
     mocks["kitchen"].assert_not_called()
     mocks["wrapped"].assert_not_called()
@@ -254,7 +326,7 @@ async def test_new_user_kitchen_branch_still_inits_languages(cleanup):
     mocks = await _run_handle_start(deep_link="kitchen")
     await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link="kitchen")
     mocks["kitchen"].assert_called_once()
-    mocks["lang_settings"].assert_not_called()
+    mocks["lang_picker"].assert_not_called()
     mocks["onboarding"].assert_not_called()
     mocks["next_message"].assert_not_called()
 
@@ -262,9 +334,12 @@ async def test_new_user_kitchen_branch_still_inits_languages(cleanup):
 @pytest.mark.asyncio
 async def test_new_user_wrapped_branch_inits_languages(cleanup):
     mocks = await _run_handle_start(deep_link="wrapped")
-    await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link="wrapped")
+    # wrapped returns early without forcing language seed
+    await _assert_universal_side_effects(
+        NEW_USER_ID, expected_deep_link="wrapped", require_languages=False
+    )
     mocks["wrapped"].assert_called_once()
-    mocks["lang_settings"].assert_not_called()
+    mocks["lang_picker"].assert_not_called()
     mocks["onboarding"].assert_not_called()
 
 
@@ -272,7 +347,7 @@ async def test_new_user_wrapped_branch_inits_languages(cleanup):
 async def test_new_user_giveaway_branch_inits_languages(cleanup):
     mocks = await _run_handle_start(deep_link="giveaway_77")
     await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link="giveaway_77")
-    mocks["lang_settings"].assert_called_once()  # main `created` path runs
+    mocks["lang_picker"].assert_not_called()
     mocks["giveaway"].assert_called_once()
     mocks["onboarding"].assert_not_called()
 
@@ -280,10 +355,14 @@ async def test_new_user_giveaway_branch_inits_languages(cleanup):
 @pytest.mark.asyncio
 async def test_new_user_share_link_branch_inits_languages(cleanup):
     mocks = await _run_handle_start(deep_link="m_12345_678", shared_meme_sent=True)
-    await _assert_universal_side_effects(NEW_USER_ID, expected_deep_link="m_12345_678")
+    # Shared meme path may only add meme language when a real meme is sent;
+    # with the handler mocked, languages can remain empty.
+    await _assert_universal_side_effects(
+        NEW_USER_ID, expected_deep_link="m_12345_678", require_languages=False
+    )
     mocks["shared_meme"].assert_called_once()
     assert mocks["shared_meme"].call_args.kwargs["reaction_context"] == "onboard"
-    mocks["lang_settings"].assert_not_called()
+    mocks["lang_picker"].assert_not_called()
     mocks["onboarding"].assert_not_called()
     mocks["invited"].assert_called_once()
 
@@ -299,7 +378,7 @@ async def test_blocked_acquisition_channel_silently_drops_new_user(cleanup):
 
     assert u_row is None, "blocked channel should not create user row"
     assert tg_row is None, "blocked channel should not create user_tg row"
-    mocks["lang_settings"].assert_not_called()
+    mocks["lang_picker"].assert_not_called()
     mocks["onboarding"].assert_not_called()
     mocks["next_message"].assert_not_called()
     mocks["log_start"].assert_not_called()
@@ -308,19 +387,26 @@ async def test_blocked_acquisition_channel_silently_drops_new_user(cleanup):
 @pytest.mark.asyncio
 async def test_existing_user_no_deep_link_serves_meme(cleanup):
     """Existing-user branch: must call next_message (the meme)."""
-    # First /start: bootstraps the user.
+    # First /start: EN user → language picker only (no languages yet).
     await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
-    await _assert_universal_side_effects(EXISTING_USER_ID, expected_deep_link=None)
+    # Seed a language so the second /start is a true existing-user feed path.
+    async with engine.begin() as conn:
+        from tests.factories import create_user_language
 
-    # Second /start: same user → existing-user branch.
+        await create_user_language(conn, user_id=EXISTING_USER_ID, language_code="en")
+
     mocks = await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
     mocks["next_message"].assert_called_once()
-    mocks["lang_settings"].assert_not_called()
+    mocks["lang_picker"].assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_existing_user_share_link_serves_shared_meme(cleanup):
     await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
+    async with engine.begin() as conn:
+        from tests.factories import create_user_language
+
+        await create_user_language(conn, user_id=EXISTING_USER_ID, language_code="en")
 
     mocks = await _run_handle_start(
         deep_link="m_12345_678",
@@ -332,7 +418,7 @@ async def test_existing_user_share_link_serves_shared_meme(cleanup):
     mocks["shared_reward"].assert_called_once()
     mocks["onboarding"].assert_not_called()
     mocks["next_message"].assert_not_called()
-    mocks["lang_settings"].assert_not_called()
+    mocks["lang_picker"].assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -341,6 +427,9 @@ async def test_existing_user_share_link_with_prior_reaction_serves_shared_meme(c
 
     await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
     async with engine.begin() as conn:
+        from tests.factories import create_user_language
+
+        await create_user_language(conn, user_id=EXISTING_USER_ID, language_code="en")
         await create_meme_source(conn, id=10001, language_code="en")
         await create_meme(
             conn,
@@ -362,7 +451,10 @@ async def test_existing_user_share_link_with_prior_reaction_serves_shared_meme(c
 
     patches = [
         patch(f"{HANDLER_MODULE}.handle_show_kitchen", new_callable=AsyncMock),
-        patch(f"{HANDLER_MODULE}.handle_language_settings", new_callable=AsyncMock),
+        patch(
+            f"{HANDLER_MODULE}.send_onboarding_language_picker",
+            new_callable=AsyncMock,
+        ),
         patch(f"{HANDLER_MODULE}.handle_invited_user", new_callable=AsyncMock),
         patch(f"{HANDLER_MODULE}.handle_shared_meme_reward", new_callable=AsyncMock),
         patch(f"{HANDLER_MODULE}.send_meme_to_user", new_callable=AsyncMock),
@@ -385,7 +477,7 @@ async def test_existing_user_share_link_with_prior_reaction_serves_shared_meme(c
         zip(
             [
                 "kitchen",
-                "lang_settings",
+                "lang_picker",
                 "invited",
                 "shared_reward",
                 "send_meme",
@@ -414,6 +506,9 @@ async def test_existing_user_legacy_share_link_serves_shared_meme(cleanup):
 
     await _run_handle_start(deep_link=None, user_id=EXISTING_USER_ID)
     async with engine.begin() as conn:
+        from tests.factories import create_user_language
+
+        await create_user_language(conn, user_id=EXISTING_USER_ID, language_code="en")
         await create_meme_source(conn, id=10001, language_code="en")
         await create_meme(
             conn,
@@ -428,7 +523,10 @@ async def test_existing_user_legacy_share_link_serves_shared_meme(cleanup):
 
     patches = [
         patch(f"{HANDLER_MODULE}.handle_show_kitchen", new_callable=AsyncMock),
-        patch(f"{HANDLER_MODULE}.handle_language_settings", new_callable=AsyncMock),
+        patch(
+            f"{HANDLER_MODULE}.send_onboarding_language_picker",
+            new_callable=AsyncMock,
+        ),
         patch(f"{HANDLER_MODULE}.handle_invited_user", new_callable=AsyncMock),
         patch(f"{HANDLER_MODULE}.handle_shared_meme_reward", new_callable=AsyncMock),
         patch(f"{HANDLER_MODULE}.send_meme_to_user", new_callable=AsyncMock),
@@ -451,7 +549,7 @@ async def test_existing_user_legacy_share_link_serves_shared_meme(cleanup):
         zip(
             [
                 "kitchen",
-                "lang_settings",
+                "lang_picker",
                 "invited",
                 "shared_reward",
                 "send_meme",
@@ -470,15 +568,15 @@ async def test_existing_user_legacy_share_link_serves_shared_meme(cleanup):
 
 @pytest.mark.asyncio
 async def test_lazy_init_is_idempotent(cleanup):
-    """Re-running /start should not duplicate or re-insert language rows."""
-    await _run_handle_start(deep_link=None)
+    """Kitchen seeds languages; re-running /start should not duplicate rows."""
+    await _run_handle_start(deep_link="kitchen")
 
     async with engine.connect() as conn:
         first_rows = (
             await conn.execute(select(user_language).where(user_language.c.user_id == NEW_USER_ID))
         ).fetchall()
 
-    await _run_handle_start(deep_link=None)
+    await _run_handle_start(deep_link="kitchen")
 
     async with engine.connect() as conn:
         second_rows = (


### PR DESCRIPTION
## Summary

### /last
Re-shows the last **reacted** meme (`reaction_id IS NOT NULL`, `ORDER BY reacted_at`), not the latest **sent** row (often still on screen with no reaction). Purpose: fix accidental like/skip.

### Onboarding language
- Do not multi-seed `en`+`ru` from Telegram on first start
- Single-language picker (one button = one primary language)
- Auto-skip picker when signal is strong: Cyrillic name → `ru`, TG `ru`/CIS → `ru`, TG `uk` → `uk`, etc.
- `en` alone still asks
- Welcome message + countdown only **after** language is set

### Cold start (user 6731016276 readout)
First session filled with `cold_start_explore_guarded` for ~10 memes because `limit=15` is planned at `nmemes_sent=0`. Queue refill now uses **limit=5** while `nmemes_sent < 30` so adapt stage can re-plan.

## Test plan
- [x] pytest start / last / onboarding language / reaction (32 passed)
- [ ] Prod: /last after skip returns previous reacted meme
- [ ] Prod: EN TG user sees picker then welcome after tap
- [ ] Prod: RU / Cyrillic name skips picker