### PR TITLE
feat(broadcast): channel-viral memes for pushes + dormant one-shot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,8 @@ OPENROUTER_API_KEY=
 # Enable channel-hit delivery after membership backfill and fixed-cohort enrollment.
 CHANNEL_MEMBERSHIP_SYNC_ENABLED=false
 CHANNEL_HITS_ENABLED=false
+# Retention broadcasts: last-7-day channel posts by forwards, then HQ pick.
+BROADCAST_CHANNEL_VIRAL_PICK_ENABLED=true
 
 # Telethon (for channel stats collection)
 TELEGRAM_API_ID=

--- a/docs/analyst/broadcast-reengagement.sql
+++ b/docs/analyst/broadcast-reengagement.sql
@@ -1,6 +1,7 @@
 -- Retention broadcast effectiveness readout
 --
 -- Labels (after HQ pick ship):
+--   broadcast_channel_viral    — last-7-day channel posts ranked by forwards
 --   broadcast_reengagement_hq  — affinity + proven-LR picker
 --   broadcast_reengagement     — feed-queue fallback (or pre-HQ era)
 --
@@ -49,6 +50,7 @@ ORDER BY sends DESC;
 WITH base AS (
   SELECT
     CASE
+      WHEN recommended_by = 'broadcast_channel_viral' THEN 'broadcast_channel_viral'
       WHEN recommended_by = 'broadcast_reengagement_hq' THEN 'broadcast_hq'
       WHEN recommended_by LIKE 'broadcast%' THEN 'broadcast_queue_or_legacy'
       ELSE 'feed'

--- a/docs/broadcasts.md
+++ b/docs/broadcasts.md
@@ -5,7 +5,7 @@ Guide for sending bulk messages to bot users. Written after the April 2026 wrapp
 ## Architecture
 
 - **Engine**: `src/broadcasts/service.py` — `send_broadcast()` function with Redis SET dedup
-- **Scripts**: `scripts/broadcast_wrapped.py` — example broadcast script
+- **Scripts**: `scripts/broadcast_wrapped.py` (text), `scripts/broadcast_dormant.py` (per-user meme)
 - **Bot**: uses `src/tgbot/bot.bot` (python-telegram-bot) to send messages
 - **Dedup**: Redis SET `broadcast:{id}:sent` tracks which user_ids were already sent to
 - **Rate**: configurable delay between sends (default 0.15s = ~7 msg/sec)
@@ -39,6 +39,18 @@ ssh "$PROD_SSH" "docker exec -e PYTHONPATH=/src <container> \
 ```
 
 Verify counts in dry run output. Then run without `--dry-run`.
+
+### Meme broadcast to idle users
+
+`scripts/broadcast_dormant.py` sends one meme per user (channel-viral last 7
+days, then HQ, then queue). Same Redis `broadcast_id` dedup. Default delay 0.3s.
+
+```bash
+python scripts/broadcast_dormant.py dormant-channel-viral-2026-09-07 --dry-run
+python scripts/broadcast_dormant.py dormant-channel-viral-2026-09-07 --min-days 7 --delay 0.3
+```
+
+Never reuse a `broadcast_id` for a different audience.
 
 ### 3. Monitor
 

--- a/docs/growth/HYPOTHESES.md
+++ b/docs/growth/HYPOTHESES.md
@@ -206,6 +206,39 @@ most users (fallback rate &gt;80%) or LR collapses &gt;5 pp vs fallback.
 
 ---
 
+## H3c — Channel-viral memes for retention broadcasts
+
+| Field | Value |
+|-------|--------|
+| **ID** | `broadcast_channel_viral_pick` |
+| **Status** | **shipping** |
+| **Code** | `src/recommendations/broadcast_pick.py`, kill switch `BROADCAST_CHANNEL_VIRAL_PICK_ENABLED` |
+| **Labels** | `broadcast_channel_viral` vs `broadcast_reengagement_hq` vs queue |
+| **SQL** | `docs/analyst/broadcast-reengagement.sql` |
+
+### Hypothesis
+
+A meme that the channel audience already forwarded is a better single push than
+bot-internal HQ (affinity × like rate), because forwards are a community check
+that the joke is worth sending onward.
+
+### Rules
+
+- Last 7 days of `tgchannelru` / `tgchannelen` posts, at least 24h old, ranked
+  by latest snapshot forwards. Unseen, matching language, image, `published`.
+- Skip known channel members (they already got the channel push).
+- Skip `channel_hits_v1` assignees until exposure ends (feed test stays clean).
+- Empty pool → existing HQ → queue. Never skip a user because viral is empty.
+
+**Keep ON** if `broadcast_channel_viral` react_within_1h ≥ HQ (same 14d window)
+without a like-rate drop >3 pp on reacted rows.
+
+**Disable** (`BROADCAST_CHANNEL_VIRAL_PICK_ENABLED=false`) if viral share of
+broadcasts is <10% (always empty) or 1h reactivation is worse than HQ by >5 pp
+with ≥200 viral sends.
+
+---
+
 ## H4 — Skip ≠ hate (measurement contract, not a ship)
 
 | Field | Value |

--- a/scripts/broadcast_dormant.py
+++ b/scripts/broadcast_dormant.py
@@ -1,0 +1,46 @@
+"""One-shot meme broadcast to users idle for at least N days.
+
+Picks a per-user meme (channel-viral last 7 days, then HQ, then queue).
+Redis dedup via broadcast_id — safe to re-run.
+
+    PYTHONPATH=/src python scripts/broadcast_dormant.py dormant-channel-viral-2026-09-07
+    PYTHONPATH=/src python scripts/broadcast_dormant.py dormant-channel-viral-2026-09-07 --dry-run
+    PYTHONPATH=/src python scripts/broadcast_dormant.py dormant-channel-viral-2026-09-07 --delay 0.3
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from src.broadcasts.service import get_users_inactive_since_days, send_meme_broadcast
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("broadcast_id", help="Unique id; reuse to resume after a crash")
+    parser.add_argument("--min-days", type=int, default=7)
+    parser.add_argument("--delay", type=float, default=0.3)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+async def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.min_days < 1:
+        print("min-days must be >= 1", file=sys.stderr)
+        return 2
+    user_ids = await get_users_inactive_since_days(args.min_days)
+    print(f"Idle >= {args.min_days}d: {len(user_ids)} users")
+    await send_meme_broadcast(
+        broadcast_id=args.broadcast_id,
+        user_ids=user_ids,
+        delay=args.delay,
+        dry_run=args.dry_run,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/broadcasts/service.py
+++ b/src/broadcasts/service.py
@@ -115,6 +115,31 @@ async def get_users_active_more_than_days_ago(
     return await fetch_all(text(select_query))
 
 
+async def get_users_inactive_since_days(days: int) -> list[int]:
+    """Users who have not been active for at least ``days`` days.
+
+    Excludes waitlist and anyone already marked blocked. Bound ``days`` so the
+    interval cannot come from a string-concatenated query.
+    """
+    if days < 1:
+        raise ValueError("days must be >= 1")
+    rows = await fetch_all(
+        text(
+            """
+            SELECT id AS user_id
+            FROM "user"
+            WHERE blocked_bot_at IS NULL
+              AND type NOT IN ('waitlist', 'blocked_bot')
+              AND last_active_at IS NOT NULL
+              AND last_active_at < NOW() - (:days * INTERVAL '1 day')
+            ORDER BY last_active_at DESC
+            """
+        ),
+        {"days": days},
+    )
+    return [row["user_id"] for row in rows]
+
+
 async def get_all_non_blocked_users() -> list[dict]:
     """Get all users with their bot content language (from user_language table).
 
@@ -244,5 +269,95 @@ async def send_broadcast(
         await asyncio.sleep(delay)
 
     result = {"sent": sent, "blocked": blocked, "failed": failed, "skipped": skipped}
+    print(f"\nDone! {result}")
+    return result
+
+
+async def send_meme_broadcast(
+    broadcast_id: str,
+    user_ids: list[int],
+    delay: float = 0.3,
+    dry_run: bool = False,
+) -> dict:
+    """Send one per-user picked meme with Redis dedup. Safe to re-run."""
+    from src.recommendations.broadcast_pick import pick_reengagement_meme
+    from src.tgbot.senders.meme import send_meme_to_user
+
+    redis_key = _broadcast_redis_key(broadcast_id)
+    already_sent = await redis_client.scard(redis_key)
+    print(f"Meme broadcast '{broadcast_id}': {len(user_ids)} users, {already_sent} already sent")
+
+    if dry_run:
+        print("--- DRY RUN ---")
+        return {
+            "sent": 0,
+            "blocked": 0,
+            "failed": 0,
+            "skipped": int(already_sent),
+            "no_meme": 0,
+            "audience": len(user_ids),
+        }
+
+    sent = 0
+    blocked = 0
+    failed = 0
+    skipped = 0
+    no_meme = 0
+
+    for user_id in user_ids:
+        if await redis_client.sismember(redis_key, str(user_id)):
+            skipped += 1
+            continue
+
+        try:
+            meme, label = await pick_reengagement_meme(user_id)
+            if meme is None:
+                no_meme += 1
+                continue
+            await send_meme_to_user(bot, user_id, meme, recommended_by=label)
+            sent += 1
+            await redis_client.sadd(redis_key, str(user_id))
+            if sent % 100 == 0:
+                print(
+                    f"  sent:{sent} blocked:{blocked} failed:{failed} "
+                    f"skipped:{skipped} no_meme:{no_meme}"
+                )
+        except (Forbidden, BadRequest) as e:
+            err_msg = str(e).lower()
+            if isinstance(e, Forbidden) or "not found" in err_msg:
+                blocked += 1
+                await redis_client.sadd(redis_key, str(user_id))
+                try:
+                    await mark_user_blocked(user_id, source="forbidden_broadcast")
+                except Exception as mark_exc:  # noqa: BLE001
+                    logger.warning(
+                        "mark_user_blocked failed for %d in broadcast %s: %s",
+                        user_id,
+                        broadcast_id,
+                        mark_exc,
+                    )
+            else:
+                failed += 1
+                if failed <= 10:
+                    logger.warning("Broadcast %s error for %d: %s", broadcast_id, user_id, e)
+        except RetryAfter as e:
+            sleep_for = e.retry_after + 1
+            print(f"  rate limited, sleeping {sleep_for}s...")
+            await asyncio.sleep(sleep_for)
+            failed += 1
+        except Exception as e:
+            failed += 1
+            if failed <= 10:
+                logger.warning("Broadcast %s error for %d: %s", broadcast_id, user_id, e)
+
+        await asyncio.sleep(delay)
+
+    result = {
+        "sent": sent,
+        "blocked": blocked,
+        "failed": failed,
+        "skipped": skipped,
+        "no_meme": no_meme,
+    }
     print(f"\nDone! {result}")
     return result

--- a/src/config.py
+++ b/src/config.py
@@ -83,6 +83,9 @@ class Config(BaseSettings):
     # Retention broadcasts: pick high-confidence meme (affinity + LR) instead of
     # blind Redis queue pop. Kill switch rolls back to queue path.
     BROADCAST_HIGH_QUALITY_PICK_ENABLED: bool = True
+    # Prefer last-7-day channel posts ranked by forwards (community-verified).
+    # Falls back to HQ/queue. Skips channel-hit experiment users and members.
+    BROADCAST_CHANNEL_VIRAL_PICK_ENABLED: bool = True
     # RU crosspost ranker: multiply score by ln(nlikes+1) (meme volume, not LR).
     # Offline 2026-08-09: src×log1p(likes) top-20% lift ~1.14 on time-split.
     # Kill switch reverts @fastfoodmemes to score_version=2 behavior.

--- a/src/recommendations/broadcast_pick.py
+++ b/src/recommendations/broadcast_pick.py
@@ -1,8 +1,9 @@
 """High-confidence meme selection for retention broadcasts.
 
 Feed queue pop is optimized for continuous scrolling. Reengagement pushes need
-a single strong meme that earns a *fast* reaction when the user returns —
-prefer liked sources + proven like rate, never majority-dislike sources.
+a single strong meme that earns a *fast* reaction when the user returns.
+Prefer last-week channel-viral posts (community-verified forwards), then liked
+sources + proven like rate. Never majority-dislike sources.
 """
 
 from __future__ import annotations
@@ -19,12 +20,15 @@ from src.recommendations.utils import (
     disliked_source_demote_sql,
 )
 from src.storage.schemas import MemeData
+from src.tgbot.constants import TELEGRAM_CHANNEL_EN_CHAT_ID, TELEGRAM_CHANNEL_RU_CHAT_ID
 
 logger = logging.getLogger(__name__)
 
 # Delivery-path labels for analytics (dwell / reactivation).
 BROADCAST_RECOMMENDED_BY = "broadcast_reengagement"
 BROADCAST_HQ_RECOMMENDED_BY = "broadcast_reengagement_hq"
+BROADCAST_CHANNEL_VIRAL_RECOMMENDED_BY = "broadcast_channel_viral"
+_CHANNEL_HITS_EXPERIMENT_ID = "channel_hits_v1"
 
 # Quality floors for the HQ pick (explicit reactions, not lr_smoothed alone).
 _HQ_MIN_EXPLICIT_REACTIONS = 15
@@ -34,11 +38,16 @@ _HQ_MIN_RAW_LIKE_RATE = 0.45
 async def pick_reengagement_meme(user_id: int) -> tuple[MemeData | None, str]:
     """Return (meme, recommended_by_label) for a retention push.
 
-    When ``BROADCAST_HIGH_QUALITY_PICK_ENABLED`` is on, tries an affinity-aware
-    SQL pick first (label ``broadcast_reengagement_hq``). Falls back to the
-    normal feed queue (label ``broadcast_reengagement``) so we never skip a user
-    solely because the HQ pool is empty.
+    Tries last-7-day channel-viral posts first (label ``broadcast_channel_viral``),
+    then the affinity HQ pick (``broadcast_reengagement_hq``), then the feed
+    queue (``broadcast_reengagement``). Channel-hit experiment users skip the
+    viral path so the feed test stays the only channel-viral treatment.
     """
+    if settings.BROADCAST_CHANNEL_VIRAL_PICK_ENABLED:
+        meme = await _fetch_channel_viral_reengagement_meme(user_id)
+        if meme is not None:
+            return meme, BROADCAST_CHANNEL_VIRAL_RECOMMENDED_BY
+
     if settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED:
         meme = await _fetch_high_quality_reengagement_meme(user_id)
         if meme is not None:
@@ -103,6 +112,89 @@ async def _fetch_high_quality_reengagement_meme(user_id: int) -> MemeData | None
             "min_raw_like_rate": _HQ_MIN_RAW_LIKE_RATE,
         },
     )
+    return _meme_from_row(row, BROADCAST_HQ_RECOMMENDED_BY)
+
+
+async def _fetch_channel_viral_reengagement_meme(user_id: int) -> MemeData | None:
+    """Unseen image from our channels in the last 7 days, ranked by forwards.
+
+    Skips known subscribers (they already got the channel push) and anyone in
+    the live channel-hits cohort. Empty pool is normal — HQ/queue still fire.
+    """
+    query = """
+        SELECT
+            M.id
+            , M.type
+            , M.telegram_file_id
+            , M.caption
+            , COALESCE(MS.nlikes, 0) AS nlikes
+        FROM crossposting CP
+        INNER JOIN meme M
+            ON M.id = CP.meme_id
+        LEFT JOIN meme_stats MS
+            ON MS.meme_id = M.id
+        INNER JOIN user_language L
+            ON L.language_code = M.language_code
+            AND L.user_id = :user_id
+        INNER JOIN LATERAL (
+            SELECT S.views, S.forwards
+            FROM crossposting_snapshots S
+            WHERE S.channel = CP.channel
+              AND S.meme_id = CP.meme_id
+              AND S.telegram_message_id = CP.telegram_message_id
+            ORDER BY S.snapshot_at DESC
+            LIMIT 1
+        ) SNAP ON TRUE
+        LEFT JOIN user_meme_reaction R
+            ON R.meme_id = M.id
+            AND R.user_id = :user_id
+        WHERE CP.channel IN ('tgchannelru', 'tgchannelen')
+          AND CP.created_at >= (NOW() AT TIME ZONE 'UTC') - interval '7 days'
+          AND CP.created_at < (NOW() AT TIME ZONE 'UTC') - interval '24 hours'
+          AND M.status = 'published'
+          AND M.type = 'image'
+          AND M.duplicate_of IS NULL
+          AND M.telegram_file_id IS NOT NULL
+          AND R.meme_id IS NULL
+          AND SNAP.views >= 50
+          AND SNAP.forwards >= 1
+          AND NOT EXISTS (
+              SELECT 1 FROM experiment_assignment A
+              WHERE A.user_id = :user_id
+                AND A.experiment_id = :experiment_id
+                AND CAST(A.assignment_metadata->>'exposure_end_at' AS timestamptz) > NOW()
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM user_channel_membership CM
+              WHERE CM.user_id = :user_id
+                AND CM.chat_id = CASE CP.channel
+                    WHEN 'tgchannelru' THEN CAST(:ru_chat_id AS bigint)
+                    ELSE CAST(:en_chat_id AS bigint) END
+                AND (CM.status = 'member' OR CM.ever_member)
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM user_tg_chat_membership OLD
+              WHERE OLD.user_tg_id = :user_id
+                AND OLD.chat_id = CASE CP.channel
+                    WHEN 'tgchannelru' THEN CAST(:ru_chat_id AS bigint)
+                    ELSE CAST(:en_chat_id AS bigint) END
+          )
+        ORDER BY SNAP.forwards DESC, SNAP.views DESC, CP.created_at DESC
+        LIMIT 1
+    """
+    row = await fetch_one(
+        text(query),
+        {
+            "user_id": user_id,
+            "experiment_id": _CHANNEL_HITS_EXPERIMENT_ID,
+            "ru_chat_id": TELEGRAM_CHANNEL_RU_CHAT_ID,
+            "en_chat_id": TELEGRAM_CHANNEL_EN_CHAT_ID,
+        },
+    )
+    return _meme_from_row(row, BROADCAST_CHANNEL_VIRAL_RECOMMENDED_BY)
+
+
+def _meme_from_row(row: dict | None, recommended_by: str) -> MemeData | None:
     if not row:
         return None
     return MemeData(
@@ -110,6 +202,6 @@ async def _fetch_high_quality_reengagement_meme(user_id: int) -> MemeData | None
         type=row["type"],
         telegram_file_id=row["telegram_file_id"],
         caption=row.get("caption"),
-        recommended_by=BROADCAST_HQ_RECOMMENDED_BY,
+        recommended_by=recommended_by,
         nlikes=int(row.get("nlikes") or 0),
     )

--- a/tests/broadcasts/test_service.py
+++ b/tests/broadcasts/test_service.py
@@ -1,12 +1,20 @@
-from datetime import datetime
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
 from sqlalchemy import delete
 from tests.factories import create_user, create_user_language
 
-from src.broadcasts.service import get_all_non_blocked_users, get_users_with_language
+from src.broadcasts.service import (
+    get_all_non_blocked_users,
+    get_users_inactive_since_days,
+    get_users_with_language,
+    send_meme_broadcast,
+)
 from src.database import engine, user, user_language, user_tg
+from src.storage.constants import MemeType
+from src.storage.schemas import MemeData
 
 ACTIVE_USER_ID = 311001
 BLOCKED_ADMIN_ID = 311002
@@ -93,3 +101,96 @@ async def test_get_all_non_blocked_users_skips_blocked_transport_state(
         ACTIVE_USER_ID,
         ACTIVE_ADMIN_ID,
     }
+
+
+@pytest.mark.asyncio
+async def test_get_users_inactive_since_days_skips_recent_and_blocked(
+    cleanup_broadcast_users,
+) -> None:
+    now = datetime.utcnow()
+    idle_id = ACTIVE_USER_ID
+    recent_id = ACTIVE_ADMIN_ID
+    async with engine.connect() as conn:
+        await create_user(conn, id=idle_id)
+        await create_user(conn, id=recent_id)
+        await create_user(conn, id=WAITLIST_USER_ID, type="waitlist")
+        await create_user(conn, id=LEGACY_BLOCKED_USER_ID, type="blocked_bot")
+        await conn.execute(
+            user.update()
+            .where(user.c.id == idle_id)
+            .values(last_active_at=now - timedelta(days=10))
+        )
+        await conn.execute(
+            user.update()
+            .where(user.c.id == recent_id)
+            .values(last_active_at=now - timedelta(days=2))
+        )
+        await conn.execute(
+            user.update()
+            .where(user.c.id == WAITLIST_USER_ID)
+            .values(last_active_at=now - timedelta(days=20))
+        )
+        await conn.commit()
+
+    rows = await get_users_inactive_since_days(7)
+    ids = {user_id for user_id in rows if user_id in TEST_USER_IDS}
+    assert idle_id in ids
+    assert recent_id not in ids
+    assert WAITLIST_USER_ID not in ids
+    assert LEGACY_BLOCKED_USER_ID not in ids
+
+
+@pytest.mark.asyncio
+async def test_send_meme_broadcast_dry_run_does_not_send() -> None:
+    pick = AsyncMock()
+    send = AsyncMock()
+    with (
+        patch("src.broadcasts.service.redis_client.scard", AsyncMock(return_value=0)),
+        patch("src.recommendations.broadcast_pick.pick_reengagement_meme", pick),
+        patch("src.tgbot.senders.meme.send_meme_to_user", send),
+    ):
+        result = await send_meme_broadcast("test-dry", [1, 2], dry_run=True)
+
+    pick.assert_not_called()
+    send.assert_not_called()
+    assert result["audience"] == 2
+    assert result["sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_send_meme_broadcast_picks_per_user_and_dedups() -> None:
+    meme = MemeData(
+        id=11,
+        type=MemeType.IMAGE,
+        telegram_file_id="f",
+        caption=None,
+        recommended_by="broadcast_channel_viral",
+    )
+    pick = AsyncMock(return_value=(meme, "broadcast_channel_viral"))
+    send = AsyncMock()
+    seen: set[str] = set()
+
+    async def sismember(_key, value):
+        return value in seen
+
+    async def sadd(_key, value):
+        seen.add(value)
+        return 1
+
+    with (
+        patch("src.broadcasts.service.redis_client.scard", AsyncMock(return_value=0)),
+        patch("src.broadcasts.service.redis_client.sismember", sismember),
+        patch("src.broadcasts.service.redis_client.sadd", sadd),
+        patch("src.broadcasts.service.bot", object()),
+        patch("src.recommendations.broadcast_pick.pick_reengagement_meme", pick),
+        patch("src.tgbot.senders.meme.send_meme_to_user", send),
+    ):
+        result = await send_meme_broadcast("test-real", [7, 8], delay=0)
+        result_again = await send_meme_broadcast("test-real", [7, 8], delay=0)
+
+    assert pick.await_count == 2
+    assert send.await_count == 2
+    assert result["sent"] == 2
+    assert send.await_args.kwargs["recommended_by"] == "broadcast_channel_viral"
+    assert result_again["skipped"] == 2
+    assert result_again["sent"] == 0

--- a/tests/recommendations/test_broadcast_pick.py
+++ b/tests/recommendations/test_broadcast_pick.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from src.recommendations.broadcast_pick import (
+    BROADCAST_CHANNEL_VIRAL_RECOMMENDED_BY,
     BROADCAST_HQ_RECOMMENDED_BY,
     BROADCAST_RECOMMENDED_BY,
     pick_reengagement_meme,
@@ -13,8 +14,16 @@ from src.storage.constants import MemeType
 from src.storage.schemas import MemeData
 
 
+def _disable_channel_viral(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "src.recommendations.broadcast_pick.settings.BROADCAST_CHANNEL_VIRAL_PICK_ENABLED",
+        False,
+    )
+
+
 @pytest.mark.asyncio
 async def test_hq_pick_uses_sql_row_and_hq_label(monkeypatch):
+    _disable_channel_viral(monkeypatch)
     monkeypatch.setattr(
         "src.recommendations.broadcast_pick.settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED",
         True,
@@ -42,6 +51,7 @@ async def test_hq_pick_uses_sql_row_and_hq_label(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_hq_empty_falls_back_to_queue(monkeypatch):
+    _disable_channel_viral(monkeypatch)
     monkeypatch.setattr(
         "src.recommendations.broadcast_pick.settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED",
         True,
@@ -79,6 +89,7 @@ async def test_hq_empty_falls_back_to_queue(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_hq_disabled_uses_queue_only(monkeypatch):
+    _disable_channel_viral(monkeypatch)
     monkeypatch.setattr(
         "src.recommendations.broadcast_pick.settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED",
         False,
@@ -110,3 +121,64 @@ async def test_hq_disabled_uses_queue_only(monkeypatch):
     fetch_one.assert_not_called()
     assert meme is queue_meme
     assert label == BROADCAST_RECOMMENDED_BY
+
+
+@pytest.mark.asyncio
+async def test_channel_viral_pick_wins_over_hq(monkeypatch):
+    monkeypatch.setattr(
+        "src.recommendations.broadcast_pick.settings.BROADCAST_CHANNEL_VIRAL_PICK_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        "src.recommendations.broadcast_pick.settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED",
+        True,
+    )
+    row = {
+        "id": 10084067,
+        "type": MemeType.IMAGE,
+        "telegram_file_id": "viral-file",
+        "caption": None,
+        "nlikes": 12,
+    }
+    with patch(
+        "src.recommendations.broadcast_pick.fetch_one",
+        new_callable=AsyncMock,
+        return_value=row,
+    ) as fetch_one:
+        meme, label = await pick_reengagement_meme(7)
+
+    fetch_one.assert_awaited_once()
+    assert label == BROADCAST_CHANNEL_VIRAL_RECOMMENDED_BY
+    assert meme is not None
+    assert meme.id == 10084067
+    assert meme.recommended_by == BROADCAST_CHANNEL_VIRAL_RECOMMENDED_BY
+
+
+@pytest.mark.asyncio
+async def test_channel_viral_empty_falls_back_to_hq(monkeypatch):
+    monkeypatch.setattr(
+        "src.recommendations.broadcast_pick.settings.BROADCAST_CHANNEL_VIRAL_PICK_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        "src.recommendations.broadcast_pick.settings.BROADCAST_HIGH_QUALITY_PICK_ENABLED",
+        True,
+    )
+    hq_row = {
+        "id": 42,
+        "type": MemeType.IMAGE,
+        "telegram_file_id": "file-42",
+        "caption": "hi",
+        "nlikes": 99,
+    }
+    with patch(
+        "src.recommendations.broadcast_pick.fetch_one",
+        new_callable=AsyncMock,
+        side_effect=[None, hq_row],
+    ) as fetch_one:
+        meme, label = await pick_reengagement_meme(7)
+
+    assert fetch_one.await_count == 2
+    assert label == BROADCAST_HQ_RECOMMENDED_BY
+    assert meme is not None
+    assert meme.id == 42

--- a/tests/tgbot/test_channel_membership.py
+++ b/tests/tgbot/test_channel_membership.py
@@ -36,6 +36,16 @@ async def membership_data():
         await conn.execute(insert(user_tg).values(id=SUBJECT, first_name="Test"))
     yield
     async with engine.begin() as conn:
+        await conn.execute(
+            delete(user_channel_membership).where(
+                user_channel_membership.c.user_id.in_([SUBJECT, ACTOR, OUTSIDER])
+            )
+        )
+        await conn.execute(
+            delete(user_tg_chat_membership).where(
+                user_tg_chat_membership.c.user_tg_id.in_([SUBJECT, ACTOR, OUTSIDER])
+            )
+        )
         await conn.execute(delete(user).where(user.c.id.in_([SUBJECT, ACTOR, OUTSIDER])))
         await conn.execute(delete(user_tg).where(user_tg.c.id == SUBJECT))
 
@@ -144,7 +154,7 @@ async def test_older_http_response_cannot_undo_newer_snapshot_in_same_second():
 
 
 async def test_unknown_api_result_is_not_nonmembership_and_keeps_history():
-    await event()
+    await event(received_at=WHEN)
     await repo.persist_snapshot(
         SUBJECT, CHANNEL, "unknown", WHEN + timedelta(days=1), error="BadRequest"
     )


### PR DESCRIPTION
## Summary

Retention pushes now try **last-7-day channel posts ranked by forwards** first (community-verified), then the existing HQ pick, then the feed queue.

- Per user: unseen, matching language, images only, `published`
- Skip known channel members (they already got the channel post)
- Skip the live `channel_hits_v1` cohort so the feed experiment stays clean
- Kill switch: `BROADCAST_CHANNEL_VIRAL_PICK_ENABLED` (default true)
- Label: `broadcast_channel_viral` vs `broadcast_reengagement_hq`

Also adds `scripts/broadcast_dormant.py` for a **one-shot** to users idle 7+ days, Redis-deduped, same per-user picker. After this lands and Coolify deploys:

```
python scripts/broadcast_dormant.py dormant-channel-viral-2026-09-07 --dry-run
python scripts/broadcast_dormant.py dormant-channel-viral-2026-09-07 --min-days 7 --delay 0.3
```

## Test plan

- [x] `tests/recommendations/test_broadcast_pick.py`
- [x] `tests/broadcasts/test_service.py`
- [ ] dry-run dormant script on prod after deploy
- [ ] compare `broadcast_channel_viral` vs HQ react-within-1h