### PR TITLE
feat(crosspost): n_sub_likes shadow + membership sync + v4 interim

### DIFF
--- a/docs/analyst/crossposting-v4-interim-readout.md
+++ b/docs/analyst/crossposting-v4-interim-readout.md
@@ -1,0 +1,42 @@
+# Crosspost RU v4 interim readout (2026-08-13)
+
+## Online (mature ≥36h, fair window)
+
+| cohort | n | avg_fwd | avg_f1k | hit% (f1k≥30.9 ∨ fwd≥12) |
+|--------|--:|--------:|--------:|-------------------------:|
+| **v4** (since 2026-08-10) | **10** | **8.30** | **22.89** | **20%** |
+| **v2** (21d before v4) | **87** | **8.83** | **25.96** | **34.5%** |
+| Δ | | **−6%** | **−12%** | soft |
+
+Total v4 posts live at readout: **17** (not all mature yet).
+
+### Decision
+
+| Option | Choice |
+|--------|--------|
+| RED kill (−25% avg) | **No** |
+| Significant improvement | **No** |
+| Status | **WATCH / hold v4 ON** until n_mature ≥15–20 (~2026-08-15…17) |
+| Next hard gate | **2026-08-17** keep/kill per H6 |
+
+**Interpretation:** fewer hits, avg shares slightly soft, reach OK. Not a win; not a collapse.
+
+## Shadow hybrid (live log)
+
+- Deployed with PR #349; fields on candidates after 2026-08-11 21:06 UTC
+- ~8 decisions with `shadow_score` by 2026-08-13 morning; ~half disagree with prod top-1
+- Too early for f1k compare of shadow-counterfactual (shadow pick usually not posted)
+
+SQL: `docs/analyst/crossposting-shadow-hybrid.sql`
+
+## Next experiments shipped after this readout
+
+1. **n_sub_likes** shadow field (channel members ∩ bot likes) — decision_log only  
+2. **sync_channel_membership.py** — densify membership for active bot users  
+3. Offline next-wave + H9 already recorded under experiments/ml-crosspost-bot2channel/
+
+## Do not
+
+- Ship multi-feature ML as hard ranker  
+- Increase post frequency  
+- Treat WATCH as success  

--- a/experiments/active/2026-08-10-crosspost-v4-and-taste-cohort.md
+++ b/experiments/active/2026-08-10-crosspost-v4-and-taste-cohort.md
@@ -112,8 +112,10 @@ python scripts/crosspost_taste_cohort.py --days 120 --top 50 --min-n 8
 | Date | v4 n mature | avg_fwd | avg_f1k | hit% | v2 baseline hit% | H6 |
 |------|-------------|---------|---------|------|------------------|-----|
 | 2026-08-10 early | 0 | — | — | — | 38% | WATCH |
-| 2026-08-12 | | | | | | |
+| 2026-08-13 interim | **10** (≥36h) | **8.30** | **22.89** | **20%** | 34.5% (n=87, −6% fwd / −12% f1k) | **WATCH** (not RED; not a win) |
 | 2026-08-17 | | | | | | |
+
+Full interim writeup: `docs/analyst/crossposting-v4-interim-readout.md`
 
 | Date | posts with n_taste≥1 | top half f1k | bottom half f1k | H7 |
 |------|----------------------|--------------|-----------------|-----|

--- a/scripts/sync_channel_membership.py
+++ b/scripts/sync_channel_membership.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Densify user_tg_chat_membership for @fastfoodmemes / EN channel.
+
+Checks getChatMember for recently active bot users and upserts/removes membership
+rows. Improves H9 (subscriber ∩ bot) coverage for offline/online shadow features.
+
+Usage (prod or staging with real bot token + DB):
+  set -a; source .env; set +a
+  python scripts/sync_channel_membership.py --channel ru --limit 500 --sleep 0.05
+  python scripts/sync_channel_membership.py --channel ru --limit 2000 --dry-run
+
+Telegram rate limits: keep sleep >= 0.05s; default limit 500/run.
+Schedule manually or via cron/Prefect later — not auto-wired.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# repo root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import telegram
+from sqlalchemy import text
+from telegram.constants import ChatMemberStatus
+
+from src.config import settings
+from src.database import execute, fetch_all
+from src.tgbot.constants import TELEGRAM_CHANNEL_EN_CHAT_ID, TELEGRAM_CHANNEL_RU_CHAT_ID
+from src.tgbot.repo.users import add_user_tg_chat_membership
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("sync_channel_membership")
+
+MEMBER_OK = {
+    ChatMemberStatus.ADMINISTRATOR,
+    ChatMemberStatus.MEMBER,
+    ChatMemberStatus.OWNER,
+    ChatMemberStatus.RESTRICTED,  # still in channel
+}
+
+
+async def _active_user_ids(limit: int, days: int) -> list[int]:
+    rows = await fetch_all(
+        text(
+            """
+            SELECT user_id, count(*)::int AS n
+            FROM user_meme_reaction
+            WHERE reacted_at > now() - make_interval(days => :days)
+            GROUP BY user_id
+            ORDER BY n DESC
+            LIMIT :limit
+            """
+        ),
+        {"days": days, "limit": limit},
+    )
+    return [int(r["user_id"]) for r in rows]
+
+
+async def _delete_membership(user_id: int, chat_id: int) -> None:
+    await execute(
+        text(
+            """
+            DELETE FROM user_tg_chat_membership
+            WHERE user_tg_id = :uid AND chat_id = :chat_id
+            """
+        ),
+        {"uid": user_id, "chat_id": chat_id},
+    )
+
+
+async def sync(
+    *,
+    channel: str,
+    limit: int,
+    days: int,
+    sleep_s: float,
+    dry_run: bool,
+) -> dict:
+    chat_id = TELEGRAM_CHANNEL_RU_CHAT_ID if channel == "ru" else TELEGRAM_CHANNEL_EN_CHAT_ID
+    if not settings.TELEGRAM_BOT_TOKEN:
+        raise SystemExit("TELEGRAM_BOT_TOKEN required")
+
+    bot = telegram.Bot(settings.TELEGRAM_BOT_TOKEN)
+    user_ids = await _active_user_ids(limit, days)
+    log.info("checking %s users for chat_id=%s dry_run=%s", len(user_ids), chat_id, dry_run)
+
+    stats = {
+        "checked": 0,
+        "member": 0,
+        "not_member": 0,
+        "errors": 0,
+        "added_or_refreshed": 0,
+        "removed": 0,
+        "chat_id": chat_id,
+        "channel": channel,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    for uid in user_ids:
+        stats["checked"] += 1
+        try:
+            res = await bot.get_chat_member(chat_id, uid)
+            is_member = res.status in MEMBER_OK
+            if is_member:
+                stats["member"] += 1
+                if not dry_run:
+                    await add_user_tg_chat_membership(uid, chat_id)
+                    stats["added_or_refreshed"] += 1
+            else:
+                stats["not_member"] += 1
+                if not dry_run:
+                    await _delete_membership(uid, chat_id)
+                    stats["removed"] += 1
+        except telegram.error.RetryAfter as e:
+            wait = float(getattr(e, "retry_after", 1) or 1)
+            log.warning("RetryAfter %ss", wait)
+            await asyncio.sleep(wait + 0.1)
+            stats["errors"] += 1
+        except telegram.error.TelegramError as e:
+            # user not found / blocked / etc.
+            stats["errors"] += 1
+            if stats["errors"] <= 5 or stats["errors"] % 50 == 0:
+                log.warning("user %s: %s", uid, e)
+        if sleep_s > 0:
+            await asyncio.sleep(sleep_s)
+        if stats["checked"] % 100 == 0:
+            log.info("progress %s %s", stats["checked"], stats)
+
+    stats["finished_at"] = datetime.now(timezone.utc).isoformat()
+    log.info("done %s", stats)
+    return stats
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--channel", choices=("ru", "en"), default="ru")
+    ap.add_argument("--limit", type=int, default=500)
+    ap.add_argument("--days", type=int, default=30, help="active users lookback")
+    ap.add_argument("--sleep", type=float, default=0.05, dest="sleep_s")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    asyncio.run(
+        sync(
+            channel=args.channel,
+            limit=args.limit,
+            days=args.days,
+            sleep_s=args.sleep_s,
+            dry_run=args.dry_run,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/crossposting/service.py
+++ b/src/crossposting/service.py
@@ -18,6 +18,7 @@ from src.database import (
     execute,
     fetch_all,
 )
+from src.tgbot.constants import TELEGRAM_CHANNEL_EN_CHAT_ID, TELEGRAM_CHANNEL_RU_CHAT_ID
 
 # score_version in crossposting + decision_log
 SCORE_VERSION_V2 = 2
@@ -159,6 +160,7 @@ def _build_decision_log(
             "n_taste_likes": int(row.get("n_taste_likes") or 0),
             "taste_boost_shadow": float(row.get("taste_boost_shadow") or 1.0),
             "taste_cohort_version": row.get("taste_cohort_version"),
+            "n_sub_likes": int(row.get("n_sub_likes") or 0),
             "caption_present": row.get("caption") is not None,
             "src_signal": (
                 round(float(row["src_signal"]), 4) if row.get("src_signal") is not None else None
@@ -235,6 +237,58 @@ async def _enrich_candidates_with_taste_shadow(
         c["n_taste_likes"] = n
         c["taste_boost_shadow"] = round(taste_boost_multiplier(n), 4)
         c["taste_cohort_version"] = version
+    return candidates
+
+
+async def _enrich_candidates_with_sub_likes(
+    candidates: list[dict[str, Any]],
+    *,
+    channel: str,
+) -> list[dict[str, Any]]:
+    """Attach n_sub_likes: pre-existing likes from known channel members (shadow).
+
+    Membership comes from ``user_tg_chat_membership`` (bot-observed). Does not re-rank.
+    """
+    if not candidates:
+        return candidates
+    chat_id = (
+        TELEGRAM_CHANNEL_RU_CHAT_ID
+        if channel == "tgchannelru"
+        else TELEGRAM_CHANNEL_EN_CHAT_ID
+        if channel == "tgchannelen"
+        else None
+    )
+    if chat_id is None:
+        for c in candidates:
+            c["n_sub_likes"] = 0
+        return candidates
+
+    meme_ids = [int(c["id"]) for c in candidates if c.get("id") is not None]
+    counts: dict[int, int] = {}
+    if meme_ids:
+        rows = await fetch_all(
+            text(
+                """
+                SELECT umr.meme_id, COUNT(DISTINCT umr.user_id)::int AS n_sub
+                FROM user_meme_reaction umr
+                WHERE umr.reaction_id = 1
+                  AND umr.meme_id = ANY(:meme_ids)
+                  AND EXISTS (
+                    SELECT 1
+                    FROM user_tg_chat_membership m
+                    WHERE m.user_tg_id = umr.user_id
+                      AND m.chat_id = :chat_id
+                  )
+                GROUP BY umr.meme_id
+                """
+            ),
+            {"meme_ids": meme_ids, "chat_id": int(chat_id)},
+        )
+        counts = {int(r["meme_id"]): int(r["n_sub"]) for r in rows}
+
+    for c in candidates:
+        mid = int(c["id"]) if c.get("id") is not None else None
+        c["n_sub_likes"] = counts.get(mid, 0) if mid is not None else 0
     return candidates
 
 
@@ -609,15 +663,20 @@ async def _get_next_meme_for_channel(
     rows = await fetch_all(text(_STANDARD_RANKER_QUERY), params)
     if not rows:
         return None, None
-    # Shadow: taste cohort counts on top-N only (no re-rank). RU cohort file.
+    # Shadow enrichments must never block posting (log-only signals).
     if channel == "tgchannelru":
         try:
             rows = await _enrich_candidates_with_taste_shadow(rows)
         except Exception:
-            # Logging enrichment must never block posting.
             import logging
 
             logging.getLogger(__name__).warning("taste shadow enrichment failed", exc_info=True)
+    try:
+        rows = await _enrich_candidates_with_sub_likes(rows, channel=channel)
+    except Exception:
+        import logging
+
+        logging.getLogger(__name__).warning("sub-likes shadow enrichment failed", exc_info=True)
     return (
         _picked_meme_dict(rows[0]),
         _build_decision_log(

--- a/tests/crossposting/test_sub_likes_enrich.py
+++ b/tests/crossposting/test_sub_likes_enrich.py
@@ -1,0 +1,30 @@
+"""Channel-subscriber like counts on ranker candidates (shadow)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.crossposting import service as xpost
+from src.tgbot.constants import TELEGRAM_CHANNEL_RU_CHAT_ID
+
+
+@pytest.mark.asyncio
+async def test_enrich_sub_likes(monkeypatch):
+    monkeypatch.setattr(
+        xpost,
+        "fetch_all",
+        AsyncMock(return_value=[{"meme_id": 1, "n_sub": 7}]),
+    )
+    rows = [{"id": 1}, {"id": 2}]
+    out = await xpost._enrich_candidates_with_sub_likes(rows, channel="tgchannelru")
+    assert out[0]["n_sub_likes"] == 7
+    assert out[1]["n_sub_likes"] == 0
+    # ensure we queried with RU chat id
+    call_kw = xpost.fetch_all.await_args
+    assert call_kw[0][1]["chat_id"] == TELEGRAM_CHANNEL_RU_CHAT_ID
+
+
+@pytest.mark.asyncio
+async def test_enrich_sub_likes_empty(monkeypatch):
+    out = await xpost._enrich_candidates_with_sub_likes([], channel="tgchannelru")
+    assert out == []


### PR DESCRIPTION
## Summary

- **Shadow** `n_sub_likes` on crosspost decision_log candidates (channel members ∩ bot likes) — does not change pick
- **Script** `scripts/sync_channel_membership.py` to densify `user_tg_chat_membership` for active bot users (H9 coverage)
- **Readout** `docs/analyst/crossposting-v4-interim-readout.md`: v4 mature n=10, fwd −6% / f1k −12% / hit 20% vs v2 → **WATCH**, keep ON until n≥15–20

## Test plan

- [x] `pytest tests/crossposting/ -q --noconftest` (10 passed)
- [x] ruff
- [ ] After deploy: decision_log candidates have `n_sub_likes`
- [ ] Optional: `python scripts/sync_channel_membership.py --channel ru --limit 500` on prod (rate-limited)