### PR TITLE
feat(admin): meme inspect API for agents + OCR/cold-start readouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ MEME_STORAGE_TELEGRAM_CHAT_ID=-1234  # tg chat id for
 
 ADMIN_LOGS_CHAT_ID=-1234  # tg chat id for admin logs
 
+# Internal admin HTTP API for agent/operator meme inspect (GET /admin/memes/{id}).
+# Generate a long random token; leave empty to disable (endpoints return 503).
+ADMIN_API_TOKEN=
+
 UPLOADED_MEMES_REVIEW_CHAT_ID=-1234  # tg chat id for uploaded memes review
 
 # parsing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,20 @@ prefect deployment resume "Describe Memes (OpenRouter Vision)/Describe Memes (Op
 
 Before resuming, verify the root cause is fixed (check recent flow run logs).
 
+## Admin meme inspect (agents)
+
+HTTP API for compact meme cards + media download (Telegram `file_id` needs the
+production bot token). Auth: `ADMIN_API_TOKEN`.
+
+- Docs: [`docs/admin-meme-inspect.md`](docs/admin-meme-inspect.md)
+- `GET /admin/memes/{id}` — status, source, stats, OCR summary
+- `GET /admin/memes/{id}/media` — raw image/video bytes
+- OCR health SQL: [`docs/analyst/describe-memes-health.sql`](docs/analyst/describe-memes-health.sql)
+
 ## Key settings & environment toggles
 - Redis, Postgres, and Telegram configuration live in [`src/config.py`](src/config.py).
 - `OPENROUTER_API_KEY` — required for describe_memes. Balance must stay >= $0.
+- `ADMIN_API_TOKEN` — shared secret for `/admin/*` inspect endpoints (optional; 503 if unset).
 
 ## Public repo hygiene
 - This repository is public. Follow [`docs/public-repo-rule.md`](docs/public-repo-rule.md).

--- a/docs/admin-meme-inspect.md
+++ b/docs/admin-meme-inspect.md
@@ -1,0 +1,73 @@
+# Admin meme inspect API
+
+Internal HTTP endpoints for agents and operators to inspect a meme without
+hand-joining SQL tables, and to **download media via the production Telegram
+bot token** (file_id cannot be resolved from SQL alone).
+
+## Auth
+
+Set `ADMIN_API_TOKEN` in the app environment (long random secret). When unset,
+routes return **503**.
+
+```http
+Authorization: Bearer $ADMIN_API_TOKEN
+```
+
+or
+
+```http
+X-Admin-Token: $ADMIN_API_TOKEN
+```
+
+Never commit the token. Never paste real values into the public repo.
+
+## Endpoints
+
+### `GET /admin/memes/{meme_id}`
+
+Compact JSON card:
+
+| Field | Contents |
+|-------|----------|
+| `meme` | id, status, type, language, caption, dates, duplicate_of, has_telegram_file_id |
+| `source` | id, type, url, status, language |
+| `stats` | nlikes, ndislikes, nmemes_sent, lr_smoothed, engagement_score, age_days, … |
+| `ocr` | has_ocr, calculated_at, description, text, language, model, failures |
+| `media` | available, download_path, content_type, filename |
+
+Optional query: `?include_media=true` — embeds base64 when the file is **≤ 4MB**.
+Larger files return `media.inline_error` and you should use the media route.
+
+### `GET /admin/memes/{meme_id}/media`
+
+Raw image/video bytes (`Content-Type: image/jpeg` / `video/mp4` / `image/gif`).
+Downloaded through `download_meme_content_from_tg` using `TELEGRAM_BOT_TOKEN`.
+
+## Agent usage
+
+```bash
+# Info only
+curl -sS -H "Authorization: Bearer $ADMIN_API_TOKEN" \
+  "$SITE_BASE_URL/admin/memes/123456" | jq .
+
+# Save media for visual inspection (images work with the image read tool)
+curl -sS -H "Authorization: Bearer $ADMIN_API_TOKEN" \
+  "$SITE_BASE_URL/admin/memes/123456/media" -o /tmp/meme_123456.jpg
+```
+
+`$SITE_BASE_URL` is the production app origin (private ops notes / Coolify).
+Do not commit hostnames into this public repo.
+
+Related Telegram-only command: moderators can still use `/meme <id>` in the bot
+([`src/tgbot/handlers/moderator/get_meme.py`](../src/tgbot/handlers/moderator/get_meme.py)).
+That path is not available to HTTP agents.
+
+## Code
+
+| Piece | Path |
+|-------|------|
+| Router | [`src/admin/router.py`](../src/admin/router.py) |
+| Payload builder | [`src/admin/service.py`](../src/admin/service.py) |
+| Auth | [`src/admin/auth.py`](../src/admin/auth.py) |
+| Config | `ADMIN_API_TOKEN` in [`src/config.py`](../src/config.py) |
+| Tests | [`tests/admin/test_meme_inspect.py`](../tests/admin/test_meme_inspect.py) |

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -16,7 +16,8 @@ override current Codex or Paperclip decisions.
 | Routine health and outcomes | [Routine observability](routine-observability.md) and [Outcome ledger](outcome-ledger.md) | Prefer business outcome checks over generic liveness checks. |
 | PR review automation | [PR review cycle](pr-review-cycle.md) | Keep GitHub payloads narrow and Paperclip issue links explicit. |
 | Moderator source scouting | [Moderator community loop spec](../../specs/moderator-community-loop.md), [CONTEXT.md](../../CONTEXT.md), and [ADR-0003](../adr/0003-prepared-source-etl-guard.md) | Use the Russian domain vocabulary; prepared sources stay parked until enabled. |
-| Describe Memes / vision OCR | [AGENTS.md](../../AGENTS.md) and [Describe Memes spec](../../specs/describe-memes.md) | Free OpenRouter vision models only. |
+| Describe Memes / vision OCR | [AGENTS.md](../../AGENTS.md), [Describe Memes spec](../../specs/describe-memes.md), [health SQL](../analyst/describe-memes-health.sql) | Free OpenRouter vision models only. |
+| Inspect a meme (info + media) | [Admin meme inspect](../admin-meme-inspect.md) | `ADMIN_API_TOKEN` + `GET /admin/memes/{id}` (+ `/media`). |
 | In-bot meme share button | [Share readout (archive)](../archive/2026-q2/meme-share-button-readout-2026-06-04.md), [CONTEXT.md](../../CONTEXT.md), [growth/virality-loop](../growth/virality-loop.md), and [Analyst README](../analyst/README.md) | Count non-self `m_`/`s_` deep-link starts; raw share-click counts include self-clicks. |
 | Crossposting / channel shares | [Crossposting share readout](../../specs/crossposting-share-optimization-2026-05-18.md), [Analyst crossposting SQL](../analyst/crossposting.sql), and [CONTEXT.md](../../CONTEXT.md) | Separate in-bot share clicks, channel deep links, and Telegram channel forwards/views. |
 

--- a/docs/analyst/README.md
+++ b/docs/analyst/README.md
@@ -11,6 +11,9 @@ The Analyst agent monitors product health, tracks experiments, and produces dail
 ## Key Files
 - `docs/analyst/metrics.sql` — SQL queries organized by section (health, north star, engines, retention, etc.)
 - `docs/analyst/command-surface-proxies.sql` — private slash commands from `message_tg` (`chat_id > 0`) + secondary feature proxies. Notes: [`docs/product/surface-and-commands.md`](../product/surface-and-commands.md).
+- `docs/analyst/cold-start-first10-post-limit5.sql` + [readout 2026-08-13](readouts/2026-08-13-cold-start-first10-post-limit5.md) — first-10 quality pre/post queue limit=5; guarded explore skip problem.
+- `docs/analyst/describe-memes-health.sql` + [readout 2026-08-13](readouts/2026-08-13-describe-memes-health.md) — OCR / OpenRouter describe throughput vs 864/day target; backlog ~222k.
+- Agent meme inspect (JSON + media download via bot token): [`docs/admin-meme-inspect.md`](../admin-meme-inspect.md).
 - `docs/analyst/viral-shares-blender-v1.sql` — readout for `viral_shares_blender_v1` (share clickers + invites vs control + session guardrail).
 - `docs/analyst/dwell-feed-vs-broadcast.sql` — `sec_to_react` percentiles: like vs skip × feed vs broadcast; dwell buckets; demote inventory risk.
 - `docs/analyst/source-affinity-demote-guardrails.sql` — post-deploy volume / LR checks for soft-demote (#340).

--- a/docs/analyst/cold-start-first10-post-limit5.sql
+++ b/docs/analyst/cold-start-first10-post-limit5.sql
@@ -1,0 +1,154 @@
+-- Cold-start first-10 readout (pre vs post queue limit=5 fix)
+-- Fix deployed: 2026-08-11 ~19:42 UTC (PR #351)
+-- Cohort: users whose *first-ever* user_meme_reaction.sent_at is in the last 7 days.
+-- Run via analyst_readonly. statement_timeout 60s recommended.
+--
+-- Companion readout: docs/analyst/readouts/2026-08-13-cold-start-first10-post-limit5.md
+
+\set fix_at '2026-08-11 19:42:00'
+
+-- 1) Cohort sizes
+WITH first_send AS (
+  SELECT user_id, MIN(sent_at) AS first_sent_at
+  FROM user_meme_reaction
+  GROUP BY user_id
+),
+cohort AS (
+  SELECT
+    user_id,
+    first_sent_at,
+    CASE
+      WHEN first_sent_at >= TIMESTAMP :'fix_at' THEN 'post_fix'
+      ELSE 'pre_fix'
+    END AS period
+  FROM first_send
+  WHERE first_sent_at >= now() - interval '7 days'
+)
+SELECT period, COUNT(*) AS n_users, MIN(first_sent_at), MAX(first_sent_at)
+FROM cohort
+GROUP BY 1
+ORDER BY 1;
+
+-- 2) First-10 overall skip/like
+WITH first_send AS (
+  SELECT user_id, MIN(sent_at) AS first_sent_at
+  FROM user_meme_reaction
+  GROUP BY user_id
+),
+cohort AS (
+  SELECT
+    user_id,
+    first_sent_at,
+    CASE
+      WHEN first_sent_at >= TIMESTAMP :'fix_at' THEN 'post_fix'
+      ELSE 'pre_fix'
+    END AS period
+  FROM first_send
+  WHERE first_sent_at >= now() - interval '7 days'
+),
+ranked AS (
+  SELECT
+    R.user_id,
+    R.reaction_id,
+    R.recommended_by,
+    c.period,
+    row_number() OVER (PARTITION BY R.user_id ORDER BY R.sent_at, R.meme_id) AS rn
+  FROM user_meme_reaction R
+  JOIN cohort c ON c.user_id = R.user_id
+),
+f10 AS (SELECT * FROM ranked WHERE rn <= 10)
+SELECT
+  period,
+  COUNT(DISTINCT user_id) AS users,
+  COUNT(*) AS sends,
+  COUNT(*) FILTER (WHERE reaction_id = 1) AS likes,
+  COUNT(*) FILTER (WHERE reaction_id = 2) AS skips,
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE reaction_id = 2)
+    / NULLIF(COUNT(*) FILTER (WHERE reaction_id IS NOT NULL), 0),
+    1
+  ) AS skip_pct
+FROM f10
+GROUP BY period
+ORDER BY period;
+
+-- 3) Engine mix in first-10
+WITH first_send AS (
+  SELECT user_id, MIN(sent_at) AS first_sent_at
+  FROM user_meme_reaction
+  GROUP BY user_id
+),
+cohort AS (
+  SELECT
+    user_id,
+    CASE
+      WHEN first_sent_at >= TIMESTAMP :'fix_at' THEN 'post_fix'
+      ELSE 'pre_fix'
+    END AS period
+  FROM first_send
+  WHERE first_sent_at >= now() - interval '7 days'
+),
+ranked AS (
+  SELECT
+    R.user_id,
+    R.reaction_id,
+    R.recommended_by,
+    c.period,
+    row_number() OVER (PARTITION BY R.user_id ORDER BY R.sent_at, R.meme_id) AS rn
+  FROM user_meme_reaction R
+  JOIN cohort c ON c.user_id = R.user_id
+),
+f10 AS (SELECT * FROM ranked WHERE rn <= 10)
+SELECT
+  period,
+  recommended_by,
+  COUNT(*) AS n,
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE reaction_id = 2)
+    / NULLIF(COUNT(*) FILTER (WHERE reaction_id IS NOT NULL), 0),
+    1
+  ) AS skip_pct
+FROM f10
+GROUP BY 1, 2
+ORDER BY 1, n DESC;
+
+-- 4) pos 1-5 vs 6-10 engines (expect adapt in 6-10 after a working fix)
+WITH first_send AS (
+  SELECT user_id, MIN(sent_at) AS first_sent_at
+  FROM user_meme_reaction
+  GROUP BY user_id
+),
+cohort AS (
+  SELECT
+    user_id,
+    CASE
+      WHEN first_sent_at >= TIMESTAMP :'fix_at' THEN 'post_fix'
+      ELSE 'pre_fix'
+    END AS period
+  FROM first_send
+  WHERE first_sent_at >= now() - interval '7 days'
+),
+ranked AS (
+  SELECT
+    R.user_id,
+    R.reaction_id,
+    R.recommended_by,
+    c.period,
+    row_number() OVER (PARTITION BY R.user_id ORDER BY R.sent_at, R.meme_id) AS rn
+  FROM user_meme_reaction R
+  JOIN cohort c ON c.user_id = R.user_id
+),
+f10 AS (SELECT * FROM ranked WHERE rn <= 10)
+SELECT
+  period,
+  CASE WHEN rn <= 5 THEN 'pos_1_5' ELSE 'pos_6_10' END AS band,
+  recommended_by,
+  COUNT(*) AS n,
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE reaction_id = 2)
+    / NULLIF(COUNT(*) FILTER (WHERE reaction_id IS NOT NULL), 0),
+    1
+  ) AS skip_pct
+FROM f10
+GROUP BY 1, 2, 3
+ORDER BY 1, 2, n DESC;

--- a/docs/analyst/describe-memes-health.sql
+++ b/docs/analyst/describe-memes-health.sql
@@ -1,0 +1,91 @@
+-- Describe Memes / OCR health (read-only)
+-- Run: psql "$ANALYST_DATABASE_URL" -f docs/analyst/describe-memes-health.sql
+--
+-- Monitoring rule: use ocr_result->>'calculated_at', NOT meme.created_at.
+-- "Described" for product/dedup means description is present (OpenRouter vision).
+-- Legacy easyocr rows often have calculated_at + text but no description.
+
+\echo === Coverage (ok image memes) ===
+SELECT
+  COUNT(*) FILTER (WHERE status = 'ok') AS ok_memes,
+  COUNT(*) FILTER (WHERE status = 'ok' AND type = 'image') AS ok_images,
+  COUNT(*) FILTER (
+    WHERE status = 'ok' AND type = 'image'
+      AND ocr_result->>'description' IS NOT NULL
+  ) AS ok_images_with_description,
+  COUNT(*) FILTER (
+    WHERE status = 'ok' AND type = 'image'
+      AND ocr_result->>'calculated_at' IS NOT NULL
+  ) AS ok_images_with_calculated_at,
+  ROUND(
+    100.0 * COUNT(*) FILTER (
+      WHERE status = 'ok' AND type = 'image'
+        AND ocr_result->>'description' IS NOT NULL
+    ) / NULLIF(COUNT(*) FILTER (WHERE status = 'ok' AND type = 'image'), 0),
+    1
+  ) AS pct_images_with_description
+FROM meme;
+
+\echo === Throughput last 14 days (by calculated_at date, any OCR) ===
+SELECT
+  (ocr_result->>'calculated_at')::timestamptz::date AS day,
+  COUNT(*) AS rows_with_calc_at,
+  COUNT(*) FILTER (WHERE ocr_result->>'description' IS NOT NULL) AS with_description
+FROM meme
+WHERE ocr_result->>'calculated_at' IS NOT NULL
+  AND (ocr_result->>'calculated_at')::timestamptz >= now() - interval '14 days'
+GROUP BY 1
+ORDER BY 1 DESC;
+
+\echo === Freshness ===
+SELECT
+  MAX((ocr_result->>'calculated_at')::timestamptz) AS max_calculated_at,
+  COUNT(*) FILTER (
+    WHERE (ocr_result->>'calculated_at')::timestamptz >= now() - interval '24 hours'
+      AND ocr_result->>'description' IS NOT NULL
+  ) AS described_last_24h,
+  COUNT(*) FILTER (
+    WHERE (ocr_result->>'calculated_at')::timestamptz >= now() - interval '7 days'
+      AND ocr_result->>'description' IS NOT NULL
+  ) AS described_last_7d
+FROM meme
+WHERE ocr_result->>'calculated_at' IS NOT NULL;
+
+\echo === Eligible backlog (ok images without description) ===
+SELECT
+  COUNT(*) AS ok_images_no_description,
+  COUNT(*) FILTER (
+    WHERE COALESCE((ocr_result->>'describe_failures')::int, 0) >= 3
+  ) AS permanently_failed_ge3,
+  COUNT(*) FILTER (
+    WHERE COALESCE((ocr_result->>'describe_failures')::int, 0) < 3
+  ) AS eligible_backlog
+FROM meme
+WHERE status = 'ok'
+  AND type = 'image'
+  AND telegram_file_id IS NOT NULL
+  AND (ocr_result IS NULL OR ocr_result->>'description' IS NULL);
+
+\echo === Recent describe failure reasons ===
+SELECT
+  COALESCE(ocr_result->>'last_failure_reason', '(none)') AS reason,
+  COUNT(*) AS n
+FROM meme
+WHERE status = 'ok'
+  AND type = 'image'
+  AND COALESCE((ocr_result->>'describe_failures')::int, 0) > 0
+GROUP BY 1
+ORDER BY n DESC
+LIMIT 15;
+
+\echo === Models used (last 30d, successful description) ===
+SELECT
+  COALESCE(ocr_result->>'model', ocr_result->>'described_by', '(unknown)') AS model,
+  COUNT(*) AS n
+FROM meme
+WHERE ocr_result->>'description' IS NOT NULL
+  AND ocr_result->>'calculated_at' IS NOT NULL
+  AND (ocr_result->>'calculated_at')::timestamptz >= now() - interval '30 days'
+GROUP BY 1
+ORDER BY n DESC
+LIMIT 15;

--- a/docs/analyst/readouts/2026-08-13-cold-start-first10-post-limit5.md
+++ b/docs/analyst/readouts/2026-08-13-cold-start-first10-post-limit5.md
@@ -1,0 +1,121 @@
+# Cold-start first-10 readout (post queue limit=5)
+
+**Date:** 2026-08-13  
+**Fix under test:** PR #351 — `check_queue` uses `limit=5` while `nmemes_sent < 30` (deployed ~2026-08-11 19:42 UTC)  
+**Cohort:** users whose **first-ever** `user_meme_reaction.sent_at` is in the last 7 days  
+**SQL:** [`docs/analyst/cold-start-first10-post-limit5.sql`](../cold-start-first10-post-limit5.sql)
+
+## Sample size (critical)
+
+| Period | First-send users (7d) | New accounts (`user.created_at`) |
+|--------|----------------------:|---------------------------------:|
+| pre_fix  | 23 | 22 |
+| post_fix | **4** | **4** |
+
+Post-fix N is too small for causal claims. Treat engine-mix as directional; skip% is noisy.
+
+## Headline first-10 quality
+
+| Period | Users | Sends (f10) | Like% | **Skip%** | p50 user LR (f10) |
+|--------|------:|------------:|------:|----------:|------------------:|
+| pre_fix  | 23 | 144 | 22.8 | **77.2** | 0.22 |
+| post_fix | 4  | 23  | 23.5 | **76.5** | 0.30 |
+
+**Skip% essentially unchanged.** Fix did **not** move first-10 skip rate.
+
+## Continuation
+
+| Period | Reach ≥5 | Reach ≥10 | Reach ≥30 |
+|--------|----------|-----------|-----------|
+| pre_fix  | 56.5% | 43.5% | 4/23 |
+| post_fix | 50% (2/4) | 25% (1/4) | 1/4 |
+
+## Position curve (skip%)
+
+Pattern is stable pre and post:
+
+| rn | pre skip% | post skip% (tiny n) |
+|---:|----------:|--------------------:|
+| 1 | 46.7 | 33.3 (first meme OK) |
+| 2 | 90.9 | 100 |
+| 3–4 | 67–85 | 50 |
+| 5–10 | mostly 70–100 | mostly **100** |
+
+**First meme is fine; from #2 the feed collapses into skip.**
+
+## Engine mix — the real finding
+
+### First-10 engines
+
+| Engine | pre n | pre skip% | post n | post skip% |
+|--------|------:|----------:|-------:|-----------:|
+| `cold_start_explore` | 20 | **42.9** | 3 | **0** |
+| `cold_start_explore_guarded` | 101 | **82.5** | 10 | **77.8** |
+| `cold_start_adapt` / `_guarded` | **0** | — | **0** | — |
+| `text_light_lr_smoothed` | 0 | — | 7 | **100** |
+| broadcast / other | few | high | few | — |
+
+### pos 1–5 vs 6–10 (post_fix)
+
+| Band | Dominant engines | Adapt? |
+|------|------------------|--------|
+| 1–5 | explore, explore_guarded, text_light | no |
+| 6–10 | **still** explore_guarded + text_light + broadcast | **no adapt** |
+
+### First meme (rn=1)
+
+| Period | Main engine | Like% among reacted |
+|--------|-------------|---------------------|
+| pre | `cold_start_explore` (20/23) | **57%** |
+| post | `cold_start_explore` (3/4) | **100%** (n=2 reacted) |
+
+Unguarded explore is the only engine that works. **Guarded explore is the skip factory.**
+
+## Why limit=5 did not introduce adapt in 6–10
+
+Planner stages:
+
+- CS1 explore: `nmemes_sent < 6`
+- CS2 adapt: `6 ≤ nmemes_sent < 16`
+
+`check_queue` refill with `limit=5` at `nmemes_sent=0…5` **still plans CS1 explore**.  
+Adapt only starts when generation sees `nmemes_sent ≥ 6`.
+
+Also `queue_length ≤ 8` + small batches can restack explore before the user crosses 6 sent.
+
+**Conclusion:** smaller batches alone are not enough; need **position-aware or nmemes-aware engine switch inside the first batch**, or force refill that targets adapt once `nmemes_sent ≥ 6` and **clear remaining explore queue**.
+
+## Candidate quality (meme_stats of f10)
+
+| Period | p50 lr_smoothed | p50 raw LR |
+|--------|----------------:|-----------:|
+| pre | 0.124 | 0.61 |
+| post | 0.149 | 0.59 |
+
+Raw LR ~0.6 (majority like in population) but **session skip ~77%** → content is “crowd-ok” but wrong for *this* new user / boring / similar. Diversity: ~4–5 sources per first-10 (not single-source spam).
+
+Post-fix top skip sources (tiny): `t.me/memeromicon`, `deep_iranian_web`, `bingusrepublic`. Guardrail list already blocks some VK/TG URLs; not these.
+
+## Verdict
+
+| Hypothesis | Result |
+|------------|--------|
+| limit=5 reduces first-10 skip% | **No** (77% → 76%, n=4) |
+| limit=5 puts `cold_start_adapt` into pos 6–10 | **No** (0 adapt rows) |
+| Unguarded explore is decent | **Yes** (first meme / explore like% high) |
+| Guarded explore is bad | **Yes** (skip ~80%) |
+
+## Recommended next experiments (ordered)
+
+1. **Kill or soften explore_guarded for pos 2–5** — use unguarded explore (or higher raw LR floor) for entire CS1, not only rn=1.  
+2. **Force adapt after meme 5:** when `nmemes_sent` hits 5–6, `clear_meme_queue` + generate with adapt (don’t serve leftover explore).  
+3. **Raise quality floor** on guarded path if kept: raw LR ≥ 0.55–0.60 and/or min reactions higher (watch inventory).  
+4. **Source diversity cap** in first 10 (max 1–2 per source) — secondary.  
+5. Re-run this SQL in **7–14 days** when post_fix n ≥ 30.
+
+## Re-run
+
+```bash
+# analyst_readonly
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/cold-start-first10-post-limit5.sql
+```

--- a/docs/analyst/readouts/2026-08-13-describe-memes-health.md
+++ b/docs/analyst/readouts/2026-08-13-describe-memes-health.md
@@ -1,0 +1,72 @@
+# Describe Memes health — 2026-08-13
+
+Snapshot via `psql "$ANALYST_DATABASE_URL"` and
+[`docs/analyst/describe-memes-health.sql`](../describe-memes-health.sql).
+
+## Verdict
+
+**Pipeline is not fully dead, but throughput is ~1% of design target.**
+
+| Metric | Value | Design target |
+|--------|-------|---------------|
+| OK image memes | ~241k | — |
+| With OpenRouter `description` | ~18.9k (**7.8%**) | high coverage over time |
+| Described last 24h | **~11** | up to **864**/day scheduled |
+| Described last 7d | **~74** | ~6k |
+| Eligible backlog (no description, failures &lt; 3) | **~222k** | shrinking |
+| Permanently failed (failures ≥ 3) | ~528 | — |
+| Latest `calculated_at` | 2026-08-13 ~06:30 UTC | should advance every 15m when free tier allows |
+
+Daily successful descriptions over the last two weeks stay in the **~3–15/day**
+band (not zero). Something is still writing OCR occasionally.
+
+## Failure shape
+
+`describe_failures` / `last_failure_reason` on ok images:
+
+| Reason | Count (approx) |
+|--------|----------------|
+| `all models failed` | ~2270 |
+| `per-meme timeout (120s)` | ~196 |
+| `Timed out` | ~36 |
+
+Recent successful model mix (30d, rows with description): mostly
+`nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`, some Gemma 4 free variants.
+
+## Legacy OCR noise
+
+~55k ok images have `calculated_at` but **no** `description`. Spot checks show
+legacy **`easyocr`** payloads (`model: easyocr`, text only). Product dedup /
+search that require `description` treat these as **not described**.
+`get_memes_to_describe` correctly keys off missing `description`.
+
+## Interpretation
+
+1. **Not paused into total silence** — occasional successes prove download +
+   OpenRouter path still works sometimes.
+2. **Severe free-tier backpressure / model flakiness** — design assumes 900
+   free attempts/day; observed successful descriptions are ~10/day, consistent
+   with near-constant 429 / all-models-failed / timeout windows documented in
+   [`specs/describe-memes.md`](../../../specs/describe-memes.md).
+3. **Backlog will not clear** at current rate (~220k / 10 per day ≈ decades).
+4. Dedup and OCR-aware ranking only see the ~8% with full vision descriptions
+   (plus any text-only legacy easyocr rows for text search).
+
+## Follow-ups (ops, not done in this PR)
+
+1. Prefect: check whether `Describe Memes (OpenRouter)` runs are Completed vs
+   short-circuited on quota/rate-limit (flow logs: `rate_limited`,
+   `daily_budget_exhausted`, key health).
+2. OpenRouter dashboard: free-model daily remaining, key limit, balance ≥ $0,
+   lifetime purchase tier ($10+ → 1000 free req/day vs 50).
+3. Redis: `openrouter:free_requests:YYYY-MM-DD`, model cooldown keys.
+4. If free tier is stuck at 50/day, expect ~dozens of attempts and few
+   successes — matches this readout; paid models remain **forbidden**.
+5. Optional product: re-describe high-`nlikes` easyocr-only memes to fill
+   `description` for dedup (priority already likes-desc after uploads).
+
+## Related
+
+- Flow: [`src/flows/storage/describe_memes.py`](../../../src/flows/storage/describe_memes.py)
+- Spec: [`specs/describe-memes.md`](../../../specs/describe-memes.md)
+- Agent inspect API (media + OCR card): [`docs/admin-meme-inspect.md`](../../admin-meme-inspect.md)

--- a/src/admin/__init__.py
+++ b/src/admin/__init__.py
@@ -1,0 +1,4 @@
+"""Internal admin HTTP API for agent/operator inspection.
+
+Authenticated with ADMIN_API_TOKEN. Not part of the public product surface.
+"""

--- a/src/admin/auth.py
+++ b/src/admin/auth.py
@@ -1,0 +1,47 @@
+"""Admin API token auth.
+
+Agents and operators call admin routes with either:
+  Authorization: Bearer <ADMIN_API_TOKEN>
+or
+  X-Admin-Token: <ADMIN_API_TOKEN>
+"""
+
+from __future__ import annotations
+
+import secrets
+
+from fastapi import Header, HTTPException, status
+
+from src.config import settings
+
+
+def _extract_bearer(authorization: str | None) -> str | None:
+    if not authorization:
+        return None
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return None
+    return token.strip()
+
+
+async def require_admin_token(
+    authorization: str | None = Header(default=None),
+    x_admin_token: str | None = Header(default=None, alias="X-Admin-Token"),
+) -> None:
+    configured = settings.ADMIN_API_TOKEN
+    if not configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="ADMIN_API_TOKEN is not configured",
+        )
+
+    presented = x_admin_token.strip() if x_admin_token else None
+    if not presented:
+        presented = _extract_bearer(authorization)
+
+    if not presented or not secrets.compare_digest(presented, configured):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing admin token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )

--- a/src/admin/router.py
+++ b/src/admin/router.py
@@ -1,0 +1,111 @@
+"""Admin HTTP routes for meme inspection (agent/operator tooling)."""
+
+from __future__ import annotations
+
+import base64
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import Response
+
+from src.admin.auth import require_admin_token
+from src.admin.service import (
+    MAX_INLINE_MEDIA_BYTES,
+    build_meme_inspect_payload,
+    media_content_type,
+    media_filename,
+)
+from src.storage.upload import download_meme_content_from_tg
+from src.tgbot.service import get_meme_by_id
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/admin",
+    tags=["Admin"],
+    dependencies=[Depends(require_admin_token)],
+)
+
+
+@router.get("/memes/{meme_id}")
+async def inspect_meme(
+    meme_id: int,
+    include_media: bool = Query(
+        default=False,
+        description=(
+            "If true, embed media as base64 when the file is <= 4MB. "
+            "Prefer GET /admin/memes/{id}/media for larger files or binary save."
+        ),
+    ),
+) -> dict:
+    """Compact meme card: status, source, stats, OCR, media availability.
+
+    Use this to understand what a meme is without SQL joins across meme /
+    meme_source / meme_stats / ocr_result. Media itself requires a second hop
+    (or include_media=1 for small images).
+    """
+    payload = await build_meme_inspect_payload(meme_id)
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Meme not found")
+
+    if include_media and payload["media"]["available"]:
+        meme_row = await get_meme_by_id(meme_id)
+        file_id = meme_row and meme_row.get("telegram_file_id")
+        if file_id:
+            try:
+                content = await download_meme_content_from_tg(file_id)
+            except Exception as exc:
+                logger.warning("admin inspect media download failed meme_id=%s: %s", meme_id, exc)
+                payload["media"]["inline_error"] = f"download failed: {type(exc).__name__}"
+            else:
+                if len(content) > MAX_INLINE_MEDIA_BYTES:
+                    payload["media"]["inline_error"] = (
+                        f"media too large for inline base64 "
+                        f"({len(content)} bytes > {MAX_INLINE_MEDIA_BYTES}); "
+                        f"use GET {payload['media']['download_path']}"
+                    )
+                    payload["media"]["size_bytes"] = len(content)
+                else:
+                    payload["media"]["size_bytes"] = len(content)
+                    payload["media"]["base64"] = base64.b64encode(content).decode("ascii")
+
+    return payload
+
+
+@router.get("/memes/{meme_id}/media")
+async def download_meme_media(meme_id: int) -> Response:
+    """Download meme image/video bytes via the production Telegram bot token.
+
+    This is the piece agents cannot do with SQL alone: Telegram file_id only
+    resolves with the bot that uploaded the file.
+    """
+    meme_row = await get_meme_by_id(meme_id)
+    if meme_row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Meme not found")
+
+    file_id = meme_row.get("telegram_file_id")
+    if not file_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Meme has no telegram_file_id (not uploaded to Telegram storage)",
+        )
+
+    try:
+        content = await download_meme_content_from_tg(file_id)
+    except Exception as exc:
+        logger.exception("admin media download failed meme_id=%s", meme_id)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Telegram download failed: {type(exc).__name__}: {exc}",
+        ) from exc
+
+    meme_type = meme_row.get("type")
+    return Response(
+        content=content,
+        media_type=media_content_type(meme_type),
+        headers={
+            "Content-Disposition": f'inline; filename="{media_filename(meme_id, meme_type)}"',
+            "X-Meme-Id": str(meme_id),
+            "X-Meme-Type": str(meme_type or ""),
+        },
+    )

--- a/src/admin/service.py
+++ b/src/admin/service.py
@@ -1,0 +1,137 @@
+"""Compact meme inspect payloads for agents and operators."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+from src.storage.constants import MemeType
+from src.tgbot.service import get_meme_by_id, get_meme_source_by_id, get_meme_stats
+
+# Cap for optional base64 embedding so agents don't pull multi‑MB videos into JSON.
+MAX_INLINE_MEDIA_BYTES = 4 * 1024 * 1024
+
+
+def _iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value)
+
+
+def _compact_ocr(ocr_result: dict[str, Any] | None) -> dict[str, Any]:
+    if not ocr_result:
+        return {
+            "has_ocr": False,
+            "calculated_at": None,
+            "description": None,
+            "text": None,
+            "language": None,
+            "model": None,
+            "describe_failures": 0,
+            "last_failure_reason": None,
+        }
+
+    raw = ocr_result.get("raw_result") if isinstance(ocr_result.get("raw_result"), dict) else {}
+    text = ocr_result.get("text") or raw.get("ocr_text")
+    description = ocr_result.get("description") or raw.get("description")
+    language = ocr_result.get("language") or raw.get("language")
+    has_ocr = bool(description or text or ocr_result.get("calculated_at"))
+
+    return {
+        "has_ocr": has_ocr,
+        "calculated_at": ocr_result.get("calculated_at"),
+        "description": description,
+        "text": text,
+        "language": language,
+        "model": ocr_result.get("model") or ocr_result.get("described_by"),
+        "describe_failures": int(ocr_result.get("describe_failures") or 0),
+        "last_failure_reason": ocr_result.get("last_failure_reason"),
+    }
+
+
+def _compact_stats(stats: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not stats:
+        return None
+    return {
+        "nlikes": stats.get("nlikes"),
+        "ndislikes": stats.get("ndislikes"),
+        "nmemes_sent": stats.get("nmemes_sent"),
+        "lr_smoothed": stats.get("lr_smoothed"),
+        "engagement_score": stats.get("engagement_score"),
+        "age_days": stats.get("age_days"),
+        "raw_impr_rank": stats.get("raw_impr_rank"),
+        "sec_to_react": stats.get("sec_to_react"),
+        "invited_count": stats.get("invited_count"),
+        "updated_at": _iso(stats.get("updated_at")),
+    }
+
+
+def _compact_source(source: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not source:
+        return None
+    return {
+        "id": source.get("id"),
+        "type": source.get("type"),
+        "url": source.get("url"),
+        "status": source.get("status"),
+        "language_code": source.get("language_code"),
+        "parsed_at": _iso(source.get("parsed_at")),
+    }
+
+
+def media_content_type(meme_type: str | None) -> str:
+    if meme_type == MemeType.VIDEO.value:
+        return "video/mp4"
+    if meme_type == MemeType.ANIMATION.value:
+        return "image/gif"
+    return "image/jpeg"
+
+
+def media_filename(meme_id: int, meme_type: str | None) -> str:
+    if meme_type == MemeType.VIDEO.value:
+        ext = "mp4"
+    elif meme_type == MemeType.ANIMATION.value:
+        ext = "gif"
+    else:
+        ext = "jpg"
+    return f"meme_{meme_id}.{ext}"
+
+
+async def build_meme_inspect_payload(meme_id: int) -> dict[str, Any] | None:
+    meme_row = await get_meme_by_id(meme_id)
+    if meme_row is None:
+        return None
+
+    source = await get_meme_source_by_id(meme_row["meme_source_id"])
+    stats = await get_meme_stats(meme_id)
+    file_id = meme_row.get("telegram_file_id")
+
+    return {
+        "meme": {
+            "id": meme_row["id"],
+            "status": meme_row.get("status"),
+            "type": meme_row.get("type"),
+            "language_code": meme_row.get("language_code"),
+            "caption": meme_row.get("caption"),
+            "published_at": _iso(meme_row.get("published_at")),
+            "created_at": _iso(meme_row.get("created_at")),
+            "updated_at": _iso(meme_row.get("updated_at")),
+            "duplicate_of": meme_row.get("duplicate_of"),
+            "meme_source_id": meme_row.get("meme_source_id"),
+            "raw_meme_id": meme_row.get("raw_meme_id"),
+            "has_telegram_file_id": bool(file_id),
+        },
+        "source": _compact_source(source),
+        "stats": _compact_stats(stats),
+        "ocr": _compact_ocr(meme_row.get("ocr_result")),
+        "media": {
+            "available": bool(file_id),
+            "download_path": f"/admin/memes/{meme_id}/media" if file_id else None,
+            "content_type": media_content_type(meme_row.get("type")) if file_id else None,
+            "filename": media_filename(meme_id, meme_row.get("type")) if file_id else None,
+        },
+    }

--- a/src/config.py
+++ b/src/config.py
@@ -37,6 +37,9 @@ class Config(BaseSettings):
     MEME_STORAGE_TELEGRAM_CHAT_ID: str | None = None
     UPLOADED_MEMES_REVIEW_CHAT_ID: str | None = None
     ADMIN_LOGS_CHAT_ID: str | None = None
+    # Shared secret for internal /admin/* HTTP inspect endpoints (agents/operators).
+    # When unset, those routes return 503. Prefer a long random token; never commit it.
+    ADMIN_API_TOKEN: str | None = None
 
     VK_TOKEN: str | None = None
     VK_USER_TOKEN: str | None = None

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 from starlette.middleware.cors import CORSMiddleware
 
 from src import redis
+from src.admin.router import router as admin_router
 from src.config import app_configs, settings
 from src.observability.sentry import before_send, before_send_log
 from src.tgbot import app as tgbot_app
@@ -160,3 +161,4 @@ async def prefect_deployments():
 
 
 app.include_router(tgbot_router, prefix="/tgbot", tags=["Telegram Bot"])
+app.include_router(admin_router)

--- a/tests/admin/test_meme_inspect.py
+++ b/tests/admin/test_meme_inspect.py
@@ -1,0 +1,320 @@
+"""Tests for admin meme inspect HTTP API."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.admin.auth import require_admin_token
+from src.admin.router import router as admin_router
+from src.admin.service import (
+    MAX_INLINE_MEDIA_BYTES,
+    _compact_ocr,
+    build_meme_inspect_payload,
+    media_content_type,
+    media_filename,
+)
+
+
+def _app_with_admin() -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_router)
+    return app
+
+
+@pytest.fixture
+def admin_token(monkeypatch):
+    token = "test-admin-token-not-real"
+    monkeypatch.setattr("src.admin.auth.settings.ADMIN_API_TOKEN", token)
+    return token
+
+
+@pytest.mark.asyncio
+async def test_require_admin_token_missing_config(monkeypatch):
+    monkeypatch.setattr("src.admin.auth.settings.ADMIN_API_TOKEN", None)
+    with pytest.raises(Exception) as exc_info:
+        await require_admin_token(authorization=None, x_admin_token=None)
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_require_admin_token_rejects_bad_token(admin_token):
+    with pytest.raises(Exception) as exc_info:
+        await require_admin_token(authorization="Bearer wrong", x_admin_token=None)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_require_admin_token_accepts_bearer_and_header(admin_token):
+    await require_admin_token(authorization=f"Bearer {admin_token}", x_admin_token=None)
+    await require_admin_token(authorization=None, x_admin_token=admin_token)
+
+
+def test_compact_ocr_empty():
+    assert _compact_ocr(None)["has_ocr"] is False
+    assert _compact_ocr({})["has_ocr"] is False
+
+
+def test_compact_ocr_from_raw_result():
+    ocr = {
+        "calculated_at": "2026-08-13T00:00:00+00:00",
+        "model": "google/gemma-4-31b-it:free",
+        "raw_result": {
+            "ocr_text": "hello",
+            "description": "a cat meme",
+            "language": "en",
+        },
+    }
+    compact = _compact_ocr(ocr)
+    assert compact["has_ocr"] is True
+    assert compact["text"] == "hello"
+    assert compact["description"] == "a cat meme"
+    assert compact["language"] == "en"
+    assert compact["model"] == "google/gemma-4-31b-it:free"
+
+
+def test_media_helpers():
+    assert media_content_type("video") == "video/mp4"
+    assert media_content_type("animation") == "image/gif"
+    assert media_content_type("image") == "image/jpeg"
+    assert media_filename(42, "video") == "meme_42.mp4"
+    assert media_filename(42, "image") == "meme_42.jpg"
+
+
+@pytest.mark.asyncio
+async def test_build_meme_inspect_payload_not_found():
+    with patch("src.admin.service.get_meme_by_id", new=AsyncMock(return_value=None)):
+        assert await build_meme_inspect_payload(999) is None
+
+
+@pytest.mark.asyncio
+async def test_build_meme_inspect_payload_compact():
+    meme = {
+        "id": 101,
+        "status": "ok",
+        "type": "image",
+        "language_code": "ru",
+        "caption": "cap",
+        "published_at": datetime(2024, 6, 1, 12, 0, 0),
+        "created_at": datetime(2024, 6, 1, 12, 0, 0),
+        "updated_at": None,
+        "duplicate_of": None,
+        "meme_source_id": 7,
+        "raw_meme_id": 55,
+        "telegram_file_id": "file_abc",
+        "ocr_result": {
+            "description": "joke about code",
+            "text": "print hello",
+            "language": "en",
+            "calculated_at": "2026-08-01T12:00:00+00:00",
+            "model": "google/gemma-4-31b-it:free",
+        },
+    }
+    source = {
+        "id": 7,
+        "type": "telegram",
+        "url": "https://t.me/example",
+        "status": "parsing_enabled",
+        "language_code": "ru",
+        "parsed_at": None,
+    }
+    stats = {
+        "nlikes": 10,
+        "ndislikes": 2,
+        "nmemes_sent": 20,
+        "lr_smoothed": 0.7,
+        "engagement_score": 1.2,
+        "age_days": 5,
+        "raw_impr_rank": 1,
+        "sec_to_react": 3.5,
+        "invited_count": 0,
+        "updated_at": datetime(2024, 6, 2, 12, 0, 0),
+    }
+
+    with (
+        patch("src.admin.service.get_meme_by_id", new=AsyncMock(return_value=meme)),
+        patch("src.admin.service.get_meme_source_by_id", new=AsyncMock(return_value=source)),
+        patch("src.admin.service.get_meme_stats", new=AsyncMock(return_value=stats)),
+    ):
+        payload = await build_meme_inspect_payload(101)
+
+    assert payload is not None
+    assert payload["meme"]["id"] == 101
+    assert payload["meme"]["has_telegram_file_id"] is True
+    assert payload["source"]["url"] == "https://t.me/example"
+    assert payload["stats"]["nlikes"] == 10
+    assert payload["ocr"]["description"] == "joke about code"
+    assert payload["media"]["download_path"] == "/admin/memes/101/media"
+    assert "telegram_file_id" not in payload["meme"]
+
+
+@pytest.mark.asyncio
+async def test_inspect_endpoint_auth_and_payload(admin_token):
+    payload = {
+        "meme": {"id": 5, "has_telegram_file_id": True},
+        "source": None,
+        "stats": None,
+        "ocr": {"has_ocr": False},
+        "media": {
+            "available": True,
+            "download_path": "/admin/memes/5/media",
+            "content_type": "image/jpeg",
+            "filename": "meme_5.jpg",
+        },
+    }
+    app = _app_with_admin()
+    with patch(
+        "src.admin.router.build_meme_inspect_payload",
+        new=AsyncMock(return_value=payload),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            unauth = await client.get("/admin/memes/5")
+            assert unauth.status_code == 401
+
+            ok = await client.get(
+                "/admin/memes/5",
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            assert ok.status_code == 200
+            assert ok.json()["meme"]["id"] == 5
+
+
+@pytest.mark.asyncio
+async def test_inspect_endpoint_not_found(admin_token):
+    app = _app_with_admin()
+    with patch(
+        "src.admin.router.build_meme_inspect_payload",
+        new=AsyncMock(return_value=None),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/admin/memes/404",
+                headers={"X-Admin-Token": admin_token},
+            )
+            assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_media_endpoint_downloads(admin_token):
+    meme = {
+        "id": 9,
+        "type": "image",
+        "telegram_file_id": "tg_file",
+    }
+    app = _app_with_admin()
+    with (
+        patch("src.admin.router.get_meme_by_id", new=AsyncMock(return_value=meme)),
+        patch(
+            "src.admin.router.download_meme_content_from_tg",
+            new=AsyncMock(return_value=b"\xff\xd8fakejpeg"),
+        ),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/admin/memes/9/media",
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            assert resp.status_code == 200
+            assert resp.content == b"\xff\xd8fakejpeg"
+            assert resp.headers["content-type"].startswith("image/jpeg")
+            assert "meme_9.jpg" in resp.headers.get("content-disposition", "")
+
+
+@pytest.mark.asyncio
+async def test_media_endpoint_missing_file_id(admin_token):
+    meme = {"id": 9, "type": "image", "telegram_file_id": None}
+    app = _app_with_admin()
+    with patch("src.admin.router.get_meme_by_id", new=AsyncMock(return_value=meme)):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/admin/memes/9/media",
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_include_media_inline_base64(admin_token):
+    payload = {
+        "meme": {"id": 3},
+        "source": None,
+        "stats": None,
+        "ocr": {"has_ocr": False},
+        "media": {
+            "available": True,
+            "download_path": "/admin/memes/3/media",
+            "content_type": "image/jpeg",
+            "filename": "meme_3.jpg",
+        },
+    }
+    meme = {"id": 3, "telegram_file_id": "f", "type": "image"}
+    app = _app_with_admin()
+    with (
+        patch(
+            "src.admin.router.build_meme_inspect_payload",
+            new=AsyncMock(return_value=payload),
+        ),
+        patch("src.admin.router.get_meme_by_id", new=AsyncMock(return_value=meme)),
+        patch(
+            "src.admin.router.download_meme_content_from_tg",
+            new=AsyncMock(return_value=b"abc"),
+        ),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/admin/memes/3",
+                params={"include_media": "true"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["media"]["base64"] == "YWJj"
+            assert body["media"]["size_bytes"] == 3
+
+
+@pytest.mark.asyncio
+async def test_include_media_too_large(admin_token):
+    payload = {
+        "meme": {"id": 3},
+        "source": None,
+        "stats": None,
+        "ocr": {"has_ocr": False},
+        "media": {
+            "available": True,
+            "download_path": "/admin/memes/3/media",
+            "content_type": "video/mp4",
+            "filename": "meme_3.mp4",
+        },
+    }
+    meme = {"id": 3, "telegram_file_id": "f", "type": "video"}
+    huge = b"x" * (MAX_INLINE_MEDIA_BYTES + 1)
+    app = _app_with_admin()
+    with (
+        patch(
+            "src.admin.router.build_meme_inspect_payload",
+            new=AsyncMock(return_value=payload),
+        ),
+        patch("src.admin.router.get_meme_by_id", new=AsyncMock(return_value=meme)),
+        patch(
+            "src.admin.router.download_meme_content_from_tg",
+            new=AsyncMock(return_value=huge),
+        ),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/admin/memes/3",
+                params={"include_media": "true"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert "base64" not in body["media"] or body["media"].get("base64") is None
+            assert "too large" in body["media"]["inline_error"]


### PR DESCRIPTION
## Summary

- **Admin HTTP API** for agent/operator meme inspection:
  - `GET /admin/memes/{id}` — compact card (status, source, stats, OCR summary, media availability)
  - `GET /admin/memes/{id}?include_media=true` — inline base64 for files ≤4MB
  - `GET /admin/memes/{id}/media` — raw image/video via production Telegram bot token
  - Auth: `ADMIN_API_TOKEN` + `Authorization: Bearer` or `X-Admin-Token` (503 if unset)
- **OCR health readout** (2026-08-13): describe_memes still alive but ~10/day vs 864 target; ~222k eligible backlog; SQL + docs
- **Cold-start first-10 readout** (post queue limit=5): docs/SQL only, no code change

Docs: `docs/admin-meme-inspect.md`, `docs/analyst/describe-memes-health.sql`, cold-start first10 SQL/readout. Linked from `AGENTS.md` / agent map.

## Deploy note

Set `ADMIN_API_TOKEN` in production env after merge (long random secret). Without it, routes return 503.

## Test plan

- [x] `ruff check` / `ruff format` on new admin module
- [x] `pytest tests/admin/test_meme_inspect.py` — 14 passed (auth, compact payload, media download, base64 size cap)
- [ ] After deploy: set `ADMIN_API_TOKEN`, curl `/admin/memes/{id}` and `/media` from an ops shell
- [ ] Optional: re-run `psql "$ANALYST_DATABASE_URL" -f docs/analyst/describe-memes-health.sql`

## Pre-landing review

- Token compare uses `secrets.compare_digest`
- No Telegram file_id leaked in compact meme JSON (`has_telegram_file_id` only)
- Public repo: example env has empty `ADMIN_API_TOKEN=`; no hostnames/secrets committed