### PR TITLE
feat(onboarding): skip countdown and A/B fresh cold-start memes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Онбординг: убран 3-2-1, первый мем сразу после welcome; шара после лайка/скипа идёт в ленту без второго welcome.
+- Холодный старт: A/B `cold_start_fresh_viral_v1` — половине новых юзеров в CS1 показываем качественные мемы младше 30 дней.
+
 ## [0.0.0.1] - 2026-07-17
 
 ### Added

--- a/docs/analyst/onboarding-funnel.sql
+++ b/docs/analyst/onboarding-funnel.sql
@@ -1,0 +1,245 @@
+-- Onboarding funnel + first-meme quality
+--
+-- Companion: docs/analyst/readouts/2026-09-07-onboarding-and-dormant-blast.md
+-- Hypotheses: docs/growth/HYPOTHESES.md H9 / H10 / H11
+--
+-- Growth bar for any onboarding change:
+--   1) less leaky: first-tap %, first-like %, reached-5
+--   2) k-factor: unique non-self share clicks / new-user invites from the cohort
+--
+-- Pitfall: user_stats.nmemes_sent stays 0 until a reaction. Count sends from
+-- user_meme_reaction, not stats.
+--
+-- Run: psql "$ANALYST_DATABASE_URL" -f docs/analyst/onboarding-funnel.sql
+-- Keep statement_timeout; 90d cohort is small.
+
+\set ON_ERROR_STOP on
+
+-- 1) 90d new-user funnel
+WITH cohort AS (
+  SELECT u.id, u.created_at, u.blocked_bot_at
+  FROM "user" u
+  WHERE u.type = 'user'
+    AND u.created_at >= now() - interval '90 days'
+),
+first_dl AS (
+  SELECT DISTINCT ON (l.user_id)
+    l.user_id,
+    l.deep_link
+  FROM user_deep_link_log l
+  JOIN cohort c ON c.id = l.user_id
+  ORDER BY l.user_id, l.created_at
+),
+agg AS (
+  SELECT
+    r.user_id,
+    COUNT(*) AS n_sends,
+    MIN(r.sent_at) AS first_sent,
+    MIN(r.reacted_at) FILTER (WHERE r.reaction_id IS NOT NULL) AS first_reacted,
+    (ARRAY_AGG(r.recommended_by ORDER BY r.sent_at))[1] AS first_engine,
+    (ARRAY_AGG(r.reaction_id ORDER BY r.reacted_at)
+      FILTER (WHERE r.reaction_id IS NOT NULL))[1] AS first_rid
+  FROM user_meme_reaction r
+  JOIN cohort c ON c.id = r.user_id
+  GROUP BY r.user_id
+),
+has_lang AS (
+  SELECT DISTINCT user_id FROM user_language
+)
+SELECT
+  COUNT(*) AS n_registered,
+  COUNT(a.first_sent) AS got_meme,
+  COUNT(a.first_reacted) AS ever_reacted,
+  COUNT(*) FILTER (
+    WHERE a.first_reacted IS NOT NULL
+      AND a.first_reacted < a.first_sent + interval '1 hour'
+  ) AS reacted_1h,
+  COUNT(*) FILTER (
+    WHERE a.first_sent IS NOT NULL AND a.first_reacted IS NULL
+  ) AS got_meme_never_reacted,
+  COUNT(*) FILTER (WHERE a.first_sent IS NULL) AS never_got_meme,
+  COUNT(*) FILTER (WHERE hl.user_id IS NULL) AS no_lang,
+  COUNT(*) FILTER (
+    WHERE hl.user_id IS NULL AND c.blocked_bot_at IS NULL
+  ) AS no_lang_alive,
+  ROUND(
+    100.0 * COUNT(a.first_reacted) / NULLIF(COUNT(a.first_sent), 0),
+    1
+  ) AS first_tap_pct_of_got_meme
+FROM cohort c
+LEFT JOIN agg a ON a.user_id = c.id
+LEFT JOIN has_lang hl ON hl.user_id = c.id;
+
+-- 2) Entry path (empty start vs share vs channel)
+WITH cohort AS (
+  SELECT u.id, u.created_at, u.blocked_bot_at
+  FROM "user" u
+  WHERE u.type = 'user'
+    AND u.created_at >= now() - interval '90 days'
+),
+first_dl AS (
+  SELECT DISTINCT ON (l.user_id)
+    l.user_id,
+    l.deep_link
+  FROM user_deep_link_log l
+  JOIN cohort c ON c.id = l.user_id
+  ORDER BY l.user_id, l.created_at
+),
+agg AS (
+  SELECT
+    r.user_id,
+    MIN(r.sent_at) AS first_sent,
+    MIN(r.reacted_at) FILTER (WHERE r.reaction_id IS NOT NULL) AS first_reacted,
+    (ARRAY_AGG(r.reaction_id ORDER BY r.reacted_at)
+      FILTER (WHERE r.reaction_id IS NOT NULL))[1] AS first_rid
+  FROM user_meme_reaction r
+  JOIN cohort c ON c.id = r.user_id
+  GROUP BY r.user_id
+)
+SELECT
+  CASE
+    WHEN d.deep_link IS NULL OR d.deep_link = '' THEN 'empty_start'
+    WHEN d.deep_link ~ '^(s|m)_' THEN 'share_meme'
+    WHEN d.deep_link LIKE 'sc_%' THEN 'channel_sc'
+    ELSE 'other'
+  END AS entry,
+  COUNT(*) AS n,
+  COUNT(a.first_sent) AS got_meme,
+  COUNT(a.first_reacted) AS ever_reacted,
+  ROUND(100.0 * COUNT(a.first_reacted) / NULLIF(COUNT(*), 0), 1)
+    AS pct_reacted_of_reg,
+  COUNT(*) FILTER (WHERE a.first_rid = 1) AS first_like,
+  COUNT(*) FILTER (WHERE a.first_rid = 2) AS first_skip,
+  ROUND(
+    PERCENTILE_CONT(0.5) WITHIN GROUP (
+      ORDER BY EXTRACT(EPOCH FROM (a.first_sent - c.created_at))
+    )::numeric,
+    1
+  ) AS p50_sec_to_first_meme
+FROM cohort c
+LEFT JOIN first_dl d ON d.user_id = c.id
+LEFT JOIN agg a ON a.user_id = c.id
+GROUP BY 1
+ORDER BY n DESC;
+
+-- 3) First-meme age (cold_start_explore only) vs first like
+WITH cohort AS (
+  SELECT u.id
+  FROM "user" u
+  WHERE u.type = 'user'
+    AND u.created_at >= now() - interval '90 days'
+),
+first_meme AS (
+  SELECT DISTINCT ON (r.user_id)
+    r.user_id,
+    r.meme_id,
+    r.sent_at,
+    r.recommended_by,
+    r.reaction_id
+  FROM user_meme_reaction r
+  JOIN cohort c ON c.id = r.user_id
+  ORDER BY r.user_id, r.sent_at
+)
+SELECT
+  CASE
+    WHEN m.created_at > fm.sent_at - interval '7 days' THEN '0-7d'
+    WHEN m.created_at > fm.sent_at - interval '30 days' THEN '7-30d'
+    WHEN m.created_at > fm.sent_at - interval '90 days' THEN '30-90d'
+    ELSE '90d+'
+  END AS meme_age,
+  COUNT(*) AS n,
+  COUNT(*) FILTER (WHERE fm.reaction_id IS NOT NULL) AS reacted,
+  COUNT(*) FILTER (WHERE fm.reaction_id = 1) AS liked,
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE fm.reaction_id = 1) / NULLIF(COUNT(*), 0),
+    1
+  ) AS first_like_pct
+FROM first_meme fm
+JOIN meme m ON m.id = fm.meme_id
+WHERE fm.recommended_by = 'cold_start_explore'
+GROUP BY 1
+ORDER BY MIN(EXTRACT(EPOCH FROM (fm.sent_at - m.created_at)));
+
+-- 4) All-time never-reacted buckets (type user + blocked_bot)
+WITH reacted AS (
+  SELECT DISTINCT user_id
+  FROM user_meme_reaction
+  WHERE reaction_id IS NOT NULL
+),
+got_meme AS (
+  SELECT
+    user_id,
+    COUNT(*) AS n_sends,
+    MIN(sent_at) AS first_sent
+  FROM user_meme_reaction
+  GROUP BY user_id
+)
+SELECT
+  CASE
+    WHEN g.user_id IS NULL
+      AND COALESCE(u.blocked_bot_at IS NOT NULL, u.type = 'blocked_bot')
+      THEN 'blocked_no_meme'
+    WHEN g.user_id IS NULL THEN 'alive_no_meme'
+    WHEN COALESCE(u.blocked_bot_at IS NOT NULL, u.type = 'blocked_bot')
+      THEN 'blocked_got_meme_silent'
+    ELSE 'alive_got_meme_silent'
+  END AS bucket,
+  COUNT(*) AS n,
+  COUNT(*) FILTER (WHERE g.n_sends = 1) AS n_1,
+  COUNT(*) FILTER (WHERE g.n_sends BETWEEN 2 AND 5) AS n_2_5,
+  COUNT(*) FILTER (WHERE g.n_sends >= 6) AS n_6plus,
+  COUNT(*) FILTER (
+    WHERE u.blocked_bot_at IS NOT NULL
+      AND u.blocked_bot_at < u.created_at + interval '5 minutes'
+  ) AS block_5m_from_start,
+  COUNT(*) FILTER (
+    WHERE g.first_sent IS NOT NULL
+      AND u.blocked_bot_at IS NOT NULL
+      AND u.blocked_bot_at < g.first_sent + interval '5 minutes'
+  ) AS block_5m_after_first
+FROM "user" u
+LEFT JOIN reacted r ON r.user_id = u.id
+LEFT JOIN got_meme g ON g.user_id = u.id
+WHERE u.type IN ('user', 'blocked_bot')
+  AND r.user_id IS NULL
+GROUP BY 1
+ORDER BY n DESC;
+
+-- 5) H10 assignment + first-tap by variant (true-new, last 14d)
+WITH assigned AS (
+  SELECT
+    a.user_id,
+    a.variant,
+    a.assigned_at
+  FROM experiment_assignment a
+  WHERE a.experiment_id = 'cold_start_fresh_viral_v1'
+    AND a.assigned_at >= now() - interval '14 days'
+),
+first_meme AS (
+  SELECT DISTINCT ON (r.user_id)
+    r.user_id,
+    r.recommended_by,
+    r.reaction_id,
+    r.sent_at
+  FROM user_meme_reaction r
+  JOIN assigned a ON a.user_id = r.user_id
+  ORDER BY r.user_id, r.sent_at
+)
+SELECT
+  a.variant,
+  COUNT(*) AS n_assigned,
+  COUNT(f.user_id) AS got_meme,
+  COUNT(*) FILTER (WHERE f.reaction_id IS NOT NULL) AS tapped,
+  COUNT(*) FILTER (WHERE f.reaction_id = 1) AS first_like,
+  COUNT(*) FILTER (
+    WHERE f.recommended_by LIKE 'cold_start_explore_fresh%'
+  ) AS fresh_first_meme,
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE f.reaction_id IS NOT NULL)
+    / NULLIF(COUNT(f.user_id), 0),
+    1
+  ) AS first_tap_pct
+FROM assigned a
+LEFT JOIN first_meme f ON f.user_id = a.user_id
+GROUP BY 1
+ORDER BY 1;

--- a/docs/analyst/readouts/2026-09-07-onboarding-and-dormant-blast.md
+++ b/docs/analyst/readouts/2026-09-07-onboarding-and-dormant-blast.md
@@ -1,0 +1,147 @@
+# Onboarding leak + dormant blast — 2026-09-07
+
+**Clock:** analyst DB `2026-09-07 ~12:32 UTC`  
+**SQL to re-run:** [`docs/analyst/onboarding-funnel.sql`](../onboarding-funnel.sql), [`docs/analyst/broadcast-reengagement.sql`](../broadcast-reengagement.sql)  
+**Hypotheses:** H3c (viral push), H9 (first-tap), H10 (fresh first meme), H11 (drop 3-2-1) in [`docs/growth/HYPOTHESES.md`](../../growth/HYPOTHESES.md)
+
+Growth bar for any follow-up: **less leaky funnel** (first-tap, first-like, reached-5) and/or **k-factor** (unique non-self share clicks, new-user invites). Session length stays a guardrail.
+
+## Founder calls (do not re-litigate)
+
+1. Exponential reengagement **15m → 24h → 48h → 1w → 2w → 4w** is intended while the user is still fresh. Habit, not spam. After that, **one monthly reminder** for people who already used the bot.
+2. Do **not** kill that cadence. Lever is **meme quality** in the push, not fewer early nudges.
+3. Today's one-shot `dormant-channel-viral-2026-09-07` **finishes**. Next time: not all idle ghosts; prefer 7–28d with holdout.
+4. Language picker / share-skip-onboarding are **not** the first thing to rewrite.
+
+## Measurement pitfall
+
+`user_stats.nmemes_sent` often stays **0** until a reaction. Silent users look like they got 0–1 memes. Count sends from `user_meme_reaction`. Include `user.type IN ('user','blocked_bot')` for all-time block funnels (`blocked_bot` is a legacy type, ~10.5k rows).
+
+---
+
+## 1. Onboarding steps (as shipped)
+
+| Step | Empty `/start` | Share `s_` / `m_` |
+|------|----------------|-------------------|
+| 1. Entry | logged in `user_deep_link_log` | same |
+| 2. Language | auto (Cyrillic name / CIS → `ru`; `uk`/`es`/`fa`/`hi` → that code) or **one-tap** `ol:{lang}` | language of **that** meme added |
+| 3. Explain | welcome + **~9s 3-2-1** | skipped |
+| 4. First meme | `cold_start_explore` | the shared meme (`share_link`) |
+| 5. First tap | like/skip | like/skip, then welcome+countdown runs |
+| 6. Feed | `next_message` | same |
+
+New-user picker is already exclusive (`set_user_languages_exclusive`). Multi-select with checkmarks is **`/lang` settings**, not first start.
+
+---
+
+## 2. 90-day new-user funnel (`type=user`, n=415)
+
+| Stage | n |
+|-------|--:|
+| Registered | 415 |
+| Got a meme | 402 |
+| Ever reacted | 252 |
+| Reacted within 1h of first send | 246 |
+| Got meme, never reacted | **150** |
+| Never got a meme | 13 (3 blocked in ~5s, 10 alive, all no language) |
+| No `user_language` | 43 (16 blocked / 27 alive) |
+
+**Leak is step 5**, not step 2 or 4. 402/415 saw a meme; 150/402 (~37%) never tapped.
+
+### By entry
+
+| Entry | n | Got meme | Ever reacted | % of registered | p50 to first meme |
+|-------|--:|---------:|-------------:|----------------:|------------------:|
+| empty `/start` | 310 | 298 | 189 | **61.0%** | 11.6s |
+| share `s_`/`m_` | 31 | 31 | 22 | **71.0%** | 0.2s |
+| channel `sc_` | 21 | 20 | 14 | 66.7% | 11.5s |
+| other | 53 | 53 | 27 | 50.9% | 11.7s |
+
+Share skips welcome+picker and **converts better**, not worse. First like on share first-meme: 12/31 (36%) vs cold-start 83/371 (22%). After a share tap we still fire welcome+countdown — odd, not the leak.
+
+### Empty start, time to first meme
+
+| Lag | n | Reacted | First like | First skip |
+|-----|--:|--------:|-----------:|-----------:|
+| no meme | 12 | 0 | 0 | 0 |
+| 8–15s (countdown) | 233 | 140 (**60%**) | 55 (24%) | 85 |
+| 15–60s (picker) | 58 | 46 (**79%**) | 18 (31%) | 28 |
+
+Picker users convert **better** than auto-language + countdown. Volume leak is the 233 countdown people.
+
+### Silent after first meme (90d)
+
+- Blocked silent: **84**. 44 got exactly 1 meme. p50 **~3 min** from first meme to block.
+- Alive silent: **66**. Almost none with 1 meme; 57 already have 6+ sends (`cold_start_explore` + later `lr_smoothed` + `broadcast_*`). We keep writing into a chat that never tapped.
+
+Global unblocked, no language: **598** (532 never reacted). Viral/HQ picks skip them.
+
+---
+
+## 3. All-time never-reacted (`user` + `blocked_bot`) = 9,161
+
+| Bucket | n | Exactly 1 meme | Block in 5m from start | Block in 5m after first meme |
+|--------|--:|---------------:|-----------------------:|-----------------------------:|
+| alive, got meme, silent | 4,492 | 278 | — | — |
+| blocked, no meme | 2,015 | — | **1,421** | — |
+| blocked, got meme, silent | 2,011 | 906 | 631 | **690** |
+| alive, no meme | 643 | — | — | — |
+
+Historically both “start then delete before a meme” and “one meme then delete” were large. **Last 90 days** the first pattern is almost gone (3 people). The remaining hole is “saw first meme, did not tap”.
+
+---
+
+## 4. First cold-start meme is old (observational)
+
+`cold_start_explore` floors: ≥25 explicit reactions, raw LR ≥0.50, order by `lr_smoothed`. **No recency filter.** Catch-22: a fresh post from a strong TG channel often cannot enter the first slot until the bot has already shown it a lot.
+
+90d first `cold_start_explore` meme (n=371):
+
+| Age at send | n | First like % | React % |
+|-------------|--:|-------------:|--------:|
+| 0–7d | 163 | 22.7 | 57.7 |
+| 7–30d | 17 | 17.6 | 52.9 |
+| 30–90d | 36 | 27.8 | 66.7 |
+| 90d+ | 155 | 21.3 | 57.4 |
+
+Median age **40 days**, mean **192**, half older than a month, mean **315** bot likes.
+
+Age **did not** move first-like in this cut (~22% fresh and old). Hypothesis “old = automatically bad” is **unproven**. What is proven: we systematically show a **bot-proven old hit**, not a **fresh channel outlier**. Share first-memes are fresher (p50 **6 days**) and like more — but those users chose the meme.
+
+Parser already keeps per-source outliers (top 5 of last 10 posts by views; drop below 30% of source median). That inventory does not automatically become the first onboarding meme.
+
+Earlier cold-start notes (Jul–Aug, small n) said first meme was “fine” and skip exploded from position 2. This 90d cut says **37% never even tap the first**. Both can be true in different windows; H9 treats first-tap as the current primary leak.
+
+---
+
+## 5. Dormant blast `dormant-channel-viral-2026-09-07`
+
+One-shot to users idle **7+ days** (12,223 dry-run). Picker: last-7d channel-viral by forwards, else HQ, else queue. Delay 0.3s. Started **2026-09-07 11:27 UTC**. Founder: **let it finish**.
+
+~12:32 UTC (still sending):
+
+| Lifetime | Blasted | First meme was this blast | Prior exactly 1 | Prior 2–5 | Prior 6+ | p50 prior sends |
+|----------|--------:|--------------------------:|----------------:|----------:|---------:|----------------:|
+| ever reacted | 5,048 | 0 | 0 | 14 | 5,034 | 62.5 |
+| **never reacted** | **1,378** | **11** | 11 | 1,000 | 356 | **5.0** |
+
+“Never reacted” in this blast ≠ onboarding drop-off. They already had a median **5** prior sends (reactivations). Only 11 people got today's meme as their first ever.
+
+Earlier in the send (~11:57 UTC, ~3.1–3.4k delivered): viral LR among reactors **70.8%** (n=48) vs HQ **58.3%** (n=12). React-in-1h ~2% (dormant; live HQ baseline ~33%). Ordinary users who continued after a react: next-feed LR **56.2%** (51 users, 337 sends) — feed after push was not garbage. Two viral memes dominated (`10084067`, `10173160`) because unseen+lang → same #1 for ghosts.
+
+**Process lesson:** blasting all 7d+ idle (including 90d+ never-reacted) was worse than A/B on 7–28d. Cadence 15m–4w stays. Extra all-idle waves should not become the default.
+
+---
+
+## 6. What not to “fix”
+
+- Multi-language onboarding keyboard — already one tap for new users.
+- Share skipping welcome/picker — best converting entry in 90d.
+- Killing 15m/24h/48h/1w/2w/4w — rejected; habit while fresh.
+- MTProto full-user scrape for language — names already used; mass scrape is ToS/flood.
+
+## 7. Next measurements
+
+- **2026-09-08** (T+24h blast): `broadcast-reengagement.sql` + never-reacted share of sends, block rate since 11:20Z, viral vs HQ react-in-1h.
+- **2026-09-14** (T+7d): same, plus whether reactors started a second session / invited anyone.
+- Re-run `onboarding-funnel.sql` when H9–H11 ship, same 90d window definition.

--- a/docs/growth/HYPOTHESES.md
+++ b/docs/growth/HYPOTHESES.md
@@ -3,8 +3,10 @@
 **Purpose:** When an agent (or human) resumes after days/weeks, this file answers:
 what is live, what we expected, when to re-measure, and what “good / kill” means.
 
-**Last updated:** 2026-08-11 (UTC) — H8 bot→channel offline ML lab  
-**Prod DB clock at last interim:** `2026-08-10 ~17 UTC` (v4 early WATCH; H7 not yet deployed)
+**Last updated:** 2026-09-07 (UTC) — H9 scoreboard, H10/H11 onboarding ship  
+**Prod DB clock at last interim:** `2026-09-07 ~12:32 UTC`
+
+**Growth bar (all new Hs):** ship only if the funnel gets less leaky (first-tap / first-like / reached-5) **and/or** k-factor moves (unique non-self share clicks, new-user invites). Session length and block rate are guardrails. See [`docs/growth/virality-loop.md`](virality-loop.md).
 
 How to use on resume:
 
@@ -21,6 +23,8 @@ How to use on resume:
 
 | Date (UTC) | What to run | Hypotheses |
 |------------|-------------|------------|
+| **2026-09-08** | Dormant blast T+24h | **H3c** |
+| **2026-09-14** | Onboarding funnel + fresh CS split | **H9**, **H10**, **H11** |
 | **2026-08-12** | Smoke + mature v4 if n≥8 | H1, H2, H3b, H5, **H6** |
 | **2026-08-16** | Primary feed/reco day-7 | H1, H2, H3b, H5 |
 | **2026-08-17** | **Crosspost v4 mature keep/kill** | **H6** |
@@ -236,6 +240,18 @@ without a like-rate drop >3 pp on reacted rows.
 **Disable** (`BROADCAST_CHANNEL_VIRAL_PICK_ENABLED=false`) if viral share of
 broadcasts is <10% (always empty) or 1h reactivation is worse than HQ by >5 pp
 with ≥200 viral sends.
+
+### One-shot idle blast (2026-09-07)
+
+`scripts/broadcast_dormant.py` id `dormant-channel-viral-2026-09-07`.
+**Let it finish.** Next extra wave: 7–28d + holdout, not 90d+ never-reacted.
+Readout: `docs/analyst/readouts/2026-09-07-onboarding-and-dormant-blast.md`.
+
+### Cadence doctrine (founder 2026-09-07)
+
+Keep **15m / 24h / 48h / 1w / 2w / 4w** while the user is still fresh.
+After that, **one monthly** reminder for people who already reacted.
+Lever inside the cadence is meme quality (H3c), not fewer early nudges.
 
 ---
 
@@ -460,6 +476,88 @@ Also logs `shadow_rank`, `shadow_pick_meme_id`, `shadow_vs_prod_disagree`.
 - After H7 merge: re-export + optional taste feature
 - Do not schedule as feed experiment
 
+---
+
+## H9 — First-tap is the onboarding leak
+
+| Field | Value |
+|-------|--------|
+| **ID** | `onboarding_first_tap_v1` |
+| **Status** | **scoreboard** for H10/H11 |
+| **Readout** | `docs/analyst/readouts/2026-09-07-onboarding-and-dormant-blast.md` |
+| **SQL** | `docs/analyst/onboarding-funnel.sql` |
+
+### Hypothesis
+
+New-user growth is gated by **first meme → first tap**, not language picker
+and not share skipping welcome. 90d (2026-09-07): 402 got a meme, 252 reacted,
+**150** silent. Empty start 61% vs share 71%.
+
+### Growth bar
+
+First-tap % of got-meme; first-like %; reached-5. Secondary: non-self share
+clicks and invites from the same cohort. Guardrail: block-in-1h.
+
+### Next check
+
+**2026-09-14** re-run `onboarding-funnel.sql`.
+
+---
+
+## H10 — Fresh channel-quality memes as CS1 (A/B)
+
+| Field | Value |
+|-------|--------|
+| **ID** | `cold_start_fresh_viral_v1` |
+| **Status** | **shipping** |
+| **Kill switch** | `COLD_START_FRESH_VIRAL_EXPERIMENT_ENABLED` |
+| **Code** | `src/recommendations/cold_start_experiments.py`, `cold_start_explore(max_age_days=)` |
+| **Labels** | `cold_start_explore_fresh` / `_guarded` vs classic `cold_start_explore` |
+
+### Hypothesis
+
+Same CS floors, but only memes **created in the last 30 days**, newest first,
+lifts first-tap / first-like vs all-time `lr_smoothed` hits. Empty fresh pool
+fills from classic CS so we never starve the first session.
+
+50/50 `sha256(experiment_id:user_id)%2` on true-new CS1 (`nmemes_sent < 6`,
+`nsessions <= 1`). Observational 90d did **not** show an age→like gap (~22%
+both); this A/B is the actual test.
+
+### Decision rules (day-7, ≥80 new users/arm if we get them)
+
+**Keep treatment / ship default** if first-tap ≥ control +5 pp (or first-like
++3 pp), reached-5 not down, invites/1k not down.  
+**Disable flag** if first-tap down, block-in-1h up, or empty-queue for new users.
+
+### Next check
+
+**2026-09-14** — assignment counts + first-tap by variant.
+
+---
+
+## H11 — Drop empty-start 3-2-1 countdown
+
+| Field | Value |
+|-------|--------|
+| **ID** | `onboarding_skip_countdown_v1` |
+| **Status** | **shipping as default** |
+| **Code** | `src/tgbot/handlers/onboarding.py`, share tap in `reaction.py` |
+
+### Hypothesis
+
+Removing the ~9s 3-2-1 (p50 11.6s to first meme) and sending the first meme
+right after welcome raises first-tap. Share path already did this at 0.2s and
+converted better; after a share tap we now continue the feed (no second welcome).
+
+Not an A/B — UX debt. Score with H9. Rollback = restore the countdown block.
+
+### Next check
+
+**2026-09-14** empty-start p50 seconds to first meme should drop toward ~1s;
+first-tap of empty start vs 61% baseline.
+
+---
 
 ## Explicitly not open experiments
 
@@ -472,6 +570,9 @@ Also logs `shadow_rank`, `shadow_pick_meme_id`, `shadow_vs_prod_disagree`.
 | Crosspost rank by bot LR only | **Rejected** |
 | Crosspost taste-only ranker | **Rejected** (coverage); soft boost only after H7 |
 | Crosspost rank by bot LR | **Rejected** offline (H6) |
+| Kill 15m–4w reengagement cadence | **Rejected** 2026-09-07 (habit while fresh; monthly after) |
+| Rewrite new-user language as multi-select | **Already one-tap**; `/lang` is settings |
+| “Fix” share skipping welcome/picker | **Rejected** — 90d share converts better than empty start |
 
 ---
 
@@ -484,6 +585,7 @@ psql "$ANALYST_DATABASE_URL" -f docs/analyst/viral-shares-blender-v1.sql
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/source-affinity-demote-guardrails.sql
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/dwell-feed-vs-broadcast.sql
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/broadcast-reengagement.sql
+psql "$ANALYST_DATABASE_URL" -f docs/analyst/onboarding-funnel.sql            # H9–H11
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/crossposting-v4-like-volume.sql   # H6
 psql "$ANALYST_DATABASE_URL" -f docs/analyst/crossposting-taste-shadow.sql    # H7
 # 3) Update this file Status/Decision + write

--- a/src/config.py
+++ b/src/config.py
@@ -64,6 +64,9 @@ class Config(BaseSettings):
     # FFM-1882: narrow true-new cold-start positions 2-10 experiment.
     # Roll back by setting this to false in production env.
     COLD_START_CANDIDATE_GUARDRAILS_ENABLED: bool = True
+    # H10: 50/50 true-new users get <30d quality memes in CS1. Kill switch
+    # stops new assignment and treats everyone as control.
+    COLD_START_FRESH_VIRAL_EXPERIMENT_ENABLED: bool = True
 
     # Recommendation batch diagnostics are realtime operational data, not
     # durable product facts. Keep compact logs/spans always on and sample full

--- a/src/recommendations/candidates.py
+++ b/src/recommendations/candidates.py
@@ -36,6 +36,8 @@ COLD_START_EXPLORE_RECOMMENDED_BY = "cold_start_explore"
 COLD_START_ADAPT_RECOMMENDED_BY = "cold_start_adapt"
 COLD_START_EXPLORE_GUARDED_RECOMMENDED_BY = "cold_start_explore_guarded"
 COLD_START_ADAPT_GUARDED_RECOMMENDED_BY = "cold_start_adapt_guarded"
+COLD_START_EXPLORE_FRESH_RECOMMENDED_BY = "cold_start_explore_fresh"
+COLD_START_EXPLORE_FRESH_GUARDED_RECOMMENDED_BY = "cold_start_explore_fresh_guarded"
 
 _OCR_TEXT_SQL = "trim(coalesce(M.ocr_result->>'text', M.ocr_result->'raw_result'->>'ocr_text', ''))"
 TEXT_LIGHT_OCR_FILTER_SQL = f"""
@@ -64,9 +66,19 @@ def _build_params(
     return params
 
 
-def _cold_start_recommended_by(engine: str, candidate_guardrails_enabled: bool) -> str:
-    if engine == COLD_START_EXPLORE_RECOMMENDED_BY and candidate_guardrails_enabled:
-        return COLD_START_EXPLORE_GUARDED_RECOMMENDED_BY
+def _cold_start_recommended_by(
+    engine: str,
+    candidate_guardrails_enabled: bool,
+    *,
+    max_age_days: int | None = None,
+) -> str:
+    if engine == COLD_START_EXPLORE_RECOMMENDED_BY:
+        if max_age_days:
+            if candidate_guardrails_enabled:
+                return COLD_START_EXPLORE_FRESH_GUARDED_RECOMMENDED_BY
+            return COLD_START_EXPLORE_FRESH_RECOMMENDED_BY
+        if candidate_guardrails_enabled:
+            return COLD_START_EXPLORE_GUARDED_RECOMMENDED_BY
     if engine == COLD_START_ADAPT_RECOMMENDED_BY and candidate_guardrails_enabled:
         return COLD_START_ADAPT_GUARDED_RECOMMENDED_BY
     return engine
@@ -83,16 +95,23 @@ def _cold_start_params(
     *,
     engine: str,
     candidate_guardrails_enabled: bool,
+    max_age_days: int | None = None,
 ) -> dict[str, Any]:
     params = _build_params(
         user_id,
         limit,
         exclude_meme_ids,
-        recommended_by=_cold_start_recommended_by(engine, candidate_guardrails_enabled),
+        recommended_by=_cold_start_recommended_by(
+            engine,
+            candidate_guardrails_enabled,
+            max_age_days=max_age_days,
+        ),
         text_light_max_ocr_words=TEXT_LIGHT_MAX_OCR_WORDS,
     )
     if candidate_guardrails_enabled:
         params["cold_start_guardrail_source_urls"] = list(COLD_START_GUARDRAIL_SOURCE_URLS)
+    if max_age_days:
+        params["cold_start_max_age_days"] = max_age_days
     return params
 
 
@@ -490,6 +509,7 @@ async def cold_start_explore(
     limit: int = 5,
     exclude_meme_ids: list[int] = [],
     candidate_guardrails_enabled: bool = False,
+    max_age_days: int | None = None,
 ):
     """Phase 1 cold start: quality-first selection for new user first impression.
 
@@ -507,7 +527,25 @@ async def cold_start_explore(
     correction.
 
     Used for memes 1-5 (first impression).
+
+    ``max_age_days`` (H10 treatment) keeps the same quality floors but only
+    among memes created in that window, ranked newest first. Empty pool is
+    filled by the pipeline from unfiltered cold_start_explore.
     """
+
+    age_filter_sql = ""
+    if max_age_days:
+        age_filter_sql = "AND M.created_at >= NOW() - (:cold_start_max_age_days * INTERVAL '1 day')"
+    order_sql = (
+        """M.created_at DESC,
+                 MS.lr_smoothed DESC NULLS LAST,
+                 (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0)) DESC,
+                 (MS.nlikes + MS.ndislikes) DESC"""
+        if max_age_days
+        else """MS.lr_smoothed DESC NULLS LAST,
+                 (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0)) DESC,
+                 (MS.nlikes + MS.ndislikes) DESC"""
+    )
 
     query = f"""
         SELECT
@@ -535,14 +573,13 @@ async def cold_start_explore(
             AND MS.lr_smoothed >= :cold_start_explore_min_lr_smoothed
             AND (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0))
                 >= :cold_start_explore_min_raw_like_rate
+            {age_filter_sql}
             {TEXT_LIGHT_OCR_FILTER_SQL}
             {_cold_start_guardrail_source_filter(candidate_guardrails_enabled)}
             {exclude_meme_ids_sql_filter(exclude_meme_ids)}
             {block_disliked_sources_sql_filter()}
 
-        ORDER BY MS.lr_smoothed DESC NULLS LAST,
-                 (MS.nlikes::float / NULLIF(MS.nlikes + MS.ndislikes, 0)) DESC,
-                 (MS.nlikes + MS.ndislikes) DESC
+        ORDER BY {order_sql}
         LIMIT :limit
     """
     params = _cold_start_params(
@@ -551,6 +588,7 @@ async def cold_start_explore(
         exclude_meme_ids,
         engine=COLD_START_EXPLORE_RECOMMENDED_BY,
         candidate_guardrails_enabled=candidate_guardrails_enabled,
+        max_age_days=max_age_days,
     )
     params.update(
         {

--- a/src/recommendations/cold_start_experiments.py
+++ b/src/recommendations/cold_start_experiments.py
@@ -1,0 +1,96 @@
+"""A/B: fresh (<30d) quality memes for true-new cold start (H10)."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from src.tgbot.service import (
+    assign_experiment,
+    get_experiment_assignment,
+    get_experiment_variant,
+)
+
+COLD_START_FRESH_VIRAL_EXPERIMENT_ID = "cold_start_fresh_viral_v1"
+COLD_START_FRESH_VIRAL_CONTROL = "control"
+COLD_START_FRESH_VIRAL_TREATMENT = "treatment_fresh_30d"
+COLD_START_FRESH_MAX_AGE_DAYS = 30
+COLD_START_FRESH_ENROLL_MAX_MEMES_SENT = 6
+
+
+def cold_start_fresh_variant_for_user(user_id: int) -> str:
+    key = f"{COLD_START_FRESH_VIRAL_EXPERIMENT_ID}:{user_id}"
+    bucket = int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % 2
+    if bucket == 0:
+        return COLD_START_FRESH_VIRAL_CONTROL
+    return COLD_START_FRESH_VIRAL_TREATMENT
+
+
+def is_cold_start_fresh_eligible(
+    nmemes_sent: int,
+    nsessions: int,
+    cold_start_account_too_old: bool,
+) -> bool:
+    return (
+        nmemes_sent < COLD_START_FRESH_ENROLL_MAX_MEMES_SENT
+        and (nsessions or 0) <= 1
+        and not cold_start_account_too_old
+    )
+
+
+def build_cold_start_fresh_assignment(user_id: int) -> tuple[str, dict[str, Any]]:
+    variant = cold_start_fresh_variant_for_user(user_id)
+    return variant, {
+        "assignment_strategy": "sha256(experiment_id:user_id)%2",
+        "max_age_days": COLD_START_FRESH_MAX_AGE_DAYS,
+        "primary_read": (
+            "first-tap %, first-like %, reached-5; k-factor: non-self share clicks, invites"
+        ),
+    }
+
+
+async def get_or_assign_cold_start_fresh_variant(
+    user_id: int,
+    *,
+    nmemes_sent: int,
+    nsessions: int,
+    cold_start_account_too_old: bool,
+) -> str:
+    assignment = await get_experiment_assignment(
+        user_id,
+        COLD_START_FRESH_VIRAL_EXPERIMENT_ID,
+    )
+    if assignment is not None:
+        return assignment["variant"]
+
+    if not is_cold_start_fresh_eligible(nmemes_sent, nsessions, cold_start_account_too_old):
+        return COLD_START_FRESH_VIRAL_CONTROL
+
+    proposed_variant, assignment_metadata = build_cold_start_fresh_assignment(user_id)
+    inserted = await assign_experiment(
+        user_id,
+        COLD_START_FRESH_VIRAL_EXPERIMENT_ID,
+        proposed_variant,
+        assignment_metadata,
+    )
+    if inserted:
+        return proposed_variant
+
+    return (
+        await get_experiment_variant(user_id, COLD_START_FRESH_VIRAL_EXPERIMENT_ID)
+        or COLD_START_FRESH_VIRAL_CONTROL
+    )
+
+
+def fresh_max_age_days_for_variant(
+    variant: str,
+    *,
+    nmemes_sent: int,
+    nsessions: int,
+    cold_start_account_too_old: bool,
+) -> int | None:
+    if variant != COLD_START_FRESH_VIRAL_TREATMENT:
+        return None
+    if not is_cold_start_fresh_eligible(nmemes_sent, nsessions, cold_start_account_too_old):
+        return None
+    return COLD_START_FRESH_MAX_AGE_DAYS

--- a/src/recommendations/meme_queue.py
+++ b/src/recommendations/meme_queue.py
@@ -16,6 +16,10 @@ from src.recommendations.blender_experiments import (
 from src.recommendations.candidates import (
     CandidatesRetriever,
 )
+from src.recommendations.cold_start_experiments import (
+    fresh_max_age_days_for_variant,
+    get_or_assign_cold_start_fresh_variant,
+)
 from src.recommendations.pipeline import (
     RecommendationBatchPipeline,
     RecommendationBatchRequest,
@@ -31,12 +35,15 @@ COLD_START_RECOMMENDED_BY = frozenset(
         "cold_start_adapt",
         "cold_start_explore_guarded",
         "cold_start_adapt_guarded",
+        "cold_start_explore_fresh",
+        "cold_start_explore_fresh_guarded",
     }
 )
 COLD_START_GUARDED_RECOMMENDED_BY = frozenset(
     {
         "cold_start_explore_guarded",
         "cold_start_adapt_guarded",
+        "cold_start_explore_fresh_guarded",
     }
 )
 
@@ -255,6 +262,29 @@ async def check_queue(user_id: int) -> bool:
     return True
 
 
+async def _cold_start_fresh_max_age_days(
+    user_id: int,
+    *,
+    nmemes_sent: int,
+    nsessions: int,
+    cold_start_account_too_old: bool,
+) -> int | None:
+    if settings.COLD_START_FRESH_VIRAL_EXPERIMENT_ENABLED is not True:
+        return None
+    variant = await get_or_assign_cold_start_fresh_variant(
+        user_id,
+        nmemes_sent=nmemes_sent,
+        nsessions=nsessions,
+        cold_start_account_too_old=cold_start_account_too_old,
+    )
+    return fresh_max_age_days_for_variant(
+        variant,
+        nmemes_sent=nmemes_sent,
+        nsessions=nsessions,
+        cold_start_account_too_old=cold_start_account_too_old,
+    )
+
+
 async def generate_recommendations(
     user_id: int,
     limit: int,
@@ -324,6 +354,12 @@ async def generate_recommendations(
             cold_start_nsessions_gate_enabled=settings.COLD_START_NSESSIONS_GATE_ENABLED,
             cold_start_candidate_guardrails_enabled=(
                 settings.COLD_START_CANDIDATE_GUARDRAILS_ENABLED
+            ),
+            cold_start_fresh_max_age_days=await _cold_start_fresh_max_age_days(
+                user_id,
+                nmemes_sent=nmemes_sent,
+                nsessions=nsessions,
+                cold_start_account_too_old=cold_start_account_too_old,
             ),
             # FFM-1357: stop new exposure until this overlay has a CEO-owned
             # active experiment record. Existing assignment rows remain readable.

--- a/src/recommendations/pipeline.py
+++ b/src/recommendations/pipeline.py
@@ -79,6 +79,7 @@ class RecommendationBatchRequest:
     random_seed: int | None = None
     cold_start_nsessions_gate_enabled: bool = False
     cold_start_candidate_guardrails_enabled: bool = False
+    cold_start_fresh_max_age_days: int | None = None
     text_light_blender_v1_enabled: bool = False
     source_diversity_enabled: bool = False
     shadow_scoring_enabled: bool = True
@@ -144,6 +145,7 @@ class RecommendationBatchDiagnostics:
     cold_start_nsessions_gate_enabled: bool = False
     cold_start_candidate_guardrails_enabled: bool = False
     cold_start_candidate_guardrails_applied: bool = False
+    cold_start_fresh_applied: bool = False
     diagnostics_sample_rate: float = 0.01
     maturity_stage: str | None = None
     duration_ms: int = 0
@@ -194,6 +196,7 @@ class RecommendationBatchDiagnostics:
             "cold_start_candidate_guardrails_applied": (
                 self.cold_start_candidate_guardrails_applied
             ),
+            "cold_start_fresh_applied": self.cold_start_fresh_applied,
             "queue_len_before": self.queue_len_before,
             "exclude_count": self.exclude_count,
             "selected_count": self.selected_count,
@@ -475,6 +478,18 @@ class RecommendationBatchPipeline:
             diagnostics,
             queued_or_selected_ahead=len(exclude_ids),
         )
+        if request.cold_start_fresh_max_age_days and engine == "cold_start_explore":
+            diagnostics.cold_start_fresh_applied = True
+            segments = [
+                (
+                    segment_limit,
+                    {
+                        **kwargs,
+                        "max_age_days": request.cold_start_fresh_max_age_days,
+                    },
+                )
+                for segment_limit, kwargs in segments
+            ]
 
         for segment_limit, kwargs in segments:
             if segment_limit <= 0:
@@ -514,6 +529,23 @@ class RecommendationBatchPipeline:
                         )
                     )
                 return selected
+
+        if (
+            engine == "cold_start_explore"
+            and request.cold_start_fresh_max_age_days
+            and len(selected) < limit
+        ):
+            fill_limit = limit - len(selected)
+            fill = await self._fetch_engine(
+                engine,
+                request.user_id,
+                fill_limit,
+                segment_exclude_ids,
+                diagnostics,
+            )
+            excluded = set(segment_exclude_ids)
+            fill = [candidate for candidate in fill if candidate.get("id") not in excluded]
+            selected.extend(fill[:fill_limit])
 
         return selected
 

--- a/src/tgbot/handlers/onboarding.py
+++ b/src/tgbot/handlers/onboarding.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from telegram import Bot, Update
 from telegram.constants import ParseMode
 
@@ -8,8 +6,8 @@ from src.tgbot.senders.next_message import next_message
 from src.tgbot.user_info import update_user_info_cache
 
 
-# not sure about the best args for that func
 async def onboarding_flow(update: Update, bot: Bot):
+    """Welcome (if still new) then the first feed meme. No 3-2-1 wait."""
     user_id = update.effective_user.id
 
     user_info = await update_user_info_cache(user_id)
@@ -20,18 +18,6 @@ async def onboarding_flow(update: Update, bot: Bot):
             localizer.t("onboarding.welcome_message", user_info["interface_lang"]),
             parse_mode=ParseMode.HTML,
         )
-
-        await asyncio.sleep(3)
-
-        m = await update.effective_user.send_message("3️⃣")
-        await asyncio.sleep(2)
-        m = await m.edit_text("2️⃣")
-        await asyncio.sleep(2)
-        m = await m.edit_text("1️⃣")
-        await asyncio.sleep(2)
-        # m = await m.edit_text("💣")
-        # await asyncio.sleep(2.5)
-        await m.delete()
 
     return await next_message(
         bot,

--- a/src/tgbot/handlers/reaction.py
+++ b/src/tgbot/handlers/reaction.py
@@ -12,7 +12,6 @@ from src.recommendations.service import (
     update_user_meme_reaction,
 )
 from src.tgbot.handlers.moderator.invite import maybe_send_moderator_invite
-from src.tgbot.handlers.onboarding import onboarding_flow
 from src.tgbot.senders.next_message import next_message
 from src.tgbot.sharing import MEME_REACTION_CONTEXT_ONBOARD
 from src.tgbot.user_info import update_user_info_counters
@@ -45,8 +44,15 @@ async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     )
 
     if reaction_is_new:
+        # Share-link first meme already taught the product. Skip welcome +
+        # countdown and continue the feed (H11).
         if reaction_context == MEME_REACTION_CONTEXT_ONBOARD:
-            return await onboarding_flow(update, context.bot)
+            return await next_message(
+                context.bot,
+                user_id,
+                prev_update=update,
+                prev_reaction_id=int(reaction_id),
+            )
 
         return await next_message(
             context.bot,

--- a/tests/recommendations/test_cold_start_fresh.py
+++ b/tests/recommendations/test_cold_start_fresh.py
@@ -1,0 +1,176 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.recommendations.candidates import (
+    COLD_START_EXPLORE_FRESH_GUARDED_RECOMMENDED_BY,
+    COLD_START_EXPLORE_FRESH_RECOMMENDED_BY,
+    cold_start_explore,
+)
+from src.recommendations.cold_start_experiments import (
+    COLD_START_FRESH_MAX_AGE_DAYS,
+    COLD_START_FRESH_VIRAL_CONTROL,
+    COLD_START_FRESH_VIRAL_TREATMENT,
+    cold_start_fresh_variant_for_user,
+    fresh_max_age_days_for_variant,
+    is_cold_start_fresh_eligible,
+)
+from src.recommendations.pipeline import (
+    RecommendationBatchPipeline,
+    RecommendationBatchRequest,
+)
+
+
+def _fetch_call_sql_and_params(fetch_all: AsyncMock) -> tuple[str, dict]:
+    query, params = fetch_all.call_args.args
+    return str(query), params
+
+
+def test_fresh_variant_is_stable_split():
+    control_ids = [
+        user_id
+        for user_id in range(200)
+        if cold_start_fresh_variant_for_user(user_id) == COLD_START_FRESH_VIRAL_CONTROL
+    ]
+    treatment_ids = [
+        user_id
+        for user_id in range(200)
+        if cold_start_fresh_variant_for_user(user_id) == COLD_START_FRESH_VIRAL_TREATMENT
+    ]
+    assert len(control_ids) > 40
+    assert len(treatment_ids) > 40
+    assert cold_start_fresh_variant_for_user(control_ids[0]) == COLD_START_FRESH_VIRAL_CONTROL
+    assert cold_start_fresh_variant_for_user(treatment_ids[0]) == COLD_START_FRESH_VIRAL_TREATMENT
+
+
+def test_fresh_eligibility_and_max_age():
+    assert is_cold_start_fresh_eligible(0, 1, False) is True
+    assert is_cold_start_fresh_eligible(6, 1, False) is False
+    assert is_cold_start_fresh_eligible(0, 2, False) is False
+    assert is_cold_start_fresh_eligible(0, 1, True) is False
+    assert (
+        fresh_max_age_days_for_variant(
+            COLD_START_FRESH_VIRAL_TREATMENT,
+            nmemes_sent=0,
+            nsessions=1,
+            cold_start_account_too_old=False,
+        )
+        == COLD_START_FRESH_MAX_AGE_DAYS
+    )
+    assert (
+        fresh_max_age_days_for_variant(
+            COLD_START_FRESH_VIRAL_CONTROL,
+            nmemes_sent=0,
+            nsessions=1,
+            cold_start_account_too_old=False,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_cold_start_explore_fresh_filters_age_and_ranks_newest():
+    with patch(
+        "src.recommendations.candidates.fetch_all",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as fetch_all:
+        await cold_start_explore(123, limit=5, max_age_days=30)
+
+    query_sql, params = _fetch_call_sql_and_params(fetch_all)
+    assert "cold_start_max_age_days" in query_sql
+    assert params["cold_start_max_age_days"] == 30
+    assert params["recommended_by"] == COLD_START_EXPLORE_FRESH_RECOMMENDED_BY
+    assert "M.created_at DESC" in query_sql
+
+
+@pytest.mark.asyncio
+async def test_cold_start_explore_fresh_guarded_label():
+    with patch(
+        "src.recommendations.candidates.fetch_all",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as fetch_all:
+        await cold_start_explore(
+            123,
+            limit=5,
+            max_age_days=30,
+            candidate_guardrails_enabled=True,
+        )
+
+    _, params = _fetch_call_sql_and_params(fetch_all)
+    assert params["recommended_by"] == COLD_START_EXPLORE_FRESH_GUARDED_RECOMMENDED_BY
+
+
+@pytest.mark.asyncio
+async def test_generate_recommendations_passes_fresh_max_age_for_treatment():
+    from src.recommendations.meme_queue import generate_recommendations
+
+    retriever = AsyncMock()
+    retriever.get_candidates = AsyncMock(return_value=[])
+    retriever.get_candidates_dict = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "src.recommendations.meme_queue.get_user_info",
+            new_callable=AsyncMock,
+            return_value={"nmemes_sent": 0, "nsessions": 1, "type": "user"},
+        ),
+        patch(
+            "src.recommendations.meme_queue.redis.get_all_memes_in_queue_by_key",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "src.recommendations.meme_queue.get_or_assign_cold_start_fresh_variant",
+            new_callable=AsyncMock,
+            return_value=COLD_START_FRESH_VIRAL_TREATMENT,
+        ),
+        patch("src.recommendations.meme_queue.settings") as settings,
+        patch(
+            "src.recommendations.meme_queue.RecommendationBatchPipeline.run",
+            new_callable=AsyncMock,
+        ) as run,
+    ):
+        settings.COLD_START_FRESH_VIRAL_EXPERIMENT_ENABLED = True
+        settings.COLD_START_NSESSIONS_GATE_ENABLED = False
+        settings.COLD_START_CANDIDATE_GUARDRAILS_ENABLED = False
+        settings.RECOMMENDATION_SOURCE_DIVERSITY_ENABLED = False
+        settings.RECOMMENDATION_SHADOW_SCORING_ENABLED = False
+        settings.RECOMMENDATION_DIAGNOSTICS_SAMPLE_RATE = 0.0
+        run.return_value.selected = []
+        await generate_recommendations(7, limit=5, nmemes_sent=0, retriever=retriever)
+
+    request = run.await_args.args[0]
+    assert request.cold_start_fresh_max_age_days == COLD_START_FRESH_MAX_AGE_DAYS
+
+
+@pytest.mark.asyncio
+async def test_pipeline_prefers_fresh_then_fills_classic_cs():
+    retriever = AsyncMock()
+
+    async def get_candidates(engine, user_id, limit, exclude_mem_ids=None, **kwargs):
+        if kwargs.get("max_age_days"):
+            return [{"id": 1, "recommended_by": "cold_start_explore_fresh"}]
+        return [
+            {"id": 1, "recommended_by": "cold_start_explore"},
+            {"id": 2, "recommended_by": "cold_start_explore"},
+            {"id": 3, "recommended_by": "cold_start_explore"},
+        ]
+
+    retriever.get_candidates.side_effect = get_candidates
+    pipeline = RecommendationBatchPipeline(retriever=retriever)
+    result = await pipeline.run(
+        RecommendationBatchRequest(
+            user_id=7,
+            limit=3,
+            nmemes_sent=0,
+            nsessions=1,
+            cold_start_fresh_max_age_days=30,
+        )
+    )
+
+    assert [row["id"] for row in result.selected] == [1, 2, 3]
+    assert result.selected[0]["recommended_by"] == "cold_start_explore_fresh"
+    assert result.diagnostics.cold_start_fresh_applied is True
+    assert retriever.get_candidates.await_count >= 2

--- a/tests/recommendations/test_meme_queue.py
+++ b/tests/recommendations/test_meme_queue.py
@@ -27,6 +27,16 @@ def _patch_user_info(nsessions: int = 0, nmemes_sent: int = 0, **extra):
 
 
 @pytest.fixture(autouse=True)
+def disable_cold_start_fresh_experiment():
+    with patch(
+        "src.recommendations.meme_queue._cold_start_fresh_max_age_days",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def mock_redis():
     """Mock Redis and user_info calls — these tests validate blending logic, not Redis."""
     user_info = defaultdict(int, {"nmemes_sent": 0})

--- a/tests/tgbot/test_onboarding_flow.py
+++ b/tests/tgbot/test_onboarding_flow.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.tgbot.handlers.onboarding import onboarding_flow
+
+
+@pytest.mark.asyncio
+async def test_onboarding_flow_sends_welcome_then_first_meme_without_countdown():
+    sent: list[str] = []
+    welcome = "Like memes you like"
+
+    async def send_welcome(text, **kwargs):
+        sent.append(text)
+        return SimpleNamespace()
+
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=42, send_message=send_welcome),
+    )
+
+    with (
+        patch(
+            "src.tgbot.handlers.onboarding.update_user_info_cache",
+            new_callable=AsyncMock,
+            return_value={"nmemes_sent": 0, "interface_lang": "en"},
+        ),
+        patch(
+            "src.tgbot.handlers.onboarding.next_message",
+            new_callable=AsyncMock,
+        ) as next_message,
+        patch(
+            "src.tgbot.handlers.onboarding.localizer.t",
+            return_value=welcome,
+        ),
+    ):
+        await onboarding_flow(update, bot=object())
+
+    assert sent == [welcome]
+    next_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_onboarding_flow_skips_welcome_after_early_memes():
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=42, send_message=AsyncMock()),
+    )
+
+    with (
+        patch(
+            "src.tgbot.handlers.onboarding.update_user_info_cache",
+            new_callable=AsyncMock,
+            return_value={"nmemes_sent": 4, "interface_lang": "en"},
+        ),
+        patch(
+            "src.tgbot.handlers.onboarding.next_message",
+            new_callable=AsyncMock,
+        ) as next_message,
+    ):
+        await onboarding_flow(update, bot=object())
+
+    update.effective_user.send_message.assert_not_called()
+    next_message.assert_awaited_once()

--- a/tests/tgbot/test_reaction_handler.py
+++ b/tests/tgbot/test_reaction_handler.py
@@ -83,19 +83,17 @@ async def test_new_reaction_calls_next_message(
 
 
 @pytest.mark.asyncio
-@patch(f"{HANDLER_MODULE}.onboarding_flow", new_callable=AsyncMock)
 @patch(f"{HANDLER_MODULE}.next_message", new_callable=AsyncMock)
 @patch(f"{HANDLER_MODULE}.reward_user_for_daily_activity", new_callable=AsyncMock)
 @patch(f"{HANDLER_MODULE}.update_user_last_active_at", new_callable=AsyncMock)
 @patch(f"{HANDLER_MODULE}.maybe_send_moderator_invite", new_callable=AsyncMock)
 @patch(f"{HANDLER_MODULE}.update_user_info_counters", new_callable=AsyncMock)
-async def test_onboard_reaction_context_calls_onboarding(
+async def test_onboard_reaction_context_continues_feed(
     mock_counters,
     mock_mod_invite,
     mock_active,
     mock_reward,
     mock_next,
-    mock_onboarding,
     setup,
 ):
     from src.tgbot.handlers.reaction import handle_reaction
@@ -107,8 +105,7 @@ async def test_onboard_reaction_context_calls_onboarding(
     context = _make_context()
     await handle_reaction(update, context)
 
-    mock_onboarding.assert_called_once()
-    mock_next.assert_not_called()
+    mock_next.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Onboarding leak is first meme → first tap (H9). This ships two changes:

1. **H11 (default):** drop the ~9s 3-2-1. Welcome, then the first meme. Share-link users already saw a meme — after like/skip they go to the next one, no second welcome.
2. **H10 (50/50 A/B `cold_start_fresh_viral_v1`):** true-new CS1 treatment gets quality memes created in the last 30 days, newest first. Empty pool fills from classic `cold_start_explore`. Kill switch: `COLD_START_FRESH_VIRAL_EXPERIMENT_ENABLED=false`.

Reengagement 15m→4w is unchanged (habit while fresh).

## Scoreboard

`psql "$ANALYST_DATABASE_URL" -f docs/analyst/onboarding-funnel.sql`

Growth bar: first-tap / first-like / reached-5, then k-factor (non-self share clicks, invites). Next check 2026-09-14.

Findings dump: `docs/analyst/readouts/2026-09-07-onboarding-and-dormant-blast.md`

## Tests

`pytest tests/recommendations/test_cold_start_fresh.py tests/tgbot/test_onboarding_flow.py tests/tgbot/test_reaction_handler.py tests/recommendations/test_pipeline.py tests/recommendations/test_meme_queue.py`