### PR TITLE
fix(feed): offer channel hits on return sessions

### DIFF
--- a/docs/analyst/channel-hits-v1.sql
+++ b/docs/analyst/channel-hits-v1.sql
@@ -48,6 +48,7 @@ WITH seeds AS MATERIALIZED (
     SELECT s.*, u.blocked_bot_at,
            g.new_invitees, g.mature_invitees, g.retained_invitees,
            d.feed_delivery_rows, d.hit_delivery_rows, d.hit_delivery_days,
+           d.daily_hit_delivery_rows, d.session_hit_delivery_rows,
            h.normal_reactions, h.normal_likes, h.normal_active_days,
            h.normal_reactions_d7_13
     FROM seeds s JOIN "user" u ON u.id = s.user_id
@@ -60,9 +61,15 @@ WITH seeds AS MATERIALIZED (
     ) g
     CROSS JOIN LATERAL (
         SELECT count(*) AS feed_delivery_rows,
-               count(*) FILTER (WHERE recommended_by = 'channel_hit_v1') AS hit_delivery_rows,
+               count(*) FILTER (WHERE recommended_by IN (
+                   'channel_hit_v1', 'channel_hit_session_v2'
+               )) AS hit_delivery_rows,
+               count(*) FILTER (WHERE recommended_by = 'channel_hit_v1')
+                   AS daily_hit_delivery_rows,
+               count(*) FILTER (WHERE recommended_by = 'channel_hit_session_v2')
+                   AS session_hit_delivery_rows,
                count(DISTINCT r.sent_at::date) FILTER (
-                   WHERE recommended_by = 'channel_hit_v1'
+                   WHERE recommended_by IN ('channel_hit_v1', 'channel_hit_session_v2')
                ) AS hit_delivery_days
         FROM user_meme_reaction r
         WHERE r.user_id = s.user_id AND r.sent_at >= s.start_at
@@ -89,6 +96,8 @@ WITH seeds AS MATERIALIZED (
     SELECT variant, count(*) AS assigned_users,
            count(*) FILTER (WHERE hit_delivery_rows > 0) AS exposed_users,
            sum(hit_delivery_rows)::bigint AS hit_delivery_rows,
+           sum(daily_hit_delivery_rows)::bigint AS daily_hit_delivery_rows,
+           sum(session_hit_delivery_rows)::bigint AS session_hit_delivery_rows,
            sum(hit_delivery_days)::bigint AS hit_delivery_user_days,
            sum(feed_delivery_rows)::bigint AS normal_feed_delivery_rows,
            round(sum(hit_delivery_rows)::numeric / nullif(sum(feed_delivery_rows), 0), 4)

--- a/docs/analyst/research/2026-09-05-growth/session-cadence/data.json
+++ b/docs/analyst/research/2026-09-05-growth/session-cadence/data.json
@@ -1,0 +1,420 @@
+{
+  "sends": {
+    "from": "2026-08-12T00:00:00Z",
+    "to_exclusive": "2026-09-05T00:00:00Z",
+    "basis": "ordinary_sends",
+    "extracted_at": "2026-09-05 19:22:17.722541+00:00",
+    "summary": [
+      {
+        "segment": "all",
+        "minutes": 15,
+        "active_user_days": 2706,
+        "sessions": "8179",
+        "days_with_2plus": 1605,
+        "days_with_3plus": 1108,
+        "mean_sessions_per_active_day": "3.0225424981522542",
+        "sessions_per_day_p50_p75_p90_p95": [
+          2,
+          4,
+          6,
+          9
+        ],
+        "cap2_opportunities": "4311",
+        "cap3_opportunities": "5419",
+        "cap4_opportunities": "6221",
+        "users": 402,
+        "users_with_multi_session_day": 234,
+        "median_user_mean_sessions_per_active_day": 1.4,
+        "reactions": "238889",
+        "reactions_per_session_p50_p75_p90": [
+          11,
+          34,
+          76
+        ],
+        "active_session_minutes_p50_p75_p90": [
+          2.382883533333333,
+          9.029252558333333,
+          19.80284363333333
+        ],
+        "sessions_with_3plus_reactions": 6255
+      },
+      {
+        "segment": "all",
+        "minutes": 30,
+        "active_user_days": 2705,
+        "sessions": "6841",
+        "days_with_2plus": 1501,
+        "days_with_3plus": 967,
+        "mean_sessions_per_active_day": "2.5290203327171904",
+        "sessions_per_day_p50_p75_p90_p95": [
+          2,
+          3,
+          5,
+          6
+        ],
+        "cap2_opportunities": "4206",
+        "cap3_opportunities": "5173",
+        "cap4_opportunities": "5798",
+        "users": 402,
+        "users_with_multi_session_day": 221,
+        "median_user_mean_sessions_per_active_day": 1.275,
+        "reactions": "238889",
+        "reactions_per_session_p50_p75_p90": [
+          13,
+          41,
+          93
+        ],
+        "active_session_minutes_p50_p75_p90": [
+          3.8057513666666667,
+          16.260555766666666,
+          35.872532316666664
+        ],
+        "sessions_with_3plus_reactions": 5376
+      },
+      {
+        "segment": "all",
+        "minutes": 60,
+        "active_user_days": 2703,
+        "sessions": "5491",
+        "days_with_2plus": 1330,
+        "days_with_3plus": 709,
+        "mean_sessions_per_active_day": "2.0314465408805031",
+        "sessions_per_day_p50_p75_p90_p95": [
+          1,
+          3,
+          4,
+          5
+        ],
+        "cap2_opportunities": "4033",
+        "cap3_opportunities": "4742",
+        "cap4_opportunities": "5091",
+        "users": 402,
+        "users_with_multi_session_day": 200,
+        "median_user_mean_sessions_per_active_day": 1,
+        "reactions": "238889",
+        "reactions_per_session_p50_p75_p90": [
+          17,
+          52,
+          115
+        ],
+        "active_session_minutes_p50_p75_p90": [
+          6.22597465,
+          33.659861633333335,
+          74.18283861666667
+        ],
+        "sessions_with_3plus_reactions": 4443
+      },
+      {
+        "segment": "pilot",
+        "minutes": 15,
+        "active_user_days": 1343,
+        "sessions": "4912",
+        "days_with_2plus": 959,
+        "days_with_3plus": 695,
+        "mean_sessions_per_active_day": "3.6574832464631422",
+        "sessions_per_day_p50_p75_p90_p95": [
+          3,
+          5,
+          8,
+          10
+        ],
+        "cap2_opportunities": "2302",
+        "cap3_opportunities": "2997",
+        "cap4_opportunities": "3514",
+        "users": 85,
+        "users_with_multi_session_day": 85,
+        "median_user_mean_sessions_per_active_day": 2.5714285714285716,
+        "reactions": "146421",
+        "reactions_per_session_p50_p75_p90": [
+          11,
+          35,
+          78
+        ],
+        "active_session_minutes_p50_p75_p90": [
+          2.4163823666666664,
+          9.526255341666666,
+          21.32794980666669
+        ],
+        "sessions_with_3plus_reactions": 3677
+      },
+      {
+        "segment": "pilot",
+        "minutes": 30,
+        "active_user_days": 1342,
+        "sessions": "4075",
+        "days_with_2plus": 904,
+        "days_with_3plus": 609,
+        "mean_sessions_per_active_day": "3.0365126676602086",
+        "sessions_per_day_p50_p75_p90_p95": [
+          2,
+          4,
+          6,
+          7
+        ],
+        "cap2_opportunities": "2246",
+        "cap3_opportunities": "2855",
+        "cap4_opportunities": "3267",
+        "users": 85,
+        "users_with_multi_session_day": 85,
+        "median_user_mean_sessions_per_active_day": 2.25,
+        "reactions": "146421",
+        "reactions_per_session_p50_p75_p90": [
+          13,
+          42,
+          96
+        ],
+        "active_session_minutes_p50_p75_p90": [
+          3.8689148166666665,
+          17.612419841666668,
+          36.86466538
+        ],
+        "sessions_with_3plus_reactions": 3127
+      },
+      {
+        "segment": "pilot",
+        "minutes": 60,
+        "active_user_days": 1341,
+        "sessions": "3179",
+        "days_with_2plus": 800,
+        "days_with_3plus": 450,
+        "mean_sessions_per_active_day": "2.3706189410887397",
+        "sessions_per_day_p50_p75_p90_p95": [
+          2,
+          3,
+          4,
+          5
+        ],
+        "cap2_opportunities": "2141",
+        "cap3_opportunities": "2591",
+        "cap4_opportunities": "2827",
+        "users": 85,
+        "users_with_multi_session_day": 84,
+        "median_user_mean_sessions_per_active_day": 1.8,
+        "reactions": "146421",
+        "reactions_per_session_p50_p75_p90": [
+          18,
+          55,
+          118.20000000000027
+        ],
+        "active_session_minutes_p50_p75_p90": [
+          7.38480025,
+          37.464029125,
+          80.77192748000002
+        ],
+        "sessions_with_3plus_reactions": 2519
+      }
+    ],
+    "gaps": [
+      {
+        "segment": "all",
+        "gap": "01: <5s",
+        "intervals": 87346
+      },
+      {
+        "segment": "all",
+        "gap": "02: 5-15s",
+        "intervals": 99883
+      },
+      {
+        "segment": "all",
+        "gap": "03: 15-60s",
+        "intervals": 36908
+      },
+      {
+        "segment": "all",
+        "gap": "04: 1-5m",
+        "intervals": 4718
+      },
+      {
+        "segment": "all",
+        "gap": "05: 5-15m",
+        "intervals": 1855
+      },
+      {
+        "segment": "all",
+        "gap": "06: 15-30m",
+        "intervals": 1338
+      },
+      {
+        "segment": "all",
+        "gap": "07: 30-60m",
+        "intervals": 1350
+      },
+      {
+        "segment": "all",
+        "gap": "08: 1-2h",
+        "intervals": 1221
+      },
+      {
+        "segment": "all",
+        "gap": "09: 2-4h",
+        "intervals": 809
+      },
+      {
+        "segment": "all",
+        "gap": "10: 4-8h",
+        "intervals": 617
+      },
+      {
+        "segment": "all",
+        "gap": "11: 8-12h",
+        "intervals": 555
+      },
+      {
+        "segment": "all",
+        "gap": "12: 12-24h",
+        "intervals": 823
+      },
+      {
+        "segment": "all",
+        "gap": "13: >=24h",
+        "intervals": 1172
+      },
+      {
+        "segment": "pilot",
+        "gap": "01: <5s",
+        "intervals": 53693
+      },
+      {
+        "segment": "pilot",
+        "gap": "02: 5-15s",
+        "intervals": 60140
+      },
+      {
+        "segment": "pilot",
+        "gap": "03: 15-60s",
+        "intervals": 23283
+      },
+      {
+        "segment": "pilot",
+        "gap": "04: 1-5m",
+        "intervals": 3068
+      },
+      {
+        "segment": "pilot",
+        "gap": "05: 5-15m",
+        "intervals": 1325
+      },
+      {
+        "segment": "pilot",
+        "gap": "06: 15-30m",
+        "intervals": 837
+      },
+      {
+        "segment": "pilot",
+        "gap": "07: 30-60m",
+        "intervals": 896
+      },
+      {
+        "segment": "pilot",
+        "gap": "08: 1-2h",
+        "intervals": 872
+      },
+      {
+        "segment": "pilot",
+        "gap": "09: 2-4h",
+        "intervals": 510
+      },
+      {
+        "segment": "pilot",
+        "gap": "10: 4-8h",
+        "intervals": 372
+      },
+      {
+        "segment": "pilot",
+        "gap": "11: 8-12h",
+        "intervals": 357
+      },
+      {
+        "segment": "pilot",
+        "gap": "12: 12-24h",
+        "intervals": 464
+      },
+      {
+        "segment": "pilot",
+        "gap": "13: >=24h",
+        "intervals": 572
+      }
+    ]
+  },
+  "replay": {
+    "users": 85,
+    "totals": {
+      "sessions": 4075,
+      "active_user_days": 1342,
+      "calendar_cap2": 2246,
+      "calendar_cap3": 2855,
+      "rolling24_cap2": 1929,
+      "rolling24_cap3": 2539
+    },
+    "first_session_delivery_quantiles": {
+      "min": 1,
+      "median": 17,
+      "p90": 108,
+      "max": 1173
+    },
+    "later_session_delivery_quantiles": {
+      "min": 1,
+      "median": 11,
+      "p90": 88,
+      "max": 1036
+    },
+    "within_day_return_pause_hours_quantiles": {
+      "min": 0.500003695,
+      "median": 1.2990672399999998,
+      "p90": 6.523106125555556,
+      "max": 22.22487409
+    },
+    "direct_deliveries": 0,
+    "per_user_24d_opportunity_quantiles": {
+      "rolling24_cap2": {
+        "min": 8,
+        "median": 21,
+        "p90": 34,
+        "max": 43
+      },
+      "rolling24_cap3": {
+        "min": 9,
+        "median": 26,
+        "p90": 50,
+        "max": 60
+      }
+    }
+  },
+  "reaction_sensitivity": {
+    "from": "2026-08-12",
+    "to_exclusive": "2026-09-05",
+    "pilot": [
+      {
+        "gap_minutes": 15,
+        "active_user_days": 1282,
+        "sessions": 4037,
+        "multi_session_days": 868
+      },
+      {
+        "gap_minutes": 30,
+        "active_user_days": 1282,
+        "sessions": 3371,
+        "multi_session_days": 822
+      },
+      {
+        "gap_minutes": 60,
+        "active_user_days": 1281,
+        "sessions": 2699,
+        "multi_session_days": 737
+      }
+    ]
+  },
+  "inventory": {
+    "as_of": "2026-09-05T19:23:00Z",
+    "pool": 308,
+    "treatment_users": 42,
+    "minimum": 37,
+    "median": 128.5,
+    "users_gte_28": 42,
+    "users_gte_42": 40,
+    "users_gte_56": 37,
+    "source": "production eligible_channel_hits limit 400; aggregate only; no reservations"
+  }
+}
+

--- a/docs/analyst/research/2026-09-05-growth/session-cadence/gaps.sql
+++ b/docs/analyst/research/2026-09-05-growth/session-cadence/gaps.sql
@@ -1,0 +1,23 @@
+-- Same parameters and clean delivery exclusions as summary.sql.
+WITH base AS MATERIALIZED (
+ SELECT r.user_id,r.meme_id,r.sent_at AS event_at,
+ EXISTS(SELECT 1 FROM experiment_assignment e WHERE e.user_id=r.user_id AND e.experiment_id='channel_hits_v1') AS pilot
+ FROM user_meme_reaction r JOIN "user" u ON u.id=r.user_id
+ WHERE r.sent_at >= $1::timestamp-interval '1 day' AND r.sent_at<$2::timestamp
+ AND u.type='user'  AND r.recommended_by IS NOT NULL
+ AND r.recommended_by NOT IN('uploaded_meme','low_sent_pool','friend_challenge','share_link','last')
+ AND r.recommended_by NOT LIKE 'broadcast%' AND r.recommended_by NOT LIKE 'friend_challenge%'
+), gaps AS (
+ SELECT *,extract(epoch FROM event_at-lag(event_at) OVER(PARTITION BY user_id ORDER BY event_at,meme_id)) AS seconds
+ FROM base
+), bins AS (
+ SELECT pilot,
+ CASE WHEN seconds<5 THEN '01: <5s' WHEN seconds<15 THEN '02: 5-15s' WHEN seconds<60 THEN '03: 15-60s'
+ WHEN seconds<300 THEN '04: 1-5m' WHEN seconds<900 THEN '05: 5-15m' WHEN seconds<1800 THEN '06: 15-30m'
+ WHEN seconds<3600 THEN '07: 30-60m' WHEN seconds<7200 THEN '08: 1-2h' WHEN seconds<14400 THEN '09: 2-4h'
+ WHEN seconds<28800 THEN '10: 4-8h' WHEN seconds<43200 THEN '11: 8-12h' WHEN seconds<86400 THEN '12: 12-24h'
+ ELSE '13: >=24h' END AS gap,seconds
+ FROM gaps WHERE event_at>=$1 AND seconds IS NOT NULL
+)
+SELECT segment,gap,count(*) AS intervals FROM bins CROSS JOIN LATERAL unnest(CASE WHEN pilot THEN ARRAY['all','pilot'] ELSE ARRAY['all'] END) segment GROUP BY 1,2 ORDER BY 1,2
+

--- a/docs/analyst/research/2026-09-05-growth/session-cadence/replay.py
+++ b/docs/analyst/research/2026-09-05-growth/session-cadence/replay.py
@@ -1,0 +1,39 @@
+import os,asyncio,json,statistics
+from collections import defaultdict,deque,Counter
+from datetime import datetime,timedelta
+import asyncpg
+from sqlalchemy.engine import make_url
+SQL="WITH base AS (\n SELECT r.user_id,r.meme_id,r.sent_at AS event_at,r.recommended_by\n FROM user_meme_reaction r JOIN experiment_assignment e ON e.user_id=r.user_id AND e.experiment_id='channel_hits_v1'\n JOIN \"user\" u ON u.id=r.user_id\n WHERE r.sent_at >= $1::timestamp-interval '1 day' AND r.sent_at < $2::timestamp\n AND u.type='user' AND r.recommended_by IS NOT NULL\n AND r.recommended_by NOT IN('uploaded_meme','low_sent_pool','friend_challenge','share_link','last')\n AND r.recommended_by NOT LIKE 'broadcast%' AND r.recommended_by NOT LIKE 'friend_challenge%'\n), gaps AS (\n SELECT *,lag(event_at) OVER(PARTITION BY user_id ORDER BY event_at,meme_id) AS previous_at FROM base\n), assigned AS (\n SELECT *,sum(CASE WHEN previous_at IS NULL OR event_at-previous_at>interval '30 minutes' THEN 1 ELSE 0 END)\n OVER(PARTITION BY user_id ORDER BY event_at,meme_id) AS session_id FROM gaps\n)\nSELECT user_id,session_id,min(event_at) AS start_at,max(event_at) AS end_at,count(*) AS deliveries,\n count(*) FILTER(WHERE recommended_by='direct') AS direct_deliveries\nFROM assigned GROUP BY user_id,session_id\nHAVING min(event_at)>=$1 AND min(event_at)<$2 ORDER BY user_id,start_at"
+async def main():
+ c=await asyncpg.connect(make_url(os.environ["DATABASE_URL"]).set(drivername="postgresql").render_as_string(hide_password=False),timeout=10,server_settings={"timezone":"UTC","default_transaction_read_only":"on","statement_timeout":"45000"},statement_cache_size=0)
+ try:
+  rows=await c.fetch(SQL,datetime(2026,8,12),datetime(2026,9,5))
+  users=defaultdict(list)
+  for r in rows:users[r["user_id"]].append(dict(r))
+  totals=Counter();counts_by_user=defaultdict(list);first_lengths=[];later_lengths=[];return_hours=[];direct=0
+  for sessions in users.values():
+   day_counts=Counter()
+   rolling={2:deque(),3:deque()}
+   accepted=Counter()
+   prev_end=None
+   for s in sessions:
+    ts=s["start_at"];day=ts.date();rank=day_counts[day];day_counts[day]+=1
+    direct+=s["direct_deliveries"]
+    (first_lengths if rank==0 else later_lengths).append(s["deliveries"])
+    if prev_end and rank>0:return_hours.append((ts-prev_end).total_seconds()/3600)
+    prev_end=s["end_at"]
+    for cap,q in rolling.items():
+     while q and ts-q[0]>=timedelta(hours=24):q.popleft()
+     if len(q)<cap:q.append(ts);accepted[f"rolling24_cap{cap}"]+=1
+   totals["sessions"]+=len(sessions);totals["active_user_days"]+=len(day_counts)
+   totals["calendar_cap2"]+=sum(min(v,2) for v in day_counts.values())
+   totals["calendar_cap3"]+=sum(min(v,3) for v in day_counts.values())
+   for name,value in accepted.items():totals[name]+=value;counts_by_user[name].append(value)
+  def quantiles(values):
+   return {"min":min(values),"median":statistics.median(values),"p90":sorted(values)[int((len(values)-1)*.9)],"max":max(values)}
+  print(json.dumps({"users":len(users),"totals":dict(totals),"first_session_delivery_quantiles":quantiles(first_lengths),"later_session_delivery_quantiles":quantiles(later_lengths),"within_day_return_pause_hours_quantiles":quantiles(return_hours),"direct_deliveries":direct,"per_user_24d_opportunity_quantiles":{k:quantiles(v) for k,v in counts_by_user.items()}},default=str))
+ finally:await c.close()
+try:asyncio.run(main())
+except Exception as exc:print(json.dumps({"error":type(exc).__name__}));raise SystemExit(1)
+
+

--- a/docs/analyst/research/2026-09-05-growth/session-cadence/replay.sql
+++ b/docs/analyst/research/2026-09-05-growth/session-cadence/replay.sql
@@ -1,0 +1,19 @@
+WITH base AS (
+ SELECT r.user_id,r.meme_id,r.sent_at AS event_at,r.recommended_by
+ FROM user_meme_reaction r JOIN experiment_assignment e ON e.user_id=r.user_id AND e.experiment_id='channel_hits_v1'
+ JOIN "user" u ON u.id=r.user_id
+ WHERE r.sent_at >= $1::timestamp-interval '1 day' AND r.sent_at < $2::timestamp
+ AND u.type='user' AND r.recommended_by IS NOT NULL
+ AND r.recommended_by NOT IN('uploaded_meme','low_sent_pool','friend_challenge','share_link','last')
+ AND r.recommended_by NOT LIKE 'broadcast%' AND r.recommended_by NOT LIKE 'friend_challenge%'
+), gaps AS (
+ SELECT *,lag(event_at) OVER(PARTITION BY user_id ORDER BY event_at,meme_id) AS previous_at FROM base
+), assigned AS (
+ SELECT *,sum(CASE WHEN previous_at IS NULL OR event_at-previous_at>interval '30 minutes' THEN 1 ELSE 0 END)
+ OVER(PARTITION BY user_id ORDER BY event_at,meme_id) AS session_id FROM gaps
+)
+SELECT user_id,session_id,min(event_at) AS start_at,max(event_at) AS end_at,count(*) AS deliveries,
+ count(*) FILTER(WHERE recommended_by='direct') AS direct_deliveries
+FROM assigned GROUP BY user_id,session_id
+HAVING min(event_at)>=$1 AND min(event_at)<$2 ORDER BY user_id,start_at
+

--- a/docs/analyst/research/2026-09-05-growth/session-cadence/report-source-notes.md
+++ b/docs/analyst/research/2026-09-05-growth/session-cadence/report-source-notes.md
@@ -1,0 +1,59 @@
+# FFMemes session cadence: report source notes
+
+Source: AI analysis. Audience: product stakeholders / founder. Delivery: portable HTML; no publishing.
+
+## Reporting job
+
+- Question: Does a calendar day describe FFMemes visits poorly, and is there a recurring within-day session pattern?
+- Decision: Whether to replace the first-calendar-session opportunity with an inactivity-based session opportunity while preserving an explicit experiment exposure cap.
+- Scope: Clean voluntary meme sends during 12 August–4 September 2026 inclusive; frozen 85-user experiment cohort compared with all users.
+- Sensitivity: Session boundaries at 15, 30, and 60 minutes without clean voluntary sends.
+- Success criterion: Show the repeated-visit pattern, its stability across boundary choices, and the resulting policy implication without claiming a causal effect on growth.
+
+## Report structure contract
+
+The `product stakeholders` executive specification was read before drafting.
+
+1. Matching title block.
+2. Visible `Executive Summary` section (Russian summary; English label retained by the contract).
+3. Findings and metric definitions, with a compact native grouped bar chart. The chart compares repeat-session incidence across the three inactivity thresholds and two populations. A compact table may retain exact denominators and related measures when they improve auditability.
+4. Recommendation and open questions combined: define session boundaries and exposure cap separately; distinguish observed cadence from untested growth or ideal frequency claims.
+5. Caveats near their relevant finding and a compact closing caveat paragraph.
+
+The required `Recommended next steps` and `Further questions` roles are combined because one decision is under review. Reproducibility and source inventories remain in source metadata and this file, not a reader-facing appendix.
+
+## Chart contract
+
+- Question: Does the repeat-session finding depend on calling a pause 15, 30, or 60 minutes?
+- Family: comparison; grouped bar; six population/threshold aggregates. This is sensitivity analysis, not a three-point time trend.
+- X: inactivity threshold in natural order 15, 30, 60 minutes.
+- Y: share of active user-days with multiple observed sessions. The final artifact will carry exact numerator and denominator where supplied.
+- Group: frozen experiment cohort versus all qualifying users.
+- Palette: two restrained roots from the canonical shared chart renderer; labeled legend and ordered x-axis provide non-color distinctions.
+- Surface: canonical `artifact.json` native chart, packaged by `report:deliver` into one self-contained `report.html`.
+- No custom chart renderer, remote assets, individual user identifiers, or credentials.
+
+## Reviewed source inventory and transformations
+
+- `data.json`: root analyst's reviewed aggregate result, extracted at 19:22–19:23 UTC on 5 September 2026. This is the narrative source of record.
+- `summary.sql`: session summaries from `public.user_meme_reaction`, `public.user`, and `public.experiment_assignment`. The report preserves the executed logic, replacing the two bind parameters with the actual study bounds in source metadata.
+- `replay.sql` and `replay.py`: original session-level source query and downstream rolling-cap simulation. The report contains aggregate outcomes only; no per-user records are included.
+- Main result: 904 / 1,342 = 67.36% repeat-session days in the pilot at 30 minutes; 1,501 / 2,705 = 55.49% for all users. The all-users segment includes the pilot.
+- The sensitivity chart retains all six reviewed population/threshold aggregates, including exact repeat-day numerators, active-day denominators, user counts, session counts, and median sessions per day.
+- The policy table uses exactly 1,342, 1,929, 2,539, and 4,075 opportunities. Ratios are calculated against 1,342. Calendar-day cap-two/cap-three counts are intentionally excluded from the displayed comparison because the proposed policy uses rolling 24-hour limits.
+- Reaction sensitivity: 822 / 1,282 = 64.12% repeat-session days at 30 minutes.
+- Displayed pause: 1.29906724 hours × 60 = 77.944 minutes, rounded to 78. Session duration is the elapsed interval between retained sends, not measured viewing time.
+- Opportunity replay ignores inventory depletion, behavior changes, and exposure history before the study window. It is not an estimate of actual experimental deliveries, treatment effect, or growth.
+- Cadence policy statements describe the root agent's new-version specification. The report uses durable neutral wording: one hit at the start of each session, at most three per rolling 24 hours; the effect on growth is not yet measured. It makes no claim about deployment status; production deployment is outside this subtask.
+
+## Build and verification
+
+Canonical files: `artifact.json` and generated `report.html`. The portable builder packages the shared reader, semantic fallback, native chart, table, and source interactions; no bespoke rendering implementation was used.
+
+The first packaging attempt required actual SQL in the table's source metadata despite retaining the reproducible Python source path. The narrow correction added the original `replay.sql` query and explained that the subsequent rolling-cap calculation lives in `replay.py`; the report's content and data were preserved.
+
+Final `report:deliver` receipt: validation passed; package passed; verification passed. The packaged verifier checked 8 blocks, 1 native chart, 1 native table, source-dialog interaction, desktop width 1,440 and narrow width 390, exact embedded artifact equality, and absence of browser/network errors. This is the skill's sufficient per-report QA receipt; no redundant bespoke browser scripts or screenshots were produced.
+
+No production calls, code changes, public publication, or individual-user data exports were performed by the report task.
+
+A narrow pre-release wording revision changed only the title subline and the policy section's final status sentence. Historical evidence, quantitative values, datasets, sources, block order, and the recommendation were preserved. The original canonical artifact was repackaged after this correction.

--- a/docs/analyst/research/2026-09-05-growth/session-cadence/summary.sql
+++ b/docs/analyst/research/2026-09-05-growth/session-cadence/summary.sql
@@ -1,0 +1,54 @@
+-- Parameters: $1 inclusive UTC start, $2 exclusive UTC end. Main analysis uses sent_at, retaining nonreacted deliveries.
+WITH base AS MATERIALIZED (
+ SELECT r.user_id,r.meme_id,r.sent_at AS event_at,
+   EXISTS(SELECT 1 FROM experiment_assignment e WHERE e.user_id=r.user_id AND e.experiment_id='channel_hits_v1') AS pilot
+ FROM user_meme_reaction r JOIN "user" u ON u.id=r.user_id
+ WHERE r.sent_at >= $1::timestamp - interval '1 day' AND r.sent_at < $2::timestamp
+   AND u.type='user' 
+   AND r.recommended_by IS NOT NULL
+   AND r.recommended_by NOT IN('uploaded_meme','low_sent_pool','friend_challenge','share_link','last')
+   AND r.recommended_by NOT LIKE 'broadcast%' AND r.recommended_by NOT LIKE 'friend_challenge%'
+), gaps AS MATERIALIZED (
+ SELECT *,extract(epoch FROM event_at-lag(event_at) OVER(PARTITION BY user_id ORDER BY event_at,meme_id))/60.0 AS gap_min
+ FROM base
+), assigned AS (
+ SELECT g.*,t.minutes,
+   sum(CASE WHEN gap_min IS NULL OR gap_min>t.minutes THEN 1 ELSE 0 END)
+     OVER(PARTITION BY user_id,t.minutes ORDER BY event_at,meme_id) AS session_id
+ FROM gaps g CROSS JOIN (VALUES(15),(30),(60)) t(minutes)
+), sessions0 AS MATERIALIZED (
+ SELECT user_id,pilot,minutes,session_id,min(event_at) AS start_at,max(event_at) AS end_at,count(*) AS reactions
+ FROM assigned GROUP BY user_id,pilot,minutes,session_id
+), sessions AS MATERIALIZED (
+ SELECT s.*,segment FROM sessions0 s CROSS JOIN LATERAL unnest(CASE WHEN pilot THEN ARRAY['all','pilot'] ELSE ARRAY['all'] END) segment
+ WHERE start_at >= $1 AND start_at < $2
+), days AS (
+ SELECT segment,minutes,user_id,start_at::date AS day,count(*) AS sessions,sum(reactions) AS reactions
+ FROM sessions GROUP BY 1,2,3,4
+), per_user AS (
+ SELECT segment,minutes,user_id,count(*) AS active_days,sum(sessions) AS sessions,
+   avg(sessions) AS sessions_per_active_day, count(*) FILTER(WHERE sessions>=2) AS multi_session_days
+ FROM days GROUP BY 1,2,3
+), user_summary AS (
+ SELECT segment,minutes,count(*) AS users,count(*) FILTER(WHERE multi_session_days>0) AS users_with_multi_session_day,
+   percentile_cont(0.5) WITHIN GROUP(ORDER BY sessions_per_active_day) AS median_user_mean_sessions_per_active_day
+ FROM per_user GROUP BY 1,2
+), day_summary AS (
+ SELECT segment,minutes,count(*) AS active_user_days,sum(sessions) AS sessions,
+   count(*) FILTER(WHERE sessions>=2) AS days_with_2plus,
+   count(*) FILTER(WHERE sessions>=3) AS days_with_3plus,
+   avg(sessions) AS mean_sessions_per_active_day,
+   percentile_cont(ARRAY[0.5,0.75,0.9,0.95]) WITHIN GROUP(ORDER BY sessions) AS sessions_per_day_p50_p75_p90_p95,
+   sum(least(sessions,2)) AS cap2_opportunities,
+   sum(least(sessions,3)) AS cap3_opportunities,
+   sum(least(sessions,4)) AS cap4_opportunities
+ FROM days GROUP BY 1,2
+), lengths AS (
+ SELECT segment,minutes,sum(reactions) AS reactions,
+   percentile_cont(ARRAY[0.5,0.75,0.9]) WITHIN GROUP(ORDER BY reactions) AS reactions_per_session_p50_p75_p90,
+   percentile_cont(ARRAY[0.5,0.75,0.9]) WITHIN GROUP(ORDER BY extract(epoch FROM end_at-start_at)/60.0) AS active_session_minutes_p50_p75_p90,
+   count(*) FILTER(WHERE reactions>=3) AS sessions_with_3plus_reactions
+ FROM sessions GROUP BY 1,2
+)
+SELECT * FROM day_summary JOIN user_summary USING(segment,minutes) JOIN lengths USING(segment,minutes) ORDER BY segment,minutes
+

--- a/docs/growth/channel-hit-session-cadence.md
+++ b/docs/growth/channel-hit-session-cadence.md
@@ -1,0 +1,83 @@
+# Channel hits during return sessions
+
+The initial pilot could only place a hit in the first five ordinary sends of the
+first UTC-day session. A user who browsed earlier that day could not receive a
+hit after returning, even if the first visit produced no experimental hit.
+
+The revision allows one hit in the first five ordinary sends of each real
+session after more than 30 minutes of inactivity, capped at three attempts in
+the preceding 24 hours. A session can cross midnight. Both the old and new hit
+labels count toward quota recovery from delivery history; atomic reservations
+also count uncertain attempts. Missing candidates or operational errors keep
+the ordinary feed available. Subscriber, known-delivery and duplicate filters
+are preserved, with no Telegram membership HTTP calls in the feed.
+
+## Evidence for the frequency change
+
+Read-only production analysis covers August 12 through September 4 inclusive.
+Earlier days were excluded from the primary result because broadcast origin
+labels were not reliable throughout that history. Sessions are based on clean
+ordinary deliveries, including sends with no reaction. They are computed across
+midnight, then assigned to their start date. These are reconstructed browsing
+episodes, not measured app opens.
+
+For the frozen 85-user pilot, a 30-minute gap produces 4,075 sessions across
+1,342 active user-days. A second or later session occurred on 67.4% of those
+days; median sessions per active day were two. Median session depth was 13
+deliveries, and the median pause between same-day sessions was about 78 minutes.
+Later sessions had a median 11 deliveries, compared with 17 in the first session.
+
+The conclusion is robust to the threshold: the fraction of active days with
+multiple sessions was 71.4% at 15 minutes and 59.7% at 60 minutes. Reaction-based
+sessionization gives 64.1% at 30 minutes. The broader 402-user population gives
+55.5% at 30 minutes and includes the pilot; it is not an independent control.
+Thirty minutes remains a practical existing convention, not an estimated
+optimal threshold or proof of a unique natural boundary.
+
+A historical replay gives 1,342 ideal daily opportunities, versus 1,929 with
+one per session capped at two in rolling 24 hours, and 2,539 capped at three.
+The selected three-attempt cap gives 1.89 times as many opportunities. This
+simulation assumes a usable hit at each accepted session start and unchanged
+user behavior; it does not estimate realized exposures or growth.
+
+At the inventory check, all 42 treatment users had at least 37 eligible unseen
+hits, with median 128.5. Forty had at least 42 candidates. Stock is not promised:
+membership, moderation, ordinary consumption and rolling age can change it.
+When a user has no eligible hit, continue the ordinary feed; never recycle a
+known delivered meme to meet a frequency target.
+
+## Preserve the experiment
+
+Keep the same 42 treatment / 43 control users, baseline, original 14-day window
+and outcome denominators. New deliveries use `channel_hit_session_v2`; the
+original `channel_hit_v1` history remains intact. The readout reports both
+cadence counts and their combined exposure. Record production activation time
+and old/new exposure counts during rollout. Do not call cadence activation a
+growth result, and do not rerandomize after looking at outcomes.
+
+Reproducible evidence lives in
+`docs/analyst/research/2026-09-05-growth/session-cadence/`. Existing stored
+user/meme rows are mutable and can lose duplicate/repeat events; historical
+session reconstruction is approximate. No raw user data was exported.
+
+## Verification
+
+The complete isolated release suite passed on Python 3.14: 772 tests passed,
+two existing tests were skipped, and eight subtests passed. Ruff and the public
+repository redaction audit passed. Disposable local PostgreSQL/Redis fixtures
+were cleaned after validation; no production fixture data was written.
+
+Required regression cases cover later same-day visits, missed first-visit slots,
+cross-midnight sessions, the first-five boundary, rolling 24-hour quota,
+concurrent reservations, Redis loss with durable deliveries, both cadence labels,
+and ordinary-feed fallback. The analytical readout must retain zero-exposure
+hosts and distinguish cadence labels without changing referral denominators.
+
+The latest-six-send bound was checked against full histories in 100,000
+deterministic generated sequences with no disagreements. A read-only production
+preview for all 42 treatment users measured the session query at 1.42 ms median
+and 1.81 ms p95; this is query time, not total feed request latency.
+
+After total Redis data loss, only successful persisted deliveries can restore
+the quota. Ambiguous attempts without a delivery row cannot be reconstructed;
+do not claim durable preservation of those attempts across a cache reset.

--- a/docs/growth/channel-hits-implementation.md
+++ b/docs/growth/channel-hits-implementation.md
@@ -8,10 +8,19 @@ promise.
 ## Delivered behavior
 
 The `channel_hits_v1` experiment replaces one ordinary meme within the first
-five sends of the first voluntary session of each UTC day. There is at most one
-attempt per day. Only pre-enrolled treatment users qualify; control uses the
-existing feed. Assignment has a common 14-day exposure window. The toggle is
+five sends of any voluntary session separated by more than 30 minutes of
+inactivity. There is at most one attempt per session and three attempts in a
+rolling 24-hour window; midnight does not reset the quota or split a session.
+Only pre-enrolled treatment users qualify; control uses the existing feed.
+Assignment has a common 14-day exposure window. The toggle is
 `CHANNEL_HITS_ENABLED` (default false); enrollment alone cannot activate it.
+
+The initial September 5 release permitted only the first session of a UTC day,
+with delivery label `channel_hit_v1`. The session cadence revision uses
+`channel_hit_session_v2` while preserving the same experiment, assignments,
+baseline and exposure window. Readout totals include both labels and report
+each cadence separately. Existing hit deliveries also count toward the quota.
+See [cadence evidence and revision](channel-hit-session-cadence.md).
 
 Channel labels use the snapshot nearest 24 hours, within 20–36 hours, for posts
 at least 36 hours old in the last 120 days. Images require at least 50 views;
@@ -80,7 +89,7 @@ existing application environment; no secret arguments or files are needed.
    all ordinary, unblocked core users with at least eight active clean-feed days,
    20 likes in the preceding 28 days, and at least 14 eligible hits. Allocate
    reproducibly 50/50, keeping all assigned users in the outcome denominator.
-5. Enable `CHANNEL_HITS_ENABLED`. Confirm actual `channel_hit_v1` deliveries,
+5. Enable `CHANNEL_HITS_ENABLED`. Confirm actual `channel_hit_session_v2` deliveries,
    subscription exclusions, normal-feed fallback and error/latency behavior.
 6. `python scripts/channel_hit_experiment.py readout` reports actual exposure,
    unique non-self meme-link starts, new attributed invitees, and invitees who

--- a/src/recommendations/channel_hits.py
+++ b/src/recommendations/channel_hits.py
@@ -19,7 +19,11 @@ from src.tgbot.constants import TELEGRAM_CHANNEL_EN_CHAT_ID, TELEGRAM_CHANNEL_RU
 
 logger = logging.getLogger(__name__)
 EXPERIMENT_ID = "channel_hits_v1"
-RECOMMENDED_BY = "channel_hit_v1"
+RECOMMENDED_BY = "channel_hit_session_v2"
+HIT_RECOMMENDERS = ("channel_hit_v1", RECOMMENDED_BY)
+SESSION_GAP_SECONDS = 30 * 60
+ROLLING_QUOTA = 3
+ROLLING_WINDOW_SECONDS = 24 * 60 * 60
 POOL_KEY = "channel_hits:v1:pool"
 COHORT_KEY = "channel_hits:v1:treatment_users"
 CHANNEL_CHAT_IDS = {
@@ -218,31 +222,99 @@ async def eligible_channel_hits(
     )
 
 
-DAILY_OPPORTUNITY_SQL = """
-WITH sends AS (
-    SELECT sent_at, recommended_by,
-           lag(sent_at) OVER (ORDER BY sent_at) AS previous_sent_at
-    FROM user_meme_reaction
-    WHERE user_id = :user_id AND sent_at >= :day_start
-      AND coalesce(recommended_by, '') NOT LIKE 'broadcast%'
-      AND coalesce(recommended_by, '')
-          NOT IN ('share_link', 'last', 'uploaded_meme', 'friend_challenge')
-), activity AS (
-    SELECT count(*) AS sent, max(sent_at) AS last_sent,
-           count(*) FILTER (WHERE recommended_by = :recommended_by) AS hits,
-           count(*) FILTER (WHERE sent_at - previous_sent_at > interval '30 minutes') AS gaps
-    FROM sends
-)
-SELECT ea.variant
-FROM experiment_assignment ea JOIN "user" u ON u.id = ea.user_id CROSS JOIN activity a
+SESSION_OPPORTUNITY_SQL = """
+SELECT ea.variant,
+       coalesce((
+           SELECT jsonb_agg(jsonb_build_object(
+               'id', s.meme_id, 'sent_at', extract(epoch FROM s.sent_at),
+               'recommended_by', s.recommended_by) ORDER BY s.sent_at DESC)
+           FROM (
+               SELECT meme_id, sent_at, recommended_by FROM user_meme_reaction
+               WHERE user_id = :user_id
+                 AND sent_at >= CAST(:as_of AS timestamp) - interval '3 hours'
+                 AND sent_at <= CAST(:as_of AS timestamp)
+                 AND coalesce(recommended_by, '') NOT LIKE 'broadcast%'
+                 AND coalesce(recommended_by, '') NOT LIKE 'friend_challenge%'
+                 AND coalesce(recommended_by, '') NOT IN
+                     ('share_link', 'last', 'uploaded_meme', 'low_sent_pool')
+               ORDER BY sent_at DESC LIMIT 6
+           ) s
+       ), '[]'::jsonb) AS recent_sends,
+       coalesce((
+           SELECT jsonb_agg(jsonb_build_object(
+               'id', h.meme_id, 'sent_at', extract(epoch FROM h.sent_at)))
+           FROM (
+               SELECT meme_id, sent_at FROM user_meme_reaction
+               WHERE user_id = :user_id
+                 AND sent_at > CAST(:as_of AS timestamp) - interval '24 hours'
+                 AND sent_at <= CAST(:as_of AS timestamp)
+                 AND recommended_by = ANY(CAST(:hit_recommenders AS text[]))
+               ORDER BY sent_at DESC LIMIT 3
+           ) h
+       ), '[]'::jsonb) AS recent_hits
+FROM experiment_assignment ea JOIN "user" u ON u.id = ea.user_id
 WHERE ea.user_id = :user_id AND ea.experiment_id = :experiment_id
   AND u.type = 'user' AND u.blocked_bot_at IS NULL
-  AND CAST(ea.assignment_metadata->>'experiment_start_at' AS timestamptz) <= NOW()
-  AND CAST(ea.assignment_metadata->>'exposure_end_at' AS timestamptz) > NOW()
-  AND a.sent < 5 AND a.hits = 0 AND a.gaps = 0
-  AND (a.last_sent IS NULL
-       OR a.last_sent >= (NOW() AT TIME ZONE 'UTC') - interval '30 minutes')
+  AND CAST(ea.assignment_metadata->>'experiment_start_at' AS timestamptz)
+      <= CAST(:as_of AS timestamp) AT TIME ZONE 'UTC'
+  AND CAST(ea.assignment_metadata->>'exposure_end_at' AS timestamptz)
+      > CAST(:as_of AS timestamp) AT TIME ZONE 'UTC'
 """
+
+
+def _session_reservation_cutoff(recent_sends: list[dict], now: float) -> float | None:
+    """Find the first-five window from six sends, independent of calendar dates.
+
+    An attempt may precede the first persisted delivery. Including the preceding
+    30 minutes keeps its reservation valid after that delivery creates a session.
+    Five connected sends span at most 2.5 hours including the gap to now, so the
+    query's three-hour bound cannot hide an ineligible sixth-slot request.
+    """
+    previous = now
+    session = []
+    for row in recent_sends:
+        sent_at = float(row["sent_at"])
+        if previous - sent_at > SESSION_GAP_SECONDS:
+            break
+        session.append(row)
+        previous = sent_at
+    if len(session) >= 5 or any(row["recommended_by"] in HIT_RECOMMENDERS for row in session):
+        return None
+    return previous - SESSION_GAP_SECONDS
+
+
+RESERVE_SESSION_HIT_LUA = """
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local session_cutoff = tonumber(ARGV[3])
+local quota = tonumber(ARGV[4])
+local candidate = ARGV[5]
+local deliveries = cjson.decode(ARGV[6])
+redis.call('ZREMRANGEBYSCORE', key, '-inf', now - window)
+for _, delivery in ipairs(deliveries) do
+    local member = tostring(delivery.id)
+    local timestamp = tonumber(delivery.sent_at)
+    local reserved_at = redis.call('ZSCORE', key, member)
+    -- The same meme's reservation and delivery consume one quota unit.
+    if not reserved_at or timestamp > tonumber(reserved_at) then
+        redis.call('ZADD', key, timestamp, member)
+    end
+end
+redis.call('EXPIRE', key, window + 3600)
+if redis.call('ZCOUNT', key, session_cutoff, '+inf') > 0
+    or redis.call('ZCARD', key) >= quota
+    or redis.call('ZSCORE', key, candidate) then
+    return 0
+end
+redis.call('ZADD', key, now, candidate)
+redis.call('EXPIRE', key, window + 3600)
+return 1
+"""
+
+
+def _attempts_key(user_id: int) -> str:
+    return f"channel_hits:v2:attempts:{user_id}"
 
 
 async def maybe_get_channel_hit(
@@ -251,30 +323,52 @@ async def maybe_get_channel_hit(
     if not settings.CHANNEL_HITS_ENABLED:
         return None
     try:
-        now = datetime.now(timezone.utc)
-        key = f"channel_hits:v1:day:{now.date()}:{user_id}"
-        reserved, cohort = await redis.redis_client.mget([key, COHORT_KEY])
-        if reserved or not cohort or user_id not in json.loads(cohort):
+        cohort = await redis.redis_client.get(COHORT_KEY)
+        if not cohort or user_id not in json.loads(cohort):
             return None
+        now = datetime.now(timezone.utc)
         row = await fetch_one(
-            text(DAILY_OPPORTUNITY_SQL),
+            text(SESSION_OPPORTUNITY_SQL),
             {
                 "user_id": user_id,
-                "day_start": now.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None),
-                "recommended_by": RECOMMENDED_BY,
+                "as_of": now.replace(tzinfo=None),
+                "hit_recommenders": list(HIT_RECOMMENDERS),
                 "experiment_id": EXPERIMENT_ID,
             },
         )
         if not row or row["variant"] != "treatment":
             return None
-        candidates = await eligible_channel_hits(user_id, exclude_meme_ids=exclude_meme_ids)
+        cutoff = _session_reservation_cutoff(row["recent_sends"], now.timestamp())
+        if cutoff is None or len(row["recent_hits"]) >= ROLLING_QUOTA:
+            return None
+        attempts = await redis.redis_client.zrangebyscore(
+            _attempts_key(user_id),
+            f"({now.timestamp() - ROLLING_WINDOW_SECONDS}",
+            "+inf",
+            withscores=True,
+        )
+        if len(attempts) >= ROLLING_QUOTA or any(timestamp >= cutoff for _, timestamp in attempts):
+            return None
+        # An uncertain old attempt must not pin the next visit to the same meme.
+        excluded = list(set(exclude_meme_ids or []) | {int(member) for member, _ in attempts})
+        candidates = await eligible_channel_hits(user_id, exclude_meme_ids=excluded)
         if not candidates:
             return None
-        ttl = 86400 - (now.hour * 3600 + now.minute * 60 + now.second)
-        if not await redis.redis_client.set(key, "reserved", nx=True, ex=ttl):
+        selected = MemeData(**candidates[0])
+        if not await redis.redis_client.eval(
+            RESERVE_SESSION_HIT_LUA,
+            1,
+            _attempts_key(user_id),
+            now.timestamp(),
+            ROLLING_WINDOW_SECONDS,
+            cutoff,
+            ROLLING_QUOTA,
+            str(selected.id),
+            json.dumps(row["recent_hits"]),
+        ):
             return None
         # Reserve before Telegram; an ambiguous network result must not cause retries.
-        return MemeData(**candidates[0])
+        return selected
     except Exception:
         logger.warning("Channel-hit slot unavailable; using regular feed", exc_info=True)
         return None

--- a/src/tgbot/senders/next_message.py
+++ b/src/tgbot/senders/next_message.py
@@ -6,9 +6,10 @@ from telegram.error import BadRequest, Forbidden, NetworkError, TimedOut
 
 from src.recommendations import meme_queue
 from src.recommendations.channel_hits import (
-    RECOMMENDED_BY as CHANNEL_HIT_RECOMMENDED_BY,
+    HIT_RECOMMENDERS,
+    channel_hit_is_sendable,
+    maybe_get_channel_hit,
 )
-from src.recommendations.channel_hits import channel_hit_is_sendable, maybe_get_channel_hit
 from src.recommendations.service import (
     create_user_meme_reaction,
     user_meme_reaction_exists,
@@ -103,7 +104,7 @@ async def next_message(
         )
         meme.caption = prepared.caption
 
-        if meme.recommended_by == CHANNEL_HIT_RECOMMENDED_BY and not await channel_hit_is_sendable(
+        if meme.recommended_by in HIT_RECOMMENDERS and not await channel_hit_is_sendable(
             user_id, meme.id
         ):
             # A membership event or moderation change may arrive during preparation.

--- a/tests/recommendations/test_channel_hits.py
+++ b/tests/recommendations/test_channel_hits.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
@@ -69,7 +70,7 @@ async def channel_data(monkeypatch):
         await create_user(conn, USER)
         await create_user_language(conn, USER)
         await create_meme_source(conn, SOURCE)
-        for mid in range(MEME, MEME + 8):
+        for mid in range(MEME, MEME + 40):
             await create_meme(conn, mid, SOURCE, status="published", telegram_file_id=str(mid))
         await conn.execute(
             text("""
@@ -107,16 +108,18 @@ async def channel_data(monkeypatch):
         json.dumps([{"id": MEME, "percentile": 0.99, "posted_at": _now().isoformat()}]),
     )
     await redis.redis_client.set(hits.COHORT_KEY, json.dumps([USER]))
-    day_key = f"channel_hits:v1:day:{_now().date()}:{USER}"
-    await redis.redis_client.delete(day_key)
+    attempts_key = hits._attempts_key(USER)
+    await redis.redis_client.delete(attempts_key)
     yield
-    await redis.redis_client.delete(hits.POOL_KEY, hits.COHORT_KEY, day_key)
+    await redis.redis_client.delete(hits.POOL_KEY, hits.COHORT_KEY, attempts_key)
     async with engine.connect() as conn:
         await cleanup_test_data(conn)
 
 
 @pytest.mark.asyncio
-async def test_confirmed_nonmember_gets_only_one_daily_hit_without_touching_queue(channel_data):
+async def test_confirmed_nonmember_gets_only_one_session_attempt_without_touching_queue(
+    channel_data,
+):
     first = await hits.maybe_get_channel_hit(USER)
     assert first.id == MEME and first.recommended_by == hits.RECOMMENDED_BY
     assert await hits.maybe_get_channel_hit(USER) is None
@@ -249,8 +252,8 @@ async def test_membership_change_after_selection_cancels_delivery(channel_data):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("guard", ["control", "expired", "five_sent", "later_session", "sent_hit"])
-async def test_assignment_and_daily_session_guards(channel_data, guard):
+@pytest.mark.parametrize("guard", ["control", "expired", "five_sent", "sent_hit", "legacy_hit"])
+async def test_assignment_and_session_guards(channel_data, guard):
     async with engine.begin() as conn:
         if guard == "control":
             await conn.execute(
@@ -268,10 +271,7 @@ async def test_assignment_and_daily_session_guards(channel_data, guard):
             )
         else:
             count = 5 if guard == "five_sent" else 1
-            sent_at = _now() - timedelta(minutes=35 if guard == "later_session" else 0)
-            # Ensure the historical session remains in this UTC day in boundary runs.
-            if sent_at.date() != _now().date():
-                pytest.skip("First 35 minutes of UTC day have no previous session today")
+            sent_at = _now() - timedelta(seconds=1)
             for offset in range(count):
                 await conn.execute(
                     text("""
@@ -282,7 +282,10 @@ async def test_assignment_and_daily_session_guards(channel_data, guard):
                         "user_id": USER,
                         "meme_id": MEME + 1 + offset,
                         "sent_at": sent_at,
-                        "recommended_by": hits.RECOMMENDED_BY if guard == "sent_hit" else "test",
+                        "recommended_by": {
+                            "sent_hit": hits.RECOMMENDED_BY,
+                            "legacy_hit": "channel_hit_v1",
+                        }.get(guard, "test"),
                     },
                 )
     assert await hits.maybe_get_channel_hit(USER) is None
@@ -304,3 +307,219 @@ async def test_explicit_published_share_resolves_alias_without_subscription_gate
     async with engine.begin() as conn:
         await conn.execute(text("UPDATE meme SET status='rejected' WHERE id=:id"), {"id": MEME})
     assert await get_shareable_meme_by_id(MEME + 1) is None
+
+
+async def _record_sends(rows):
+    async with engine.begin() as conn:
+        for offset, sent_at, label in rows:
+            await conn.execute(
+                text("""
+                    INSERT INTO user_meme_reaction(user_id,meme_id,sent_at,recommended_by)
+                    VALUES (:user_id,:meme_id,:sent_at,:recommended_by)
+                """),
+                {
+                    "user_id": USER,
+                    "meme_id": MEME + offset,
+                    "sent_at": sent_at,
+                    "recommended_by": label,
+                },
+            )
+
+
+def _freeze_now(monkeypatch, moment):
+    class FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            aware = moment.replace(tzinfo=timezone.utc)
+            return aware.astimezone(tz) if tz else moment
+
+    monkeypatch.setattr(hits, "datetime", FrozenDatetime)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("current_sends", [0, 4, 5])
+async def test_return_visit_gets_first_five_window(channel_data, monkeypatch, current_sends):
+    now = _now()
+    _freeze_now(monkeypatch, now)
+    # The first visit already exhausted its window, with no reactions required.
+    rows = [(i + 1, now - timedelta(hours=2, minutes=i), "test") for i in range(6)]
+    rows += [(i + 10, now - timedelta(minutes=i + 1), "test") for i in range(current_sends)]
+    await _record_sends(rows)
+    assert (await hits.maybe_get_channel_hit(USER) is not None) == (current_sends < 5)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("gap_seconds", [1800, 1801])
+async def test_session_gap_is_strictly_over_thirty_minutes(channel_data, monkeypatch, gap_seconds):
+    now = _now()
+    _freeze_now(monkeypatch, now)
+    await _record_sends(
+        [(i + 1, now - timedelta(seconds=gap_seconds + i), "test") for i in range(5)]
+    )
+    assert (await hits.maybe_get_channel_hit(USER) is not None) == (gap_seconds > 1800)
+
+
+@pytest.mark.asyncio
+async def test_midnight_does_not_reset_continuous_session(channel_data, monkeypatch):
+    now = (_now() + timedelta(days=1)).replace(hour=0, minute=2, second=0, microsecond=0)
+    _freeze_now(monkeypatch, now)
+    await _record_sends([(i + 1, now - timedelta(minutes=i + 1), "test") for i in range(6)])
+    assert await hits.maybe_get_channel_hit(USER) is None
+
+
+@pytest.mark.asyncio
+async def test_passive_and_explicit_content_does_not_create_or_extend_session(channel_data):
+    labels = [
+        "broadcast",
+        "broadcast_reengagement",
+        "uploaded_meme",
+        "low_sent_pool",
+        "friend_challenge",
+        "friend_challenge_reveal",
+        "share_link",
+        "last",
+    ]
+    now = _now()
+    await _record_sends(
+        [(i + 1, now - timedelta(seconds=1), label) for i, label in enumerate(labels)]
+    )
+    assert await hits.maybe_get_channel_hit(USER) is not None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_reserve_one_attempt(channel_data):
+    attempts = await asyncio.gather(*(hits.maybe_get_channel_hit(USER) for _ in range(12)))
+    assert sum(result is not None for result in attempts) == 1
+    assert await redis.redis_client.zcard(hits._attempts_key(USER)) == 1
+
+
+@pytest.mark.asyncio
+async def test_reservation_survives_first_durable_send_without_duplicate_attempt(channel_data):
+    assert await hits.maybe_get_channel_hit(USER) is not None
+    # Simulate a failed/ambiguous hit followed by an ordinary durable delivery.
+    await _record_sends([(1, _now(), "test")])
+    assert await hits.maybe_get_channel_hit(USER) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "oldest_age", [timedelta(hours=23, minutes=59), timedelta(hours=24, seconds=1)]
+)
+async def test_rolling_quota_restores_from_durable_hits_after_redis_loss(
+    channel_data, monkeypatch, oldest_age
+):
+    now = _now()
+    _freeze_now(monkeypatch, now)
+    await _record_sends(
+        [
+            (1, now - oldest_age, "channel_hit_v1"),
+            (2, now - timedelta(hours=4), hits.RECOMMENDED_BY),
+            (3, now - timedelta(hours=2), hits.RECOMMENDED_BY),
+        ]
+    )
+    await redis.redis_client.delete(hits._attempts_key(USER))
+    selected = await hits.maybe_get_channel_hit(USER)
+    assert (selected is not None) == (oldest_age > timedelta(hours=24))
+    if selected:
+        assert await redis.redis_client.zcard(hits._attempts_key(USER)) == 3
+
+
+@pytest.mark.asyncio
+async def test_attempt_and_its_delivery_count_once_in_rolling_quota(channel_data, monkeypatch):
+    now = _now()
+    for offset in range(4):
+        moment = now + timedelta(hours=offset)
+        _freeze_now(monkeypatch, moment)
+        async with engine.begin() as conn:
+            if offset:
+                await conn.execute(
+                    text("INSERT INTO crossposting(channel,meme_id) VALUES ('tgchannelru',:id)"),
+                    {"id": MEME + offset},
+                )
+        await redis.redis_client.set(
+            hits.POOL_KEY,
+            json.dumps(
+                [{"id": MEME + offset, "percentile": 0.99, "posted_at": moment.isoformat()}]
+            ),
+        )
+        selected = await hits.maybe_get_channel_hit(USER)
+        if offset == 3:
+            assert selected is None
+        else:
+            assert selected is not None
+            await _record_sends([(offset, moment, hits.RECOMMENDED_BY)])
+            assert await redis.redis_client.zcard(hits._attempts_key(USER)) == offset + 1
+
+
+@pytest.mark.asyncio
+async def test_no_candidate_does_not_consume_attempt(channel_data):
+    assert await hits.maybe_get_channel_hit(USER, exclude_meme_ids=[MEME]) is None
+    assert not await redis.redis_client.exists(hits._attempts_key(USER))
+    assert await hits.maybe_get_channel_hit(USER) is not None
+
+
+@pytest.mark.asyncio
+async def test_reservation_failure_falls_back_closed(channel_data, monkeypatch):
+    monkeypatch.setattr(redis.redis_client, "eval", AsyncMock(side_effect=ConnectionError()))
+    assert await hits.maybe_get_channel_hit(USER) is None
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_attempts_allow_fresh_meme_next_visit_and_stop_at_three(
+    channel_data, monkeypatch
+):
+    now = _now()
+    async with engine.begin() as conn:
+        for offset in range(1, 4):
+            await conn.execute(
+                text("INSERT INTO crossposting(channel,meme_id) VALUES ('tgchannelru',:id)"),
+                {"id": MEME + offset},
+            )
+    await redis.redis_client.set(
+        hits.POOL_KEY,
+        json.dumps(
+            [
+                {"id": MEME + offset, "percentile": 1 - offset / 10, "posted_at": now.isoformat()}
+                for offset in range(4)
+            ]
+        ),
+    )
+    for offset in range(4):
+        _freeze_now(monkeypatch, now + timedelta(minutes=31 * offset))
+        selected = await hits.maybe_get_channel_hit(USER)
+        if offset < 3:
+            assert selected is not None and selected.id == MEME + offset
+        else:
+            assert selected is None
+    # The quota expires relative to actual attempts, not at midnight.
+    _freeze_now(monkeypatch, now + timedelta(hours=24, seconds=1))
+    assert await hits.maybe_get_channel_hit(USER) is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("label", hits.HIT_RECOMMENDERS)
+async def test_sender_rechecks_membership_for_both_hit_versions(channel_data, monkeypatch, label):
+    from importlib import import_module
+    from types import SimpleNamespace
+
+    sender = import_module("src.tgbot.senders.next_message")
+    selected = (await hits.eligible_channel_hits(USER))[0]
+    selected["recommended_by"] = label
+    selected = hits.MemeData(**selected)
+    monkeypatch.setattr(sender, "get_user_info", AsyncMock(return_value={"nmemes_sent": 10}))
+    monkeypatch.setattr(sender, "get_popup_to_send", AsyncMock(return_value=None))
+    monkeypatch.setattr(sender, "maybe_get_channel_hit", AsyncMock(return_value=selected))
+    monkeypatch.setattr(
+        sender,
+        "prepare_meme_delivery",
+        AsyncMock(return_value=SimpleNamespace(caption="", reply_markup=None)),
+    )
+    recheck = AsyncMock(return_value=False)
+    send = AsyncMock()
+    monkeypatch.setattr(sender, "channel_hit_is_sendable", recheck)
+    monkeypatch.setattr(sender, "send_new_message_with_meme", send)
+    monkeypatch.setattr(sender, "send_queue_preparing_alert", AsyncMock())
+    monkeypatch.setattr(sender.meme_queue, "check_queue", AsyncMock())
+    await sender.next_message(object(), USER, SimpleNamespace(callback_query=None))
+    assert recheck.await_count == 5
+    send.assert_not_awaited()

--- a/tests/scripts/test_channel_hit_readout.py
+++ b/tests/scripts/test_channel_hit_readout.py
@@ -131,6 +131,25 @@ async def test_guest_window_is_complete_before_retention_and_acquisition_end_exc
     assert (await outcome(conn))["treatment"]["retained_invitees"] == 1
 
 
+async def test_cadence_versions_share_cohort_outcomes_but_keep_separate_delivery_counts(conn):
+    await react(conn, HOST_T, 990101, day=1, origin="channel_hit_v1")
+    await react(conn, HOST_T, 990102, day=1, origin="channel_hit_session_v2")
+    await react(conn, HOST_T, 990103, day=2, origin="channel_hit_session_v2")
+    await react(conn, HOST_C, 990101, day=1)
+    result = await outcome(conn)
+    treatment = result["treatment"]
+    assert treatment["assigned_users"] == 2
+    assert treatment["exposed_users"] == 1
+    assert treatment["hit_delivery_rows"] == 3
+    assert treatment["daily_hit_delivery_rows"] == 1
+    assert treatment["session_hit_delivery_rows"] == 2
+    assert treatment["hit_delivery_user_days"] == 2
+    assert treatment["normal_feed_delivery_rows"] == 3
+    assert result["control"]["hit_delivery_rows"] == 0
+    assert result["control"]["daily_hit_delivery_rows"] == 0
+    assert result["control"]["session_hit_delivery_rows"] == 0
+
+
 async def test_retention_excludes_push_game_and_synthetic_reactions(conn):
     await acquire(conn, 990010, HOST_T)
     await react(conn, 990010, 990101, day=7)


### PR DESCRIPTION
Returning users could not receive a channel hit after an earlier visit that UTC day, even when that visit produced no hit. Allow one hit within the first five ordinary sends of any session after more than 30 minutes of inactivity, with an atomic cap of three attempts per rolling 24 hours. Midnight no longer resets the slot or quota.

Keep the existing 42 treatment / 43 control assignments, baseline, exposure window, membership filters and repeat protection. New deliveries use `channel_hit_session_v2`; readout totals include both cadence versions and expose their counts separately. Known successful deliveries restore quota after Redis loss; ambiguous attempts without a persisted delivery cannot be reconstructed after total cache loss.

The supporting read-only analysis found multiple sessions on 67.4% of pilot active days. Historical replay yields 1.89 times as many potential opportunities with the new cap; this is not a measured exposure or growth lift. The bounded session query measured 1.42 ms median across the 42 treatment users.

Validation: 772 tests passed, two existing skips and eight subtests passed on Python 3.14 with disposable local PostgreSQL/Redis. Ruff and public-repo redaction audit passed. Independent review checked 100,000 generated histories against full-history session logic without discrepancies; regression tests cover later visits, midnight, concurrent requests, rolling expiry, cache recovery and both delivery labels. No new migration or paid service is required.
